### PR TITLE
:lipstick: : 작가 클릭시 화면 가운데로 이동 동작 추가

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerIntent.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerIntent.kt
@@ -1,9 +1,9 @@
 package com.hm.picplz.ui.screen.search_photographer
 
 import android.content.Context
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Dp
 import com.hm.picplz.ui.model.FilteredPhotographers
-import com.hm.picplz.ui.model.Photographer
 import com.kakao.vectormap.LatLng
 
 sealed class SearchPhotographerIntent {
@@ -21,4 +21,5 @@ sealed class SearchPhotographerIntent {
     data class SetSelectedPhotographerId(val photographerId: Int?) : SearchPhotographerIntent()
     data class SetSheetMaxHeight(val maxHeight: Dp) : SearchPhotographerIntent()
     data class SetSheetPeekHeight(val peekHeight: Dp?) : SearchPhotographerIntent()
+    data class CenterSelectedPhotographer(val offset: Offset) : SearchPhotographerIntent()
 }

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerScreen.kt
@@ -8,6 +8,9 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateOffsetAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -20,6 +23,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,10 +35,12 @@ import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -122,13 +128,14 @@ fun SearchPhotographerScreen(
 
     LaunchedEffect(currentState.selectedPhotographerId) {
         if (currentState.selectedPhotographerId != null) {
-            scope.launch {
-                scaffoldState.bottomSheetState.expand()
+            val selectedOffset = currentState.randomOffsets[currentState.selectedPhotographerId]
+            if (selectedOffset != null) {
+                viewModel.handleIntent(SearchPhotographerIntent.CenterSelectedPhotographer(selectedOffset))
             }
+            scaffoldState.bottomSheetState.expand()
         } else {
-            scope.launch {
-                scaffoldState.bottomSheetState.partialExpand()
-            }
+            viewModel.handleIntent(SearchPhotographerIntent.CenterSelectedPhotographer(Offset.Zero))
+            scaffoldState.bottomSheetState.partialExpand()
         }
     }
 
@@ -209,15 +216,28 @@ fun SearchPhotographerScreen(
                             }
                         )
                     }
+
+                    val boxOffset by animateOffsetAsState(
+                        targetValue = currentState.centerOffset ?: Offset.Zero,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
+                        label = "boxAnimation"
+                    )
+
                     Box(
                         modifier = Modifier
-                            .fillMaxSize(),
+                            .fillMaxSize()
+                            .offset(boxOffset.x.dp, boxOffset.y.dp),
                         contentAlignment = Alignment.Center
                     ) {
                         Image(
                             painter = painterResource(R.drawable.multicircle),
                             contentDescription = "범위 지정 이미지",
-                            contentScale = ContentScale.FillHeight
+                            contentScale = ContentScale.FillWidth,
+                            modifier = Modifier
+                                .scale(1.5f)
                         )
                         Image(
                             painter = painterResource(id = R.drawable.center_char),
@@ -227,7 +247,7 @@ fun SearchPhotographerScreen(
                         // val userLocation = currentState.userLocation
                         val dummyUserLocation = LatLng.from(37.402960, 127.115587)
                         entirePhotographer.forEach {  ( id, name, photographerLocation, profileImageUri, isActive )  ->
-                            val (x, y) = currentState.randomOffsets[id] ?: return@forEach
+                            val offset = currentState.randomOffsets[id] ?: return@forEach
                             val isSelected = id == currentState.selectedPhotographerId
                             val distanceInMeters = photographerLocation?.let { location ->
                                 getDistance(dummyUserLocation, location) * 1000
@@ -237,12 +257,13 @@ fun SearchPhotographerScreen(
                                 profileImageUri = profileImageUri,
                                 isActive = isActive,
                                 isSelected = isSelected,
-                                offset = Offset(x, y),
+                                offset = offset,
                                 distance = distanceInMeters,
                                 onClick = {
                                     scope.launch {
                                         scaffoldState.bottomSheetState.partialExpand()
                                         viewModel.handleIntent(SearchPhotographerIntent.SetSelectedPhotographerId(id))
+                                        viewModel.handleIntent(SearchPhotographerIntent.CenterSelectedPhotographer(offset))
                                     }
                                 }
                             )

--- a/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerState.kt
+++ b/app/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/SearchPhotographerState.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.search_photographer
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.model.FilteredPhotographers
@@ -12,10 +13,11 @@ data class SearchPhotographerState (
     val isFetchingGPS: Boolean = false,
     val isSearchingPhotographer: Boolean = false,
     val nearbyPhotographers: FilteredPhotographers = FilteredPhotographers(),
-    val randomOffsets: Map<Int, Pair<Float, Float>> = emptyMap(),
+    val randomOffsets: Map<Int, Offset> = emptyMap(),
     val selectedPhotographerId: Int? = null,
     val sheetMaxHeight: Dp = 750.dp,
-    val sheetPeekHeight: Dp? = 30.dp
+    val sheetPeekHeight: Dp? = 30.dp,
+    val centerOffset: Offset? = null
 ) {
     companion object {
         fun idle(): SearchPhotographerState {

--- a/app/src/main/kotlin/com/hm/picplz/utils/LocationUtil.kt
+++ b/app/src/main/kotlin/com/hm/picplz/utils/LocationUtil.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.utils
 
+import androidx.compose.ui.geometry.Offset
 import com.kakao.vectormap.LatLng
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -43,9 +44,9 @@ object LocationUtil {
     /**
      * 화면상의 두 점의 거리
      */
-    fun calcurateScreenDistance(from: Pair<Float, Float>, to: Pair<Float, Float>): Float {
-        val dx = from.first - to.first
-        val dy = from.second - to.second
+    fun calcurateScreenDistance(from: Offset, to: Offset): Float {
+        val dx = from.x - to.x
+        val dy = from.y - to.y
         return sqrt(dx * dx + dy * dy)
     }
 }

--- a/app/src/main/kotlin/com/hm/picplz/viewmodel/SearchPhotograperViewModel.kt
+++ b/app/src/main/kotlin/com/hm/picplz/viewmodel/SearchPhotograperViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import android.Manifest
 import android.content.pm.PackageManager
 import android.location.LocationListener
+import androidx.compose.ui.geometry.Offset
 import com.hm.picplz.data.repository.PhotographerRepository
 import com.hm.picplz.ui.model.FilteredPhotographers
 import com.hm.picplz.ui.screen.search_photographer.SearchPhotographerSideEffect
@@ -197,6 +198,13 @@ class SearchPhotographerViewModel @Inject constructor(
                     sheetPeekHeight = intent.peekHeight
                 )}
             }
+            is SearchPhotographerIntent.CenterSelectedPhotographer -> {
+                val newOffset = Offset(
+                    x = -intent.offset.x,
+                    y = -intent.offset.y
+                )
+                _state.update { it.copy(centerOffset = newOffset) }
+            }
         }
     }
 
@@ -210,7 +218,7 @@ class SearchPhotographerViewModel @Inject constructor(
 
     class OffsetGenerationFailedException : Exception("전체 위치 생성 최종 실패")
 
-    private fun generateNonOverlappingOffsets(photographers: FilteredPhotographers): Map<Int, Pair<Float, Float>> {
+    private fun generateNonOverlappingOffsets(photographers: FilteredPhotographers): Map<Int, Offset> {
         val maxAttempts = 1000
 
         for (attempt in 1..maxAttempts) {
@@ -227,8 +235,8 @@ class SearchPhotographerViewModel @Inject constructor(
     private class OffsetGenerationException : Exception("개별 위치 생성 실패")
 
 
-    private fun tryGenerateOffsets(photographers: FilteredPhotographers): Map<Int, Pair<Float, Float>> {
-        val offsets = mutableMapOf<Int, Pair<Float, Float>>()
+    private fun tryGenerateOffsets(photographers: FilteredPhotographers): Map<Int, Offset> {
+        val offsets = mutableMapOf<Int, Offset>()
         val minDistance = 110f
 
         val innerAreaRatio = 0.75f
@@ -244,10 +252,10 @@ class SearchPhotographerViewModel @Inject constructor(
         val innerCircleMaxOffsetX = maxOffsetX * innerAreaRatio
         val outerCircleMinOffsetX = maxOffsetX * outerAreaRatio
 
-        val center = Pair(0f, 0f)
+        val center = Offset(0f, 0f)
 
-        fun generateOffset(): Pair<Float, Float> {
-            return Pair(
+        fun generateOffset(): Offset {
+            return Offset(
                 (Random.nextFloat() * 2 - 1) * maxOffsetX,
                 (Random.nextFloat() * 2 - 1) * maxOffsetX
             )
@@ -255,7 +263,7 @@ class SearchPhotographerViewModel @Inject constructor(
 
         if (photographers.inactive.isEmpty()) {
             photographers.active.forEachIndexed{ index, photographer ->
-                var newOffset: Pair<Float, Float>
+                var newOffset: Offset
                 var attempts = 0
 
                 do {
@@ -278,7 +286,7 @@ class SearchPhotographerViewModel @Inject constructor(
         } else {
             photographers.active.forEachIndexed { index, photographer ->
                 var attempts = 0
-                var newOffset: Pair<Float, Float>
+                var newOffset: Offset
 
                 do {
                     attempts++
@@ -297,7 +305,7 @@ class SearchPhotographerViewModel @Inject constructor(
                 offsets[photographer.id] = newOffset
             }
             photographers.inactive.forEach { photographer ->
-                var newOffset: Pair<Float, Float>
+                var newOffset: Offset
                 var attempts = 0
                 do {
                     attempts++


### PR DESCRIPTION
## 개요
- 작가 클릭시 화면 가운데로 이동 동작 추가

## 변경 사항
- 프로필 위치 형식을 Pair(Float, Float)에서 Offset으로 수정
- 작가 선택시 이동시켰던 offset만큼 전체 box를 반대로 이동

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #40 