### PR TITLE
🐛 Type-safe Navigation 리팩토링 이후 네비게이션 오류 수정

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
@@ -1,7 +1,5 @@
 package com.hm.picplz.navigation.graph
 
-import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -21,7 +19,6 @@ import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerPortfoliosS
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerReviewScreen
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerScreen
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerSingleReviewScreen
-import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerViewModel
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainScreen
 import com.hm.picplz.ui.screen.photographer_main.composable.EquipmentSettingScreen
 import com.hm.picplz.ui.screen.search_photographer.SearchPhotographerScreen
@@ -40,26 +37,18 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     }
 
     composable<ReviewPhotographer> { backStackEntry ->
-        val parentEntry =
-            remember(backStackEntry) {
-                navController.getBackStackEntry<DetailPhotographer>()
-            }
-        val sharedViewModel: DetailPhotographerViewModel = hiltViewModel(parentEntry)
+        val args = backStackEntry.toRoute<ReviewPhotographer>()
         DetailPhotographerReviewScreen(
             navController = navController,
-            viewModel = sharedViewModel,
+            photographerId = args.photographerId,
         )
     }
 
     composable<DetailPhotographerPhotoReviews> { backStackEntry ->
-        val parentEntry =
-            remember(backStackEntry) {
-                navController.getBackStackEntry<DetailPhotographer>()
-            }
-        val parentViewModel: DetailPhotographerViewModel = hiltViewModel(parentEntry)
+        val args = backStackEntry.toRoute<DetailPhotographerPhotoReviews>()
         DetailPhotographerPhotoReviewsScreen(
             navController = navController,
-            photoReviews = parentViewModel.state.value.reviewSummary.photoReviews,
+            photographerId = args.photographerId,
         )
     }
 
@@ -73,14 +62,10 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     }
 
     composable<DetailPhotographerPhotoPortfolios> { backStackEntry ->
-        val parentEntry =
-            remember(backStackEntry) {
-                navController.getBackStackEntry<DetailPhotographer>()
-            }
-        val parentViewModel: DetailPhotographerViewModel = hiltViewModel(parentEntry)
+        val args = backStackEntry.toRoute<DetailPhotographerPhotoPortfolios>()
         DetailPhotographerPhotoPortfoliosScreen(
             navController = navController,
-            photoPortfolios = parentViewModel.state.value.profileInfo.photoPortfolios,
+            photographerId = args.photographerId,
         )
     }
 

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -55,15 +55,17 @@ data class SignUpCompletion(val userInfo: User)
 @Serializable object PhotographerEquipmentSetting
 
 // === Detail Screens ===
-@Serializable object DetailPhotographer
-
-@Serializable object ReviewPhotographer
+@Serializable
+data class DetailPhotographer(val photographerId: Int)
 
 @Serializable
-object DetailPhotographerPhotoReviews
+data class ReviewPhotographer(val photographerId: Int)
 
 @Serializable
-object DetailPhotographerPhotoPortfolios
+data class DetailPhotographerPhotoReviews(val photographerId: Int)
+
+@Serializable
+data class DetailPhotographerPhotoPortfolios(val photographerId: Int)
 
 // === Screens with Arguments ===
 @Serializable

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -105,16 +105,16 @@ fun DevScreen(navController: NavHostController) {
 
             // === Detail Photographer ===
             SectionTitle("Detail Photographer")
-            DevButton("DetailPhotographer") { navController.navigate(DetailPhotographer) }
-            DevButton("ReviewPhotographer") { navController.navigate(ReviewPhotographer) }
+            DevButton("DetailPhotographer") { navController.navigate(DetailPhotographer(1)) }
+            DevButton("ReviewPhotographer") { navController.navigate(ReviewPhotographer(1)) }
             DevButton("DetailPhotographerPhotoReviews") {
                 navController.navigate(
-                    DetailPhotographerPhotoReviews,
+                    DetailPhotographerPhotoReviews(1),
                 )
             }
             DevButton("DetailPhotographerPhotoPortfolios") {
                 navController.navigate(
-                    DetailPhotographerPhotoPortfolios,
+                    DetailPhotographerPhotoPortfolios(1),
                 )
             }
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainIntent.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainIntent.kt
@@ -3,7 +3,7 @@ package com.hm.picplz.ui.screen.photographer_main
 sealed interface PhotographerMainIntent {
     data object NavigateToPrev : PhotographerMainIntent
 
-    data class Navigate(val destination: String) : PhotographerMainIntent
+    data class Navigate(val destination: Any) : PhotographerMainIntent
 
     data class SetIsModalOpen(val isModalOpen: Boolean) : PhotographerMainIntent
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainScreen.kt
@@ -36,6 +36,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.hm.picplz.core.ui.R
+import com.hm.picplz.navigation.model.PhotographerEquipmentSetting
 import com.hm.picplz.ui.navigation.BottomNavigationBar
 import com.hm.picplz.ui.screen.common.AddressMarker
 import com.hm.picplz.ui.screen.common.CommonBottomButton
@@ -175,7 +176,7 @@ fun PhotographerMainScreen(
                         onClick = {
                             if (currentState.isActive.not()) {
                                 viewModel.handleIntent(
-                                    PhotographerMainIntent.Navigate("photographer-equipment-setting"),
+                                    PhotographerMainIntent.Navigate(PhotographerEquipmentSetting),
                                 )
                             }
                         },

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainSideEffect.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainSideEffect.kt
@@ -3,5 +3,5 @@ package com.hm.picplz.ui.screen.photographer_main
 sealed interface PhotographerMainSideEffect {
     data object NavigateToPrev : PhotographerMainSideEffect
 
-    data class Navigate(val destination: String) : PhotographerMainSideEffect
+    data class Navigate(val destination: Any) : PhotographerMainSideEffect
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoPortfoliosScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoPortfoliosScreen.kt
@@ -20,17 +20,19 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
-import com.hm.picplz.common.model.PhotoPortfolio
 import com.hm.picplz.core.ui.R
+import com.hm.picplz.data.mockdata.mockPhotographerInfo
 import com.hm.picplz.navigation.model.DetailPhotographerPortfolioDetail
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
 import com.hm.picplz.ui.theme.MainThemeColor
 
+@Suppress("UNUSED_PARAMETER")
 @Composable
 fun DetailPhotographerPhotoPortfoliosScreen(
     navController: NavController,
-    photoPortfolios: List<PhotoPortfolio>,
+    photographerId: Int,
 ) {
+    val photoPortfolios = mockPhotographerInfo.photoPortfolios
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
 
     val chunkedImages = photoPortfolios.chunked(3)

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoReviewsScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoReviewsScreen.kt
@@ -25,18 +25,21 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
-import com.hm.picplz.common.model.PhotoReview
 import com.hm.picplz.core.ui.R
+import com.hm.picplz.data.mockdata.mockReviewSummary
 import com.hm.picplz.navigation.model.DetailPhotographerSingleReview
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.pretendardTypography
 
+@Suppress("UNUSED_PARAMETER")
 @Composable
 fun DetailPhotographerPhotoReviewsScreen(
     navController: NavController,
-    photoReviews: List<PhotoReview>,
+    photographerId: Int,
 ) {
+    // TODO: photographerId로 데이터 로드
+    val photoReviews = mockReviewSummary.photoReviews
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
     val chunkedImages = photoReviews.chunked(3)
 

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerReviewScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerReviewScreen.kt
@@ -51,10 +51,12 @@ import com.hm.picplz.ui.util.ReviewUtil
 import com.hm.picplz.ui.util.StarType
 import kotlinx.coroutines.flow.collectLatest
 
+@Suppress("UNUSED_PARAMETER")
 @Composable
 fun DetailPhotographerReviewScreen(
-    viewModel: DetailPhotographerViewModel = hiltViewModel(),
     navController: NavController,
+    photographerId: Int,
+    viewModel: DetailPhotographerViewModel = hiltViewModel(),
 ) {
     val currentState = viewModel.state.collectAsState().value
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
@@ -148,7 +150,7 @@ fun DetailPhotographerReviewScreen(
                                             .weight(1f)
                                             .aspectRatio(1f)
                                             .clickable {
-                                                navController.navigate(DetailPhotographerPhotoReviews)
+                                                navController.navigate(DetailPhotographerPhotoReviews(photographerId))
                                             },
                                     contentAlignment = Alignment.Center,
                                 ) {
@@ -262,6 +264,6 @@ fun DetailPhotographerReviewScreenPreview() {
     val navController = rememberNavController()
 
     PicplzTheme {
-        DetailPhotographerReviewScreen(navController = navController)
+        DetailPhotographerReviewScreen(navController = navController, photographerId = 1)
     }
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
@@ -81,6 +81,7 @@ fun DetailPhotographerScreen(
                         modifier = paddingModifier,
                         navController = navController,
                         reviewSummary = reviewSummary,
+                        photographerId = viewModel.photographerId,
                     )
 
                     Spacer(modifier = Modifier.height(30.dp))
@@ -89,6 +90,7 @@ fun DetailPhotographerScreen(
                         modifier = paddingModifier,
                         navController = navController,
                         photoPortfolios = photoPortfolios,
+                        photographerId = viewModel.photographerId,
                     )
 
                     Spacer(modifier = Modifier.height(30.dp))

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.detail_photographer
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +14,11 @@ import javax.inject.Inject
 @HiltViewModel
 open class DetailPhotographerViewModel
     @Inject
-    constructor() : ViewModel() {
+    constructor(
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        val photographerId: Int = savedStateHandle.get<Int>("photographerId") ?: 0
+
         private val _state = MutableStateFlow(DetailPhotographerState.idle())
         val state: StateFlow<DetailPhotographerState> = _state
 

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/PortfolioSection.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/PortfolioSection.kt
@@ -32,6 +32,7 @@ fun PortfolioSection(
     modifier: Modifier,
     navController: NavController,
     photoPortfolios: List<PhotoPortfolio>,
+    photographerId: Int,
 ) {
     Column {
         // 포트폴리오
@@ -91,7 +92,7 @@ fun PortfolioSection(
             verticalPadding = 0.dp,
             gap = 6.dp,
             onClick = {
-                navController.navigate(DetailPhotographerPhotoPortfolios)
+                navController.navigate(DetailPhotographerPhotoPortfolios(photographerId))
             },
             modifier = modifier.align(Alignment.End),
         )

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/ReviewSection.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/ReviewSection.kt
@@ -38,6 +38,7 @@ fun ReviewSection(
     modifier: Modifier,
     navController: NavHostController,
     reviewSummary: PhotographerReviewSummary,
+    photographerId: Int,
 ) {
     val totalRating = reviewSummary.averageRating
     val starList = ReviewUtil.calculateStarRating(totalRating, StarType.MAIN) // MathUtil에서 호출
@@ -81,7 +82,7 @@ fun ReviewSection(
             horizontalPadding = 0.dp,
             verticalPadding = 0.dp,
             gap = 6.dp,
-            onClick = { navController.navigate(ReviewPhotographer) },
+            onClick = { navController.navigate(ReviewPhotographer(photographerId)) },
             modifier = modifier.align(Alignment.End),
         )
     }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerCard.kt
@@ -40,7 +40,7 @@ fun PhotographerCard(
                 .height(140.dp)
                 .padding(vertical = 20.dp)
                 .width(345.dp)
-                .clickable { mainNavController.navigate(DetailPhotographer) },
+                .clickable { mainNavController.navigate(DetailPhotographer(photographer.id)) },
     ) {
         Image(
             painter = rememberAsyncImagePainter(model = photographer.profileImageUri),

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/search_photographer/composable/PhotographerSheet.kt
@@ -49,7 +49,11 @@ fun PhotographerSheet(
             Modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp)
-                .clickable { mainNavController.navigate(DetailPhotographer) },
+                .clickable {
+                    selectedPhotographer?.let {
+                        mainNavController.navigate(DetailPhotographer(it.id))
+                    }
+                },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary
Type-safe Navigation 리팩토링 이후 발생한 네비게이션 크래시 버그 수정

## Changes

### 1. DetailPhotographer 백스택 공유 문제 (#83)
- `ReviewPhotographer` 화면에서 `DetailPhotographer` 백스택 엔트리를 찾지 못해 크래시
- Route를 `object`에서 `data class`로 변경하여 `photographerId` argument 전달
- `getBackStackEntry<T>()` 대신 `toRoute<T>()` 사용

### 2. PhotographerMainScreen → PhotographerEquipmentSetting 네비게이션 오류
- String 기반 navigation 호출을 type-safe route 객체로 변경
- `Navigate(destination: String)` → `Navigate(destination: Any)`
- `"photographer-equipment-setting"` → `PhotographerEquipmentSetting` 객체

## Modified Files
- `core/common/.../RouteModels.kt`
- `app/.../PhotographerNavGraph.kt`
- `feature/photographer/` - 7 files
- `feature/main/.../PhotographerMainIntent.kt`
- `feature/main/.../PhotographerMainSideEffect.kt`
- `feature/main/.../PhotographerMainScreen.kt`
- `feature/main/.../dev/DevScreen.kt`

## Closes
- #83