### PR TITLE
💄 : 작가 탐색 페이지 바텀 시트 UI

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
@@ -10,6 +10,8 @@ data class PhotographerEntity(
     val isActive: Boolean,
     val profileImageUri: String,
     val workingArea: String,
+    val distance: Number,
+    val followers: List<Number>,
 )
 
 typealias PhotographerResponse = PhotographerEntity

--- a/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
@@ -12,6 +12,7 @@ data class PhotographerEntity(
     val workingArea: String,
     val distance: Number,
     val followers: List<Number>,
+    val socialAccount: String?,
 )
 
 typealias PhotographerResponse = PhotographerEntity

--- a/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/model/Photographer.kt
@@ -13,6 +13,7 @@ data class PhotographerEntity(
     val distance: Number,
     val followers: List<Number>,
     val socialAccount: String?,
+    val portfolioPhotos: List<String>,
 )
 
 typealias PhotographerResponse = PhotographerEntity

--- a/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -35,6 +35,7 @@ val dummyPhotographers = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 2,
@@ -46,6 +47,7 @@ val dummyPhotographers = listOf(
         distance = 200,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 3,
@@ -57,6 +59,7 @@ val dummyPhotographers = listOf(
         distance = 400,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 4,
@@ -68,6 +71,7 @@ val dummyPhotographers = listOf(
         distance = 300,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 5,
@@ -79,6 +83,7 @@ val dummyPhotographers = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 6,
@@ -90,6 +95,7 @@ val dummyPhotographers = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 7,
@@ -101,6 +107,7 @@ val dummyPhotographers = listOf(
         distance = 100,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 8,
@@ -112,6 +119,7 @@ val dummyPhotographers = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     )
 )
 
@@ -126,6 +134,7 @@ val dummyPhotographersTwo = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 2,
@@ -137,6 +146,7 @@ val dummyPhotographersTwo = listOf(
         distance = 100,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 3,
@@ -148,6 +158,7 @@ val dummyPhotographersTwo = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 4,
@@ -159,6 +170,7 @@ val dummyPhotographersTwo = listOf(
         distance = 100,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 5,
@@ -170,6 +182,7 @@ val dummyPhotographersTwo = listOf(
         distance = 200,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 6,
@@ -181,6 +194,7 @@ val dummyPhotographersTwo = listOf(
         distance = 100,
         followers = listOf(1, 2, 3),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 7,
@@ -192,6 +206,7 @@ val dummyPhotographersTwo = listOf(
         distance = 500,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     ),
     PhotographerResponse(
         id = 8,
@@ -203,5 +218,6 @@ val dummyPhotographersTwo = listOf(
         distance = 200,
         followers = listOf(1, 2, 4),
         socialAccount= "@account",
+        portfolioPhotos = List(5) { "https://picsum.photos/100" },
     )
 )

--- a/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -31,7 +31,9 @@ val dummyPhotographers = listOf(
         location = null,
         profileImageUri = "https://picsum.photos/200",
         isActive = false,
-        workingArea = "마포구 서교동"
+        workingArea = "마포구 서교동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 2,
@@ -39,7 +41,9 @@ val dummyPhotographers = listOf(
         location = LatLng.from(37.412510, 127.125137),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 200,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 3,
@@ -47,7 +51,9 @@ val dummyPhotographers = listOf(
         location = null,
         profileImageUri = "https://picsum.photos/200",
         isActive = false,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 400,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 4,
@@ -55,7 +61,9 @@ val dummyPhotographers = listOf(
         location = null,
         profileImageUri = "https://picsum.photos/200",
         isActive = false,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 300,
+        followers = listOf(1, 2, 4),
     ),
     PhotographerResponse(
         id = 5,
@@ -63,7 +71,9 @@ val dummyPhotographers = listOf(
         location = LatLng.from(37.384960, 127.115587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 6,
@@ -71,7 +81,9 @@ val dummyPhotographers = listOf(
         location = null,
         profileImageUri = "https://picsum.photos/200",
         isActive = false,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 7,
@@ -79,7 +91,9 @@ val dummyPhotographers = listOf(
         location = LatLng.from(37.402960, 127.106587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 4),
     ),
     PhotographerResponse(
         id = 8,
@@ -87,7 +101,9 @@ val dummyPhotographers = listOf(
         location = LatLng.from(37.412960, 127.105587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     )
 )
 
@@ -98,7 +114,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.403960, 127.116587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 2,
@@ -106,7 +124,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.401960, 127.114587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 4),
     ),
     PhotographerResponse(
         id = 3,
@@ -114,7 +134,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.404460, 127.113587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 4,
@@ -122,7 +144,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.401460, 127.117587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 4),
     ),
     PhotographerResponse(
         id = 5,
@@ -130,7 +154,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.404960, 127.117587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 200,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 6,
@@ -138,7 +164,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.400960, 127.113587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 100,
+        followers = listOf(1, 2, 3),
     ),
     PhotographerResponse(
         id = 7,
@@ -146,7 +174,9 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.405960, 127.114587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 500,
+        followers = listOf(1, 2, 4),
     ),
     PhotographerResponse(
         id = 8,
@@ -154,6 +184,8 @@ val dummyPhotographersTwo = listOf(
         location = LatLng.from(37.400960, 127.117587),
         profileImageUri = "https://picsum.photos/200",
         isActive = true,
-        workingArea = "종로구 무악동"
+        workingArea = "종로구 무악동",
+        distance = 200,
+        followers = listOf(1, 2, 4),
     )
 )

--- a/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/app/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -34,6 +34,7 @@ val dummyPhotographers = listOf(
         workingArea = "마포구 서교동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 2,
@@ -44,6 +45,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 200,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 3,
@@ -54,6 +56,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 400,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 4,
@@ -64,6 +67,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 300,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 5,
@@ -74,6 +78,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 6,
@@ -84,6 +89,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 7,
@@ -94,6 +100,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 8,
@@ -104,6 +111,7 @@ val dummyPhotographers = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     )
 )
 
@@ -117,6 +125,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 2,
@@ -127,6 +136,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 3,
@@ -137,6 +147,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 4,
@@ -147,6 +158,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 5,
@@ -157,6 +169,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 200,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 6,
@@ -167,6 +180,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 100,
         followers = listOf(1, 2, 3),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 7,
@@ -177,6 +191,7 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 500,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     ),
     PhotographerResponse(
         id = 8,
@@ -187,5 +202,6 @@ val dummyPhotographersTwo = listOf(
         workingArea = "종로구 무악동",
         distance = 200,
         followers = listOf(1, 2, 4),
+        socialAccount= "@account",
     )
 )

--- a/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
@@ -13,6 +13,7 @@ data class Photographer (
     val distance: Number,
     val followers: List<Number>,
     val socialAccount: String,
+    val portfolioPhotos: List<String>,
 )
 
 fun PhotographerResponse.toUiModel(): Photographer {
@@ -26,6 +27,7 @@ fun PhotographerResponse.toUiModel(): Photographer {
         distance = distance,
         followers = followers,
         socialAccount = socialAccount ?: "",
+        portfolioPhotos = portfolioPhotos,
     )
 }
 

--- a/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
@@ -10,6 +10,8 @@ data class Photographer (
     val profileImageUri: String,
     val isActive: Boolean,
     val workingArea: String,
+    val distance: Number,
+    val followers: List<Number>,
 )
 
 fun PhotographerResponse.toUiModel(): Photographer {
@@ -20,6 +22,8 @@ fun PhotographerResponse.toUiModel(): Photographer {
         profileImageUri = profileImageUri,
         isActive = isActive,
         workingArea = workingArea,
+        distance = distance,
+        followers = followers,
     )
 }
 

--- a/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/model/SearchPhotographerModel.kt
@@ -12,6 +12,7 @@ data class Photographer (
     val workingArea: String,
     val distance: Number,
     val followers: List<Number>,
+    val socialAccount: String,
 )
 
 fun PhotographerResponse.toUiModel(): Photographer {
@@ -24,6 +25,7 @@ fun PhotographerResponse.toUiModel(): Photographer {
         workingArea = workingArea,
         distance = distance,
         followers = followers,
+        socialAccount = socialAccount ?: "",
     )
 }
 

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomSheet.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomSheet.kt
@@ -61,7 +61,7 @@ fun CommonBottomSheetScaffold(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 6.dp),
+                        .padding(top = 10.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Surface(
@@ -69,7 +69,7 @@ fun CommonBottomSheetScaffold(
                             .width(40.dp)
                             .height(4.dp),
                         shape = RoundedCornerShape(2.dp),
-                        color = MainThemeColor.Gray3
+                        color = MainThemeColor.Black
                     ) {}
                 }
                 Column(

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/common/common_chip/CommonChip.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/common/common_chip/CommonChip.kt
@@ -66,6 +66,7 @@ fun CommonChip(
     selectedBorderColor: Color = MainThemeColor.Black,
     unselectedTextColor: Color = MainThemeColor.Gray4,
     selectedTextColor: Color = MainThemeColor.Black,
+    backgroundColor: Color = MainThemeColor.White,
     isSelected: Boolean = false,
     onClickDefaultMode: () -> Unit = {},
     isEditable: Boolean = false,
@@ -148,6 +149,10 @@ fun CommonChip(
                         onClickDefaultMode()
                     }
                     .height(chipHeight)
+                    .background(
+                        color = backgroundColor,
+                        shape = RoundedCornerShape(5.dp)
+                    )
                     .border(
                         width = 1.dp,
                         color = if (isSelected) selectedBorderColor else unselectedBorderColor,

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.search_photographer
 
-import PhotographerListScreen
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
@@ -50,6 +49,7 @@ import kotlinx.coroutines.flow.collectLatest
 import com.hm.picplz.R
 import androidx.compose.ui.layout.ContentScale
 import com.hm.picplz.ui.screen.search_photographer.composable.AddressMarker
+import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerListScreen
 import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerProfile
 import com.hm.picplz.ui.screen.search_photographer.composable.RefetchButton
 import com.hm.picplz.utils.LocationUtil.getDistance

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
@@ -49,8 +49,9 @@ import kotlinx.coroutines.flow.collectLatest
 import com.hm.picplz.R
 import androidx.compose.ui.layout.ContentScale
 import com.hm.picplz.ui.screen.search_photographer.composable.AddressMarker
-import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerListScreen
+import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerListSheet
 import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerProfile
+import com.hm.picplz.ui.screen.search_photographer.composable.PhotographerSheet
 import com.hm.picplz.ui.screen.search_photographer.composable.RefetchButton
 import com.hm.picplz.utils.LocationUtil.getDistance
 import com.kakao.vectormap.LatLng
@@ -141,11 +142,15 @@ fun SearchPhotographerScreen(
         modifier = Modifier
             .fillMaxSize(),
         sheetContent = {
-            PhotographerListScreen()
+            if (currentState.selectedPhotographerId === null) {
+                PhotographerListSheet()
+            } else {
+                PhotographerSheet()
+            }
         },
         scaffoldState = scaffoldState,
-//        sheetPeekHeight = currentState.sheetPeekHeight,
-//        sheetMaxHeight = currentState.sheetMaxHeight
+        sheetPeekHeight = currentState.sheetPeekHeight,
+        sheetMaxHeight = currentState.sheetMaxHeight
     ){
         Column(
             modifier = modifier

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
@@ -165,13 +165,9 @@ fun SearchPhotographerScreen(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null
                     ) {
-                        viewModel.handleIntent(
-                            SearchPhotographerIntent.SetSelectedPhotographerId(
-                                null
-                            )
-                        )
                         scope.launch {
                             scaffoldState.bottomSheetState.partialExpand()
+                            viewModel.handleIntent(SearchPhotographerIntent.SetSelectedPhotographerId(null))
                         }
                     },
             ) {
@@ -244,7 +240,10 @@ fun SearchPhotographerScreen(
                                 offset = Offset(x, y),
                                 distance = distanceInMeters,
                                 onClick = {
-                                    viewModel.handleIntent(SearchPhotographerIntent.SetSelectedPhotographerId(id))
+                                    scope.launch {
+                                        scaffoldState.bottomSheetState.partialExpand()
+                                        viewModel.handleIntent(SearchPhotographerIntent.SetSelectedPhotographerId(id))
+                                    }
                                 }
                             )
                         }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerState.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerState.kt
@@ -14,8 +14,8 @@ data class SearchPhotographerState (
     val nearbyPhotographers: FilteredPhotographers = FilteredPhotographers(),
     val randomOffsets: Map<Int, Pair<Float, Float>> = emptyMap(),
     val selectedPhotographerId: Int? = null,
-    val sheetMaxHeight: Dp = 600.dp,
-    val sheetPeekHeight: Dp? = null
+    val sheetMaxHeight: Dp = 750.dp,
+    val sheetPeekHeight: Dp? = 30.dp
 ) {
     companion object {
         fun idle(): SearchPhotographerState {

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/ActiveStatusBadge.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/ActiveStatusBadge.kt
@@ -1,0 +1,49 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hm.picplz.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.Pretendard
+
+@Composable
+fun ActiveStatusBadge(
+    modifier: Modifier = Modifier,
+    text: String = "바로 촬영",
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.height(20.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.active_dot),
+            contentDescription = "활성 상태 표시",
+        )
+        Spacer(modifier = Modifier.width(2.dp))
+        Text(
+            text = text,
+            color = MainThemeColor.Olive,
+            style = TextStyle(
+                fontFamily = Pretendard,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+                lineHeight = 12.sp * 1.4,
+                letterSpacing = 0.sp
+            )
+        )
+    }
+}

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/DistanceText.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/DistanceText.kt
@@ -1,0 +1,29 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.hm.picplz.ui.theme.MainThemeColor
+
+@Composable
+fun DistanceText(
+    distance: String,
+    duration: String,
+    modifier: Modifier = Modifier
+){
+    Row(
+        modifier = modifier
+    ) {
+        Text(
+            text = "${distance}m / $duration",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MainThemeColor.Gray4
+        )
+    }
+}

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.search_photographer.composable
 
-import CommonChip
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -12,26 +11,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
-import com.hm.picplz.R
-import com.hm.picplz.data.model.ChipMode
 import com.hm.picplz.ui.model.Photographer
 import com.hm.picplz.ui.theme.MainThemeColor
-import com.hm.picplz.ui.theme.Pretendard
 
 @Composable
 fun PhotographerCard (
@@ -106,6 +96,7 @@ fun PhotographerCardPreview() {
             distance = 100,
             followers = listOf(1, 2, 3),
             socialAccount = "@account",
+            portfolioPhotos = List(5) { "https://picsum.photos/100" },
         )
     )
 }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -1,0 +1,147 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import CommonChip
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.R
+import com.hm.picplz.data.model.ChipMode
+import com.hm.picplz.ui.model.Photographer
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.Pretendard
+
+@Composable
+fun PhotographerCard (
+    modifier: Modifier = Modifier,
+    photographer: Photographer,
+) {
+    Row (
+        modifier = modifier
+            .background(color = MainThemeColor.White)
+            .height(140.dp)
+            .padding(vertical = 20.dp)
+            .width(345.dp)
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(model = photographer.profileImageUri),
+            contentDescription = "작가 카드 프로필",
+            modifier = Modifier
+                .size(90.dp)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column (
+            modifier = Modifier.fillMaxSize()
+        ){
+            Row (
+                modifier = Modifier
+                    .padding(horizontal = 2.dp)
+                    .fillMaxSize()
+                    .weight(1f),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ){
+                Column {
+                    Text(
+                        text = photographer.name,
+                        style = TextStyle(
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.sp,
+                            lineHeight = 16.sp * 1.4,
+                            letterSpacing = 0.sp,
+                        )
+                    )
+                    Text(
+                        text = "${photographer.distance}m",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MainThemeColor.Gray4
+                    )
+                }
+//                if (photographer.isActive) {
+                    Row (
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .height(20.dp)
+                    ){
+                        Image(
+                            painter = painterResource(id = R.drawable.active_dot),
+                            contentDescription = "활성 상태 표시",
+                        )
+                        Text(
+                            text = "바로 촬영",
+                            color = MainThemeColor.Olive,
+                            style = TextStyle(
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 12.sp,
+                                lineHeight = 12.sp * 1.4,
+                                letterSpacing = 0.sp
+                            )
+                        )
+                    }
+//                }
+            }
+            LazyRow(
+                modifier = Modifier
+                    .height(30.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                val vibeTags = listOf(
+                    "#을지로 감성",
+                    "#키치 감성",
+                    "#MZ 감성",
+                    "#퇴폐 감성"
+                )
+
+                itemsIndexed(vibeTags) { index, vibeTag ->
+                    CommonChip(
+                        id = index.toString(),
+                        label = vibeTag,
+                        initialMode = ChipMode.DEFAULT,
+                        isEditable = false,
+                        height = ChipHeight.MEDIUM,
+                        backgroundColor = MainThemeColor.Gray2,
+                        unselectedBorderColor = MainThemeColor.Gray2,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PhotographerCardPreview() {
+    PhotographerCard(
+        photographer = Photographer(
+            id = 1,
+            name = "작가1",
+            location = null,
+            profileImageUri = "https://picsum.photos/200",
+            isActive = false,
+            workingArea = "마포구 서교동",
+            distance = 100,
+            followers = listOf(1, 2, 3),
+        )
+    )
+}

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -72,40 +72,22 @@ fun PhotographerCard (
                             letterSpacing = 0.sp,
                         )
                     )
-                    Text(
-                        text = "${photographer.distance}m",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MainThemeColor.Gray4
+                    DistanceText(
+                        distance = photographer.distance.toString(),
+                        duration = "도보 3분"
                     )
                 }
-//                if (photographer.isActive) {
+                if (photographer.isActive) {
                     ActiveStatusBadge(text = "바로 촬영")
-//                }
-            }
-            LazyRow(
-                modifier = Modifier
-                    .height(30.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                val vibeTags = listOf(
-                    "#을지로 감성",
-                    "#키치 감성",
-                    "#MZ 감성",
-                    "#퇴폐 감성"
-                )
-
-                itemsIndexed(vibeTags) { index, vibeTag ->
-                    CommonChip(
-                        id = index.toString(),
-                        label = vibeTag,
-                        initialMode = ChipMode.DEFAULT,
-                        isEditable = false,
-                        height = ChipHeight.MEDIUM,
-                        backgroundColor = MainThemeColor.Gray2,
-                        unselectedBorderColor = MainThemeColor.Gray2,
-                    )
                 }
             }
+            val vibeTags = listOf(
+                "#을지로 감성",
+                "#키치 감성",
+                "#MZ 감성",
+                "#퇴폐 감성"
+            )
+            VibeTags(tags = vibeTags)
         }
     }
 }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -142,6 +142,7 @@ fun PhotographerCardPreview() {
             workingArea = "마포구 서교동",
             distance = 100,
             followers = listOf(1, 2, 3),
+            socialAccount = "@account",
         )
     )
 }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -79,26 +79,7 @@ fun PhotographerCard (
                     )
                 }
 //                if (photographer.isActive) {
-                    Row (
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .height(20.dp)
-                    ){
-                        Image(
-                            painter = painterResource(id = R.drawable.active_dot),
-                            contentDescription = "활성 상태 표시",
-                        )
-                        Text(
-                            text = "바로 촬영",
-                            color = MainThemeColor.Olive,
-                            style = TextStyle(
-                                fontWeight = FontWeight.SemiBold,
-                                fontSize = 12.sp,
-                                lineHeight = 12.sp * 1.4,
-                                letterSpacing = 0.sp
-                            )
-                        )
-                    }
+                    ActiveStatusBadge(text = "바로 촬영")
 //                }
             }
             LazyRow(

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerListScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerListScreen.kt
@@ -1,25 +1,35 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import ChipHeight
+import CommonChip
+import CommonStatusTag
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.hm.picplz.R
 import com.hm.picplz.data.model.ChipMode
 import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.viewmodel.SearchPhotographerViewModel
 
 data class StatusTagData(
     val label: String,
@@ -40,7 +50,11 @@ private val vibeTags = listOf(
 )
 
 @Composable
-fun PhotographerListScreen() {
+fun PhotographerListScreen(
+    viewModel: SearchPhotographerViewModel = hiltViewModel()
+) {
+    val currentState = viewModel.state.collectAsState().value
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -67,6 +81,34 @@ fun PhotographerListScreen() {
                     isEditable = false,
                     height = ChipHeight.MEDIUM,
                 )
+            }
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "거리순",
+                color = MainThemeColor.Gray5
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                painter = painterResource(id = R.drawable.arrow_down),
+                contentDescription = "정렬 방식 선택",
+                modifier = Modifier.size(12.dp),
+                tint = MainThemeColor.Gray5
+            )
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            currentState.nearbyPhotographers.let { photographers ->
+                items(photographers.active + photographers.inactive) { photographer ->
+                    PhotographerCard(
+                        photographer = photographer
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerListSheet.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerListSheet.kt
@@ -50,7 +50,7 @@ private val vibeTags = listOf(
 )
 
 @Composable
-fun PhotographerListScreen(
+fun PhotographerListSheet(
     viewModel: SearchPhotographerViewModel = hiltViewModel()
 ) {
     val currentState = viewModel.state.collectAsState().value
@@ -117,6 +117,6 @@ fun PhotographerListScreen(
 @Preview(showBackground = true)
 @Composable
 fun PhotographerListScreenPreview() {
-    PhotographerListScreen()
+    PhotographerListSheet()
 }
 

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerProfile.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerProfile.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.search_photographer.composable
 
+import android.annotation.SuppressLint
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
@@ -38,6 +39,7 @@ import com.hm.picplz.R
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.Pretendard
 
+@SuppressLint("DefaultLocale")
 @Composable
 fun PhotographerProfile(
     name: String,

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
@@ -1,0 +1,73 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.Pretendard
+import com.hm.picplz.viewmodel.SearchPhotographerViewModel
+
+@Composable
+fun PhotographerSheet (
+    viewModel: SearchPhotographerViewModel = hiltViewModel()
+) {
+    val currentState = viewModel.state.collectAsState().value
+    val selectedPhotographer = currentState.selectedPhotographerId?.let { selectedId ->
+        currentState.nearbyPhotographers.let { photographers ->
+            (photographers.active + photographers.inactive).find { it.id == selectedId }
+        }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp)
+    ) {
+        Row() {
+            Image(
+                painter = rememberAsyncImagePainter(model = selectedPhotographer?.profileImageUri),
+                contentDescription = "작가 프로필 이미지",
+                modifier = Modifier
+                    .size(20.dp)
+                    .clip(CircleShape)
+                    .border(1.dp, MainThemeColor.Gray2, CircleShape)
+            )
+            Text(
+                text = selectedPhotographer?.name ?: "",
+                style = TextStyle(
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 18.sp,
+                    letterSpacing = 0.sp
+                ),
+                modifier = Modifier
+                    .padding(start = 4.dp)
+
+            )
+            Text(
+                text = selectedPhotographer?.socialAccount ?: "",
+                style = TextStyle(
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 12.sp,
+                    letterSpacing = 0.sp
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
@@ -2,17 +2,23 @@ package com.hm.picplz.ui.screen.search_photographer.composable
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -38,7 +44,9 @@ fun PhotographerSheet (
             .fillMaxWidth()
             .padding(top = 12.dp)
     ) {
-        Row() {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Image(
                 painter = rememberAsyncImagePainter(model = selectedPhotographer?.profileImageUri),
                 contentDescription = "작가 프로필 이미지",
@@ -57,7 +65,6 @@ fun PhotographerSheet (
                 ),
                 modifier = Modifier
                     .padding(start = 4.dp)
-
             )
             Text(
                 text = selectedPhotographer?.socialAccount ?: "",
@@ -66,8 +73,53 @@ fun PhotographerSheet (
                     fontWeight = FontWeight.Normal,
                     fontSize = 12.sp,
                     letterSpacing = 0.sp
-                )
+                ),
+                modifier = Modifier
+                    .padding(start = 4.dp)
             )
+        }
+        Row(
+            modifier = Modifier
+                .padding(start = 4.dp, top = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ){
+            ActiveStatusBadge(text = "바로 촬영")
+            DistanceText(
+                distance = selectedPhotographer?.distance.toString(),
+                duration = "도보 10분 거리",
+                modifier = Modifier
+                    .padding(start = 4.dp)
+            )
+        }
+        val vibeTags = listOf(
+            "#을지로 감성",
+            "#키치 감성",
+            "#MZ 감성",
+            "#퇴폐 감성"
+        )
+        VibeTags(
+            modifier = Modifier.padding(top = 20.dp),
+            tags = vibeTags
+        )
+        LazyRow(
+            modifier = Modifier
+                .padding(top = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            selectedPhotographer?.portfolioPhotos?.let { photos ->
+                itemsIndexed(photos) { _, photoUrl ->
+                    Image(
+                        painter = rememberAsyncImagePainter(
+                            model = photoUrl,
+                            contentScale = ContentScale.Crop
+                        ),
+                        contentDescription = "포트폴리오 사진",
+                        modifier = Modifier
+                            .size(100.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/VibeTags.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/VibeTags.kt
@@ -1,0 +1,36 @@
+package com.hm.picplz.ui.screen.search_photographer.composable
+
+import CommonChip
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.data.model.ChipMode
+import com.hm.picplz.ui.theme.MainThemeColor
+
+@Composable
+fun VibeTags (
+    modifier: Modifier = Modifier,
+    tags: List<String> = emptyList(),
+) {
+    LazyRow(
+        modifier = modifier
+            .height(30.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        itemsIndexed(tags) { index, vibeTag ->
+            CommonChip(
+                id = index.toString(),
+                label = vibeTag,
+                initialMode = ChipMode.DEFAULT,
+                isEditable = false,
+                height = ChipHeight.MEDIUM,
+                backgroundColor = MainThemeColor.Gray2,
+                unselectedBorderColor = MainThemeColor.Gray2,
+            )
+        }
+    }
+}

--- a/app/src/main/res/drawable/arrow_down.xml
+++ b/app/src/main/res/drawable/arrow_down.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="8dp"
+    android:viewportWidth="8"
+    android:viewportHeight="8">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M1,2.5L4,5.5L7,2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#5A6A76"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## 개요
- 작가 탐색 페이지 바텀 시트 영역 UI 개발

## 변경 사항
- 작가 미선택시 시트 
  - 작가 전체 리스트 
- 작가 선택시 시트
  - 작가 단일 정보

## 구현 내용
<img width="350" alt="image" src="https://github.com/user-attachments/assets/25bea1a1-8d18-433b-bc90-c394e4e40a11" />
</br>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/72e47cd3-38dd-4a41-9a16-1bfdf576dc2a" />

## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #32 