### PR TITLE
🩹 : 인트로페이지 ui 수정

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +38,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -84,6 +87,8 @@ fun LoginScreen(
     )
     val coroutineScope = rememberCoroutineScope()
 
+    val indicatorOffset = remember { mutableStateOf(0.dp) }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
     ) { innerPadding ->
@@ -129,41 +134,18 @@ fun LoginScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .wrapContentHeight(Alignment.CenterVertically)
+                            .layout { measurable, constraints ->
+                                // Measure the text and update the offset
+                                val placeable = measurable.measure(constraints)
+                                indicatorOffset.value = placeable.height.toDp() + 48.dp
+                                layout(placeable.width, placeable.height) {
+                                    placeable.place(0, 0)
+                                }
+                            }
                     )
 
-                    Spacer(modifier = Modifier.height(22.dp))
-
-
-                    Row(
-                        modifier = Modifier
-                            .wrapContentHeight()
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        repeat(pagerState.pageCount) { iteration ->
-                            val color =
-                                if (pagerState.currentPage == iteration) MainThemeColor.Black else MainThemeColor.White
-                            Box(
-                                modifier = Modifier
-                                    .padding(5.dp)
-                                    .clip(CircleShape)
-                                    .background(color)
-                                    .border(1.dp, MainThemeColor.Black, CircleShape)
-                                    .size(12.dp)
-                                    .clickable {
-                                        coroutineScope.launch {
-                                            pagerState.animateScrollToPage(
-                                                page = iteration,
-                                                animationSpec = tween(durationMillis = 400) // Adjust the duration as needed
-                                            )
-                                        }
-                                    }
-                            )
-                        }
-                    }
-
                     if (page == 2) {
-                        Spacer(modifier = Modifier.height(32.dp))
+                        Spacer(modifier = Modifier.height(66.dp))
 
                         Button(
                             onClick = { viewModel.handleIntent(LoginIntent.NavigateToKaKao) },
@@ -211,6 +193,37 @@ fun LoginScreen(
                         }
                     }
                 }
+            }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = indicatorOffset.value),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    repeat(pagerState.pageCount) { iteration ->
+                        val color =
+                            if (pagerState.currentPage == iteration) MainThemeColor.Black else MainThemeColor.White
+                        Box(
+                            modifier = Modifier
+                                .padding(5.dp)
+                                .clip(CircleShape)
+                                .background(color)
+                                .border(1.dp, MainThemeColor.Black, CircleShape)
+                                .size(12.dp)
+                                .clickable {
+                                    coroutineScope.launch {
+                                        pagerState.animateScrollToPage(
+                                            page = iteration,
+                                            animationSpec = tween(durationMillis = 400) // Adjust the duration as needed
+                                        )
+                                    }
+                                }
+                        )
+                    }
+                }
+
             }
         }
     }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
@@ -86,6 +87,8 @@ fun LoginScreen(
         pageCount = { pageTexts.size }
     )
     val coroutineScope = rememberCoroutineScope()
+    val configuration = LocalConfiguration.current
+    val screenHeight = configuration.screenHeightDp.dp
 
     val indicatorOffset = remember { mutableStateOf(0.dp) }
 
@@ -115,7 +118,7 @@ fun LoginScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(450.dp)
+                            .height(screenHeight * 0.65f)
                     ) {
                         Image(
                             painter = painterResource(id = imgRes),
@@ -199,7 +202,7 @@ fun LoginScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = indicatorOffset.value),
+                        .padding(top = screenHeight * 0.65f + indicatorOffset.value),
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     repeat(pagerState.pageCount) { iteration ->


### PR DESCRIPTION
## 개요
* 인트로 페이지에서 페이지 스크롤과 인디케이터가 함께 움직임
* 모바일 기기마다 이미지 영역이 고정된 크기로 보여져 시각적으로 불편함

## 변경 사항
* 페이지 스크롤과 인디케이터 종속성 분리
* 이미지 영역을 화면 높이의 65%로 설정하여 기기별 화면 크기에 유연하게 대응

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #26