### PR TITLE
:adhesive_bandage: : 찍사 고객 이미지 오류

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
@@ -26,12 +26,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import androidx.navigation.NavOptions
-import androidx.navigation.Navigator
 import androidx.navigation.compose.rememberNavController
 import com.hm.picplz.MainActivity
 import com.hm.picplz.R
@@ -122,15 +119,15 @@ fun SignUpSelectTypeScreen(
                             text = "찍사",
                             selectionState =currentState.photographerSelectionState,
                             onClick = { viewModel.handleIntent(ClickUserTypeButton(UserType.Photographer)) },
-                            selectedIconResId = R.drawable.user_selected,
-                            deSelectedIconResId = R.drawable.user_deselected,
+                            selectedIconResId = R.drawable.photographer_selected,
+                            deSelectedIconResId = R.drawable.photographer_deselected,
                         )
                         CommonSelectImageButton(
                             text = "고객",
                             selectionState =currentState.userSelectionState,
                             onClick = { viewModel.handleIntent(ClickUserTypeButton(UserType.User)) },
-                            selectedIconResId = R.drawable.photographer_selected,
-                            deSelectedIconResId = R.drawable.photographer_deselected,
+                            selectedIconResId = R.drawable.user_selected,
+                            deSelectedIconResId = R.drawable.user_deselected,
                         )
                     }
                     Spacer(


### PR DESCRIPTION
## 개요
- 찍사와 고객의 이미지가 반대로 입력되어 있었던 이슈

## 변경 사항
- CommonSelectImageButton의 파라미터를 교환해서 수정
<img src="https://github.com/user-attachments/assets/dc929f34-7487-4b22-b666-56aca2e10715" width="350"/>
<img src="https://github.com/user-attachments/assets/4ecb8b1b-ac42-47d6-94bd-0c5a6da9f7f2" width="350"/>

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #23 