### PR TITLE
♻️ 공통 컴포넌트 리팩토링 - CommonTopBar, CommonBottomButton 피그마 스타일 적용

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,34 @@ core:data → core:domain
 core:ui → core:common
 ```
 
+## GIT WORKFLOW
+
+### Issue-Driven Development
+1. **모든 작업은 GitHub Issue 기반** - 이슈 먼저 생성/확인 후 작업 시작
+2. **1 Issue = 1 Branch = 1 PR** - 이슈와 브랜치, PR이 1:1 대응
+
+### Branch Strategy
+```
+main ← develop ← feat/이슈번호
+                 fix/이슈번호
+                 refactor/이슈번호
+                 docs/이슈번호
+```
+
+- **Base**: 항상 `develop` 브랜치에서 분기
+- **Naming**: `{type}/{issue-number}` (예: `feat/12`, `refactor/86`)
+- **PR Target**: `develop`으로 머지
+
+### Commit Convention (Gitmoji)
+| Emoji | Code | Description |
+|-------|------|-------------|
+| ✨ | `:sparkles:` | 새 기능 |
+| 🐛 | `:bug:` | 버그 수정 |
+| ♻️ | `:recycle:` | 리팩토링 |
+| 🔥 | `:fire:` | 코드/파일 삭제 |
+| 📝 | `:memo:` | 문서 |
+| 🚚 | `:truck:` | 파일 이동/이름 변경 |
+
 ## COMMANDS
 
 ```bash
@@ -102,6 +130,10 @@ core:ui → core:common
 | feature:feed | ✅ | Complete |
 | feature:main | ✅ | Complete |
 | app | ✅ | Cleanup & Dependency linking done |
+
+## DESIGN
+
+**Figma**: [픽플즈 디자인](https://www.figma.com/design/Lf9FSdH8jJeIeDxdTEHLbL/%ED%94%BD%ED%94%8C%EC%A6%88)
 
 ## NOTES
 - **Android Studio**: Use "Android" view or `Shift+Shift` for navigation.

--- a/core/ui/AGENTS.md
+++ b/core/ui/AGENTS.md
@@ -60,13 +60,24 @@ Design System module providing reusable Compose components, theme, and drawable 
 | **도메인 텍스트** | `text: String` | 화면마다 다른 문구 |
 | **도메인 동작** | `onClick: () -> Unit` | 화면마다 다른 비즈니스 로직 |
 | **도메인 상태** | `enabled: Boolean` | 비즈니스 로직에 따른 활성화 |
+| **레이아웃 통합** | `modifier: Modifier = Modifier` | 부모 레이아웃과의 통합, 접근성, 테스트 |
 
 | 받으면 안 되는 것 | 예시 | 이유 |
 |------------------|------|------|
 | 색상 | `containerColor`, `contentColor` | 피그마 기준 고정 |
-| 크기/여백 | `height`, `padding`, `modifier` | 피그마 기준 고정 |
+| 크기/여백 | `height`, `padding` | 피그마 기준 고정 |
 | 폰트 스타일 | `textStyle`, `fontSize` | 디자인 시스템 고정 |
 | 테두리 | `borderColor`, `borderWidth` | 피그마 기준 고정 |
+
+### modifier는 왜 허용하는가?
+
+`Modifier`는 스타일링이 아니라 **레이아웃 통합 도구**:
+- 부모와의 배치: `padding`, `fillMaxWidth`, `weight`
+- 시스템 통합: `imePadding`, `navigationBarsPadding`
+- 접근성: `semantics`, `testTag`
+- 애니메이션: `animateContentSize`
+
+modifier 없으면 매번 `Box`/`Spacer`로 감싸는 보일러플레이트 발생.
 
 ### 스타일이 다르면 별도 컴포넌트
 

--- a/core/ui/AGENTS.md
+++ b/core/ui/AGENTS.md
@@ -44,6 +44,56 @@ Design System module providing reusable Compose components, theme, and drawable 
 - Status icons: `bookmark_*`, `like_*`, `star_*`
 - UI elements: `close.xml`, `check.xml`, `arrow_*.xml`
 
+## COMMON COMPONENT DESIGN PRINCIPLES
+
+### 공통 컴포넌트의 본질
+
+공통 컴포넌트는 **동일한 UI를 여러 곳에서 재사용**하기 위한 것이다.
+스타일이 유동적이면 공통 컴포넌트의 의미가 없다.
+
+### Props 최소화 원칙
+
+**UI적 요소는 파라미터로 받지 않는다** - 피그마 기준으로 고정
+
+| 받아야 할 것 | 예시 | 이유 |
+|-------------|------|------|
+| **도메인 텍스트** | `text: String` | 화면마다 다른 문구 |
+| **도메인 동작** | `onClick: () -> Unit` | 화면마다 다른 비즈니스 로직 |
+| **도메인 상태** | `enabled: Boolean` | 비즈니스 로직에 따른 활성화 |
+
+| 받으면 안 되는 것 | 예시 | 이유 |
+|------------------|------|------|
+| 색상 | `containerColor`, `contentColor` | 피그마 기준 고정 |
+| 크기/여백 | `height`, `padding`, `modifier` | 피그마 기준 고정 |
+| 폰트 스타일 | `textStyle`, `fontSize` | 디자인 시스템 고정 |
+| 테두리 | `borderColor`, `borderWidth` | 피그마 기준 고정 |
+
+### 스타일이 다르면 별도 컴포넌트
+
+```
+❌ CommonBottomButton(containerColor = KakaoYellow, ...)
+✅ KakaoLoginButton(text, onClick)
+
+❌ CommonTopBar(hasMenu = true, menuIcon = ...)
+✅ CommonTopBarWithMenu(text, onClickBack, onClickMenu)
+```
+
+### Defaults Object 패턴 (Material3 컨벤션)
+
+내부 상수는 `Defaults` object로 정의:
+
+```kotlin
+object CommonBottomButtonDefaults {
+    val VerticalPadding = 14.dp
+    val HorizontalPadding = 20.dp
+    val CornerRadius = 8.dp
+}
+```
+
+### 요약
+
+> **공통 컴포넌트 = 도메인 정보만 받고, UI는 피그마대로 고정**
+
 ## CONVENTIONS
 
 1. **Prefix `Common`** - All reusable components must be prefixed

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
@@ -24,11 +24,12 @@ private object CommonBottomButtonDefaults {
 fun CommonBottomButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
     Button(
         onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = MainThemeColor.Black,

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
@@ -2,11 +2,9 @@ package com.hm.picplz.ui.screen.common
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.hm.picplz.core.ui.R
@@ -29,75 +26,97 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
+private val TopBarHeight = 44.dp
+private val TopBarHorizontalPadding = 16.dp
+private val IconSize = 18.dp
+
 @Composable
 fun CommonTopBar(
-    modifier: Modifier = Modifier,
     text: String,
     onClickBack: () -> Unit,
-    showMenuIcon: Boolean = false,
-    onClickMenu: () -> Unit = {},
-    textStyle: TextStyle = pretendardTypography.bodyMedium,
-    paddingStart: Dp = 0.dp,
-    iconSize: Dp = 16.dp,
-    spacerWidth: Dp = 50.dp,
 ) {
-    Box(
+    Row(
         modifier =
             Modifier
-                .height(44.dp)
-                .fillMaxWidth(),
-        contentAlignment = Alignment.Center,
+                .fillMaxWidth()
+                .height(TopBarHeight)
+                .padding(horizontal = TopBarHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier =
-                modifier
-                    .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterStart,
         ) {
-            IconButton(
-                onClick = onClickBack,
-                modifier =
-                    Modifier
-                        .fillMaxHeight()
-                        .padding(start = paddingStart),
-            ) {
+            IconButton(onClick = onClickBack) {
                 Image(
                     painter = painterResource(R.drawable.triangle_left),
-                    contentDescription = "arrow left",
-                    modifier = Modifier.size(iconSize),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier.size(IconSize),
                 )
             }
-            Box(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = text,
-                    style = textStyle,
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                style = pretendardTypography.bodyMedium,
+            )
+        }
+
+        Box(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+fun CommonTopBarWithMenu(
+    text: String,
+    onClickBack: () -> Unit,
+    onClickMenu: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(TopBarHeight)
+                .padding(horizontal = TopBarHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            IconButton(onClick = onClickBack) {
+                Image(
+                    painter = painterResource(R.drawable.triangle_left),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier.size(IconSize),
                 )
             }
-            Box(
-                modifier =
-                    Modifier
-                        .size(spacerWidth)
-                        .fillMaxHeight(),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (showMenuIcon) {
-                    IconButton(onClick = onClickMenu) {
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .size(18.dp),
-                            painter = painterResource(id = R.drawable.menu),
-                            contentDescription = "상단바 메뉴 아이콘",
-                        )
-                    }
-                }
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                style = pretendardTypography.bodyMedium,
+            )
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterEnd,
+        ) {
+            IconButton(onClick = onClickMenu) {
+                Icon(
+                    painter = painterResource(id = R.drawable.menu),
+                    contentDescription = "메뉴",
+                    modifier = Modifier.size(IconSize),
+                )
             }
         }
     }
@@ -105,84 +124,62 @@ fun CommonTopBar(
 
 @Composable
 fun CommonTopBarWithSubtitle(
-    modifier: Modifier = Modifier,
     text: String,
     subText: String,
     onClickBack: () -> Unit,
-    showMenuIcon: Boolean = false,
-    onClickMenu: () -> Unit = {},
-    textStyle: TextStyle = pretendardTypography.bodyMedium,
+    onClickMenu: () -> Unit,
     subTextStyle: TextStyle = MainFontFamily.caption,
-    paddingStart: Dp = 0.dp,
-    iconSize: Dp = 16.dp,
-    spacerWidth: Dp = 50.dp,
 ) {
-    Box(
+    Row(
         modifier =
             Modifier
-                .height(44.dp)
-                .fillMaxWidth(),
-        contentAlignment = Alignment.Center,
+                .fillMaxWidth()
+                .height(TopBarHeight)
+                .padding(horizontal = TopBarHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier =
-                modifier
-                    .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterStart,
         ) {
-            IconButton(
-                onClick = onClickBack,
-                modifier =
-                    Modifier
-                        .fillMaxHeight()
-                        .padding(start = paddingStart),
-            ) {
+            IconButton(onClick = onClickBack) {
                 Image(
                     painter = painterResource(R.drawable.triangle_left),
-                    contentDescription = "arrow left",
-                    modifier = Modifier.size(iconSize),
+                    contentDescription = "뒤로가기",
+                    modifier = Modifier.size(IconSize),
                 )
             }
-            Box(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                contentAlignment = Alignment.Center,
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = text,
-                        style = textStyle,
-                    )
-                    Text(
-                        text = subText,
-                        style = subTextStyle,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
-                }
+                Text(
+                    text = text,
+                    style = pretendardTypography.bodyMedium,
+                )
+                Text(
+                    text = subText,
+                    style = subTextStyle,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
             }
-            Box(
-                modifier =
-                    Modifier
-                        .size(spacerWidth)
-                        .fillMaxHeight(),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (showMenuIcon) {
-                    IconButton(onClick = onClickMenu) {
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .size(18.dp),
-                            painter = painterResource(id = R.drawable.menu),
-                            contentDescription = "상단바 메뉴 아이콘",
-                        )
-                    }
-                }
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterEnd,
+        ) {
+            IconButton(onClick = onClickMenu) {
+                Icon(
+                    painter = painterResource(id = R.drawable.menu),
+                    contentDescription = "메뉴",
+                    modifier = Modifier.size(IconSize),
+                )
             }
         }
     }
@@ -198,18 +195,19 @@ fun CommonFixedTopBar(
             Modifier
                 .background(MainThemeColor.White)
                 .zIndex(1f)
-                .height(44.dp),
+                .height(TopBarHeight),
     ) {
         CommonTopBar(
             text = title,
-            onClickBack = { onClickBack() },
+            onClickBack = onClickBack,
         )
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-fun CommonTopBarPreview() {
+private fun CommonTopBarPreview() {
     PicplzTheme {
         CommonTopBar(
             text = "제목",
@@ -218,29 +216,30 @@ fun CommonTopBarPreview() {
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-fun CommonTopBarWithSubtitlePreview() {
+private fun CommonTopBarWithMenuPreview() {
     PicplzTheme {
-        CommonTopBarWithSubtitle(
+        CommonTopBarWithMenu(
             text = "제목",
-            subText = "부제목",
-            subTextStyle = MainFontFamily.caption.copy(color = MainThemeColor.Green120),
             onClickBack = {},
+            onClickMenu = {},
         )
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-fun CommonTopBarWithSubtitleMenuPreview() {
+private fun CommonTopBarWithSubtitlePreview() {
     PicplzTheme {
         CommonTopBarWithSubtitle(
-            text = "제목",
-            subText = "부제목",
+            text = "유가영 작가",
+            subText = "당장 촬영 가능",
             subTextStyle = MainFontFamily.caption.copy(color = MainThemeColor.Green120),
             onClickBack = {},
-            showMenuIcon = true,
+            onClickMenu = {},
         )
     }
 }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
@@ -22,9 +22,11 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
-internal val TopBarHeight = 44.dp
-internal val TopBarHorizontalPadding = 16.dp
-internal val TopBarIconSize = 18.dp
+private object CommonTopBarDefaults {
+    val Height = 44.dp
+    val HorizontalPadding = 16.dp
+    val IconSize = 18.dp
+}
 
 @Composable
 fun CommonTopBar(
@@ -35,8 +37,8 @@ fun CommonTopBar(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(TopBarHeight)
-                .padding(horizontal = TopBarHorizontalPadding),
+                .height(CommonTopBarDefaults.Height)
+                .padding(horizontal = CommonTopBarDefaults.HorizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
@@ -47,7 +49,7 @@ fun CommonTopBar(
                 Image(
                     painter = painterResource(R.drawable.triangle_left),
                     contentDescription = "뒤로가기",
-                    modifier = Modifier.size(TopBarIconSize),
+                    modifier = Modifier.size(CommonTopBarDefaults.IconSize),
                 )
             }
         }
@@ -76,7 +78,7 @@ fun CommonFixedTopBar(
             Modifier
                 .background(MainThemeColor.White)
                 .zIndex(1f)
-                .height(TopBarHeight),
+                .height(CommonTopBarDefaults.Height),
     ) {
         CommonTopBar(
             text = title,

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
@@ -32,10 +32,11 @@ private object CommonTopBarDefaults {
 fun CommonTopBar(
     text: String,
     onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .height(CommonTopBarDefaults.Height)
                 .padding(horizontal = CommonTopBarDefaults.HorizontalPadding),

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
@@ -33,11 +33,84 @@ import com.hm.picplz.ui.theme.pretendardTypography
 fun CommonTopBar(
     modifier: Modifier = Modifier,
     text: String,
-    subText: String? = null,
     onClickBack: () -> Unit,
     showMenuIcon: Boolean = false,
     onClickMenu: () -> Unit = {},
-    boxHeight: Dp = 50.dp,
+    textStyle: TextStyle = pretendardTypography.bodyMedium,
+    paddingStart: Dp = 0.dp,
+    iconSize: Dp = 16.dp,
+    spacerWidth: Dp = 50.dp,
+) {
+    Box(
+        modifier =
+            Modifier
+                .height(44.dp)
+                .fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Row(
+            modifier =
+                modifier
+                    .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            IconButton(
+                onClick = onClickBack,
+                modifier =
+                    Modifier
+                        .fillMaxHeight()
+                        .padding(start = paddingStart),
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.triangle_left),
+                    contentDescription = "arrow left",
+                    modifier = Modifier.size(iconSize),
+                )
+            }
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = text,
+                    style = textStyle,
+                )
+            }
+            Box(
+                modifier =
+                    Modifier
+                        .size(spacerWidth)
+                        .fillMaxHeight(),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (showMenuIcon) {
+                    IconButton(onClick = onClickMenu) {
+                        Icon(
+                            modifier =
+                                Modifier
+                                    .size(18.dp),
+                            painter = painterResource(id = R.drawable.menu),
+                            contentDescription = "상단바 메뉴 아이콘",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CommonTopBarWithSubtitle(
+    modifier: Modifier = Modifier,
+    text: String,
+    subText: String,
+    onClickBack: () -> Unit,
+    showMenuIcon: Boolean = false,
+    onClickMenu: () -> Unit = {},
     textStyle: TextStyle = pretendardTypography.bodyMedium,
     subTextStyle: TextStyle = MainFontFamily.caption,
     paddingStart: Dp = 0.dp,
@@ -47,7 +120,7 @@ fun CommonTopBar(
     Box(
         modifier =
             Modifier
-                .height(boxHeight)
+                .height(44.dp)
                 .fillMaxWidth(),
         contentAlignment = Alignment.Center,
     ) {
@@ -85,13 +158,11 @@ fun CommonTopBar(
                         text = text,
                         style = textStyle,
                     )
-                    if (subText != null) {
-                        Text(
-                            text = subText,
-                            style = subTextStyle,
-                            modifier = Modifier.padding(top = 2.dp),
-                        )
-                    }
+                    Text(
+                        text = subText,
+                        style = subTextStyle,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
                 }
             }
             Box(
@@ -149,9 +220,9 @@ fun CommonTopBarPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun CommonTopBarSubtitlePreview() {
+fun CommonTopBarWithSubtitlePreview() {
     PicplzTheme {
-        CommonTopBar(
+        CommonTopBarWithSubtitle(
             text = "제목",
             subText = "부제목",
             subTextStyle = MainFontFamily.caption.copy(color = MainThemeColor.Green120),
@@ -162,9 +233,9 @@ fun CommonTopBarSubtitlePreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun CommonTopBarSubtitleMenuPreview() {
+fun CommonTopBarWithSubtitleMenuPreview() {
     PicplzTheme {
-        CommonTopBar(
+        CommonTopBarWithSubtitle(
             text = "제목",
             subText = "부제목",
             subTextStyle = MainFontFamily.caption.copy(color = MainThemeColor.Green120),

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
@@ -1,13 +1,13 @@
 package com.hm.picplz.ui.screen.common
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,21 +15,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import com.hm.picplz.core.ui.R
-import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
-internal val TopBarHeight = 44.dp
-internal val TopBarHorizontalPadding = 16.dp
-internal val TopBarIconSize = 18.dp
-
 @Composable
-fun CommonTopBar(
+fun CommonTopBarWithMenu(
     text: String,
     onClickBack: () -> Unit,
+    onClickMenu: () -> Unit,
 ) {
     Row(
         modifier =
@@ -62,37 +56,30 @@ fun CommonTopBar(
             )
         }
 
-        Box(modifier = Modifier.weight(1f))
-    }
-}
-
-@Composable
-fun CommonFixedTopBar(
-    title: String,
-    onClickBack: () -> Unit,
-) {
-    Box(
-        modifier =
-            Modifier
-                .background(MainThemeColor.White)
-                .zIndex(1f)
-                .height(TopBarHeight),
-    ) {
-        CommonTopBar(
-            text = title,
-            onClickBack = onClickBack,
-        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterEnd,
+        ) {
+            IconButton(onClick = onClickMenu) {
+                Icon(
+                    painter = painterResource(id = R.drawable.menu),
+                    contentDescription = "메뉴",
+                    modifier = Modifier.size(TopBarIconSize),
+                )
+            }
+        }
     }
 }
 
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-private fun CommonTopBarPreview() {
+private fun CommonTopBarWithMenuPreview() {
     PicplzTheme {
-        CommonTopBar(
+        CommonTopBarWithMenu(
             text = "제목",
             onClickBack = {},
+            onClickMenu = {},
         )
     }
 }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
@@ -15,9 +15,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
+
+private object CommonTopBarWithMenuDefaults {
+    val Height = 44.dp
+    val HorizontalPadding = 16.dp
+    val IconSize = 18.dp
+}
 
 @Composable
 fun CommonTopBarWithMenu(
@@ -29,8 +36,8 @@ fun CommonTopBarWithMenu(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(TopBarHeight)
-                .padding(horizontal = TopBarHorizontalPadding),
+                .height(CommonTopBarWithMenuDefaults.Height)
+                .padding(horizontal = CommonTopBarWithMenuDefaults.HorizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
@@ -41,7 +48,7 @@ fun CommonTopBarWithMenu(
                 Image(
                     painter = painterResource(R.drawable.triangle_left),
                     contentDescription = "뒤로가기",
-                    modifier = Modifier.size(TopBarIconSize),
+                    modifier = Modifier.size(CommonTopBarWithMenuDefaults.IconSize),
                 )
             }
         }
@@ -64,7 +71,7 @@ fun CommonTopBarWithMenu(
                 Icon(
                     painter = painterResource(id = R.drawable.menu),
                     contentDescription = "메뉴",
-                    modifier = Modifier.size(TopBarIconSize),
+                    modifier = Modifier.size(CommonTopBarWithMenuDefaults.IconSize),
                 )
             }
         }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithMenu.kt
@@ -31,10 +31,11 @@ fun CommonTopBarWithMenu(
     text: String,
     onClickBack: () -> Unit,
     onClickMenu: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .height(CommonTopBarWithMenuDefaults.Height)
                 .padding(horizontal = CommonTopBarWithMenuDefaults.HorizontalPadding),

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
@@ -37,11 +37,12 @@ fun CommonTopBarWithSubtitle(
     subText: String,
     onClickBack: () -> Unit,
     onClickMenu: () -> Unit,
+    modifier: Modifier = Modifier,
     subTextStyle: TextStyle = MainFontFamily.caption,
 ) {
     Row(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .height(CommonTopBarWithSubtitleDefaults.Height)
                 .padding(horizontal = CommonTopBarWithSubtitleDefaults.HorizontalPadding),

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
@@ -1,35 +1,36 @@
 package com.hm.picplz.ui.screen.common
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainFontFamily
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
-internal val TopBarHeight = 44.dp
-internal val TopBarHorizontalPadding = 16.dp
-internal val TopBarIconSize = 18.dp
-
 @Composable
-fun CommonTopBar(
+fun CommonTopBarWithSubtitle(
     text: String,
+    subText: String,
     onClickBack: () -> Unit,
+    onClickMenu: () -> Unit,
+    subTextStyle: TextStyle = MainFontFamily.caption,
 ) {
     Row(
         modifier =
@@ -56,43 +57,47 @@ fun CommonTopBar(
             modifier = Modifier.weight(1f),
             contentAlignment = Alignment.Center,
         ) {
-            Text(
-                text = text,
-                style = pretendardTypography.bodyMedium,
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = text,
+                    style = pretendardTypography.bodyMedium,
+                )
+                Text(
+                    text = subText,
+                    style = subTextStyle,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
         }
 
-        Box(modifier = Modifier.weight(1f))
-    }
-}
-
-@Composable
-fun CommonFixedTopBar(
-    title: String,
-    onClickBack: () -> Unit,
-) {
-    Box(
-        modifier =
-            Modifier
-                .background(MainThemeColor.White)
-                .zIndex(1f)
-                .height(TopBarHeight),
-    ) {
-        CommonTopBar(
-            text = title,
-            onClickBack = onClickBack,
-        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterEnd,
+        ) {
+            IconButton(onClick = onClickMenu) {
+                Icon(
+                    painter = painterResource(id = R.drawable.menu),
+                    contentDescription = "메뉴",
+                    modifier = Modifier.size(TopBarIconSize),
+                )
+            }
+        }
     }
 }
 
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-private fun CommonTopBarPreview() {
+private fun CommonTopBarWithSubtitlePreview() {
     PicplzTheme {
-        CommonTopBar(
-            text = "제목",
+        CommonTopBarWithSubtitle(
+            text = "유가영 작가",
+            subText = "당장 촬영 가능",
+            subTextStyle = MainFontFamily.caption.copy(color = MainThemeColor.Green120),
             onClickBack = {},
+            onClickMenu = {},
         )
     }
 }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBarWithSubtitle.kt
@@ -24,6 +24,13 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
+private object CommonTopBarWithSubtitleDefaults {
+    val Height = 44.dp
+    val HorizontalPadding = 16.dp
+    val IconSize = 18.dp
+    val SubtitleTopPadding = 2.dp
+}
+
 @Composable
 fun CommonTopBarWithSubtitle(
     text: String,
@@ -36,8 +43,8 @@ fun CommonTopBarWithSubtitle(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(TopBarHeight)
-                .padding(horizontal = TopBarHorizontalPadding),
+                .height(CommonTopBarWithSubtitleDefaults.Height)
+                .padding(horizontal = CommonTopBarWithSubtitleDefaults.HorizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
@@ -48,7 +55,7 @@ fun CommonTopBarWithSubtitle(
                 Image(
                     painter = painterResource(R.drawable.triangle_left),
                     contentDescription = "뒤로가기",
-                    modifier = Modifier.size(TopBarIconSize),
+                    modifier = Modifier.size(CommonTopBarWithSubtitleDefaults.IconSize),
                 )
             }
         }
@@ -67,7 +74,7 @@ fun CommonTopBarWithSubtitle(
                 Text(
                     text = subText,
                     style = subTextStyle,
-                    modifier = Modifier.padding(top = 2.dp),
+                    modifier = Modifier.padding(top = CommonTopBarWithSubtitleDefaults.SubtitleTopPadding),
                 )
             }
         }
@@ -80,7 +87,7 @@ fun CommonTopBarWithSubtitle(
                 Icon(
                     painter = painterResource(id = R.drawable.menu),
                     contentDescription = "메뉴",
-                    modifier = Modifier.size(TopBarIconSize),
+                    modifier = Modifier.size(CommonTopBarWithSubtitleDefaults.IconSize),
                 )
             }
         }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/KakaoLoginButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/KakaoLoginButton.kt
@@ -14,35 +14,31 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 
-private object CommonBottomButtonDefaults {
+private object KakaoLoginButtonDefaults {
     val VerticalPadding = 14.dp
     val HorizontalPadding = 20.dp
     val CornerRadius = 5.dp
 }
 
 @Composable
-fun CommonBottomButton(
+fun KakaoLoginButton(
     text: String,
     onClick: () -> Unit,
-    enabled: Boolean = true,
 ) {
     Button(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
         colors =
             ButtonDefaults.buttonColors(
-                containerColor = MainThemeColor.Black,
-                contentColor = MainThemeColor.White,
-                disabledContainerColor = MainThemeColor.Gray3,
-                disabledContentColor = MainThemeColor.Gray2,
+                containerColor = MainThemeColor.Yellow,
+                contentColor = MainThemeColor.Black,
             ),
-        shape = RoundedCornerShape(CommonBottomButtonDefaults.CornerRadius),
+        shape = RoundedCornerShape(KakaoLoginButtonDefaults.CornerRadius),
         contentPadding =
             PaddingValues(
-                vertical = CommonBottomButtonDefaults.VerticalPadding,
-                horizontal = CommonBottomButtonDefaults.HorizontalPadding,
+                vertical = KakaoLoginButtonDefaults.VerticalPadding,
+                horizontal = KakaoLoginButtonDefaults.HorizontalPadding,
             ),
-        enabled = enabled,
     ) {
         Text(
             text = text,
@@ -54,25 +50,11 @@ fun CommonBottomButton(
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-private fun CommonBottomButtonEnabledPreview() {
+private fun KakaoLoginButtonPreview() {
     PicplzTheme {
-        CommonBottomButton(
-            text = "다음",
+        KakaoLoginButton(
+            text = "카카오로 계속하기",
             onClick = {},
-            enabled = true,
-        )
-    }
-}
-
-@Suppress("UnusedPrivateMember")
-@Preview(showBackground = true)
-@Composable
-private fun CommonBottomButtonDisabledPreview() {
-    PicplzTheme {
-        CommonBottomButton(
-            text = "다음",
-            onClick = {},
-            enabled = false,
         )
     }
 }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/KakaoLoginButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/KakaoLoginButton.kt
@@ -24,10 +24,11 @@ private object KakaoLoginButtonDefaults {
 fun KakaoLoginButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Button(
         onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = MainThemeColor.Yellow,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginIntroScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginIntroScreen.kt
@@ -32,8 +32,8 @@ import androidx.navigation.compose.rememberNavController
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.SignUpIntro
-import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonHorizontalPager
+import com.hm.picplz.ui.screen.common.KakaoLoginButton
 import com.hm.picplz.ui.theme.MainFontFamily
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
@@ -176,21 +176,19 @@ fun LoginIntroPage(
         if (page.isLast) {
             Spacer(modifier = Modifier.height(66.dp))
 
-            CommonBottomButton(
-                text = "카카오로 계속하기",
-                modifier = Modifier.padding(horizontal = 15.dp),
-                contentColor = MainThemeColor.Black,
-                containerColor = MainThemeColor.Yellow,
-                onClick = onLoginClick,
-            )
+            Box(modifier = Modifier.padding(horizontal = 15.dp)) {
+                KakaoLoginButton(
+                    text = "카카오로 계속하기",
+                    onClick = onLoginClick,
+                )
+            }
             Spacer(modifier = Modifier.height(10.dp))
-            CommonBottomButton(
-                text = "카카오 로그아웃",
-                modifier = Modifier.padding(horizontal = 15.dp),
-                contentColor = MainThemeColor.Black,
-                containerColor = MainThemeColor.Yellow,
-                onClick = onLogoutClick,
-            )
+            Box(modifier = Modifier.padding(horizontal = 15.dp)) {
+                KakaoLoginButton(
+                    text = "카카오 로그아웃",
+                    onClick = onLogoutClick,
+                )
+            }
         }
     }
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
@@ -148,7 +148,6 @@ fun SignUpCompletionScreen(
                         // TODO: 뒤로가기에 대한 처리 필요
                         mainNavController.navigate(Main)
                     },
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
@@ -148,7 +148,6 @@ fun SignUpNicknameScreen(
                     text = "다음",
                     onClick = { viewModel.handleIntent(Navigate(SignUpProfile)) },
                     enabled = currentState.nickname.isNotEmpty() && currentState.nicknameFieldErrors.isEmpty(),
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
@@ -123,7 +123,6 @@ fun SignUpNicknameScreen(
                             buildAnnotatedString {
                                 append("∙  한글, 영문, 숫자 입력 가능 (2~15자)\n")
                                 append("∙  중복 닉네임은 불가\n")
-                                append("∙  이모티콘, 특수문자 사용이 불가\n")
                                 append("∙  닉네임의 처음과 마지막 부분 공백 사용 불가")
                             },
                         style =

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
@@ -208,7 +208,6 @@ fun SignUpProfileImageScreen(
                         },
                     onClick = { viewModel.handleIntent(NavigateToSelected) },
                     enabled = currentState.nickname.isNotEmpty(),
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
@@ -147,7 +147,6 @@ fun SignUpSelectTypeScreen(
                     text = "다음",
                     onClick = { viewModel.handleIntent(Navigate(SignUpNickname)) },
                     enabled = currentState.selectedUserType != null,
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
@@ -156,7 +156,6 @@ fun SignUpAddDeviceScreen(
                                     !camera.modelName.isNullOrEmpty()
                             }
                         },
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpCareerPeriodScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpCareerPeriodScreen.kt
@@ -185,7 +185,6 @@ fun SignUpCareerPeriodScreen(
                         viewModel.handleIntent(Navigate(SignUpPhotographyVibe))
                     },
                     enabled = currentState.yearValue != null && currentState.monthValue != null,
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDetailExpScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDetailExpScreen.kt
@@ -142,7 +142,6 @@ fun SignUpDetailExpScreen(
                         viewModel.handleIntent(Navigate(SignUpCareerPeriod))
                     },
                     enabled = currentState.selectedPhotographyExperienceId != null,
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDeviceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDeviceScreen.kt
@@ -177,7 +177,6 @@ fun SignUpDeviceScreen(
                         viewModel.handleIntent(Navigate(SignUpPhotographyVibe))
                     },
                     enabled = currentState.phoneDevices.isNotEmpty() || currentState.cameraDevices.isNotEmpty(),
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpExperienceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpExperienceScreen.kt
@@ -173,7 +173,6 @@ fun SignUpExperienceScreen(
                         }
                     },
                     enabled = currentState.hasPhotographyExperience != null,
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
@@ -308,7 +308,6 @@ fun SignUpMainLocationScreen(
                         viewModel.handleIntent(Navigate(SignUpDevice))
                     },
                     enabled = currentState.selectedAreas.isNotEmpty(),
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpPhotographyVibeScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpPhotographyVibeScreen.kt
@@ -182,7 +182,6 @@ fun SignUpPhotographyVibeScreen(
                         viewModel.handleIntent(NavigateWithSubmit)
                     },
                     enabled = currentState.selectedVibeChipList != listOf<ChipItem>(),
-                    containerColor = MainThemeColor.Black,
                 )
             }
         }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
@@ -73,7 +73,9 @@ fun ChatRoomScreen(
                         ChatRoomIntent.NavigateToPrev,
                     )
                 },
-                showMenuIcon = true,
+                onClickMenu = {
+                    // TODO: Implement menu click action
+                },
             )
         },
         modifier =

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
@@ -46,7 +46,7 @@ import com.hm.picplz.ui.screen.chat_room.composable.bubble.CompleteBubble
 import com.hm.picplz.ui.screen.chat_room.composable.bubble.DealConfirmationBubble
 import com.hm.picplz.ui.screen.chat_room.composable.bubble.ImageChat
 import com.hm.picplz.ui.screen.chat_room.composable.bubble.NotificationBubble
-import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.screen.common.CommonTopBarWithSubtitle
 import com.hm.picplz.ui.theme.MainFontFamily.caption
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
@@ -64,7 +64,7 @@ fun ChatRoomScreen(
     Scaffold(
         containerColor = MainThemeColor.White,
         topBar = {
-            CommonTopBar(
+            CommonTopBarWithSubtitle(
                 text = "유가영 작가",
                 subText = "당장 촬영 가능",
                 subTextStyle = caption.copy(color = MainThemeColor.Green120),

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/DeviceModalBottomSheet.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/DeviceModalBottomSheet.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonModalBottomSheet
-import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -168,19 +167,18 @@ private fun Footer(
                 .padding(bottom = 45.dp, top = 30.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        CommonBottomButton(
-            text = "초기화",
-            onClick = onReset,
-            modifier = Modifier.weight(1f),
-            contentColor = MainThemeColor.Black,
-            borderColor = MainThemeColor.Gray3,
-            containerColor = MainThemeColor.White,
-        )
-        CommonBottomButton(
-            text = "{}명 작가보기",
-            onClick = onSubmit,
-            modifier = Modifier.weight(2f),
-        )
+        Box(modifier = Modifier.weight(1f)) {
+            CommonBottomButton(
+                text = "초기화",
+                onClick = onReset,
+            )
+        }
+        Box(modifier = Modifier.weight(2f)) {
+            CommonBottomButton(
+                text = "{}명 작가보기",
+                onClick = onSubmit,
+            )
+        }
     }
 }
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/MoodKeywordModalBottomSheet.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/MoodKeywordModalBottomSheet.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonModalBottomSheet
-import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -133,19 +132,18 @@ private fun Footer(
                 .padding(bottom = 45.dp, top = 30.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        CommonBottomButton(
-            text = "초기화",
-            onClick = onReset,
-            modifier = Modifier.weight(1f),
-            contentColor = MainThemeColor.Black,
-            borderColor = MainThemeColor.Gray3,
-            containerColor = MainThemeColor.White,
-        )
-        CommonBottomButton(
-            text = "{}명 작가보기",
-            onClick = onSubmit,
-            modifier = Modifier.weight(2f),
-        )
+        Box(modifier = Modifier.weight(1f)) {
+            CommonBottomButton(
+                text = "초기화",
+                onClick = onReset,
+            )
+        }
+        Box(modifier = Modifier.weight(2f)) {
+            CommonBottomButton(
+                text = "{}명 작가보기",
+                onClick = onSubmit,
+            )
+        }
     }
 }
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionModalBottomSheet.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionModalBottomSheet.kt
@@ -307,18 +307,17 @@ private fun Footer(
                 .padding(bottom = 45.dp, top = 30.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        CommonBottomButton(
-            text = "초기화",
-            onClick = onReset,
-            modifier = Modifier.weight(1f),
-            contentColor = MainThemeColor.Black,
-            borderColor = MainThemeColor.Gray3,
-            containerColor = MainThemeColor.White,
-        )
-        CommonBottomButton(
-            text = "{}명 작가보기",
-            onClick = onSubmit,
-            modifier = Modifier.weight(2f),
-        )
+        Box(modifier = Modifier.weight(1f)) {
+            CommonBottomButton(
+                text = "초기화",
+                onClick = onReset,
+            )
+        }
+        Box(modifier = Modifier.weight(2f)) {
+            CommonBottomButton(
+                text = "{}명 작가보기",
+                onClick = onSubmit,
+            )
+        }
     }
 }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainScreen.kt
@@ -224,7 +224,6 @@ fun PhotographerMainScreen(
                     onClick = {
                         viewModel.handleIntent(PhotographerMainIntent.SetIsModalOpen(true))
                     },
-                    containerColor = if (currentState.isActive) MainThemeColor.Green120 else MainThemeColor.Black,
                 )
 
                 if (currentState.isModalOpen) {

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageModifyProfileScreen.kt
@@ -60,7 +60,6 @@ fun MyPageModifyProfileScreen(
                 CommonBottomButton(
                     text = "완료",
                     onClick = { },
-                    containerColor = MainThemeColor.Black,
                 )
             }
         },

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MypageOrderSheetScreen.kt.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MypageOrderSheetScreen.kt.kt
@@ -313,11 +313,7 @@ fun MyPageOrderSheetScreen(
 
                 CommonBottomButton(
                     text = "영수증 조회",
-                    onClick = { /*TODO*/ },
-                    contentColor = MainThemeColor.Black,
-                    containerColor = MainThemeColor.White,
-                    borderColor = MainThemeColor.Gray3,
-                    modifier = Modifier.height(42.dp),
+                    onClick = { },
                 )
 
                 Spacer(modifier = Modifier.height(30.dp))

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
@@ -202,11 +202,7 @@ fun ShootingHistoryCard(
                     Spacer(modifier = Modifier.height(23.dp))
                     CommonBottomButton(
                         text = if (status === ShootingStatus.COMPLEETED) "리뷰 쓰러가기" else "다시 예약하기",
-                        onClick = { /*TODO*/ },
-                        containerColor = MainThemeColor.White,
-                        contentColor = MainThemeColor.Black,
-                        borderColor = MainThemeColor.Gray3,
-                        modifier = Modifier.height(49.dp),
+                        onClick = { },
                     )
                 }
             }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
@@ -46,7 +46,6 @@ fun DetailPhotographerScreen(
                 CommonBottomButton(
                     text = "예약하기",
                     onClick = { },
-                    containerColor = MainThemeColor.Black,
                 )
             }
         },


### PR DESCRIPTION
## Summary

closes #90

공통 컴포넌트(CommonTopBar, CommonBottomButton)를 피그마 디자인에 맞게 리팩토링하고, props를 최소화하여 일관된 UI를 보장합니다.

## Changes

### CommonTopBar
- 파일 분리: `CommonTopBar.kt`, `CommonTopBarWithMenu.kt`, `CommonTopBarWithSubtitle.kt`
- Props 최소화: `text`, `onClickBack`만 유지
- 피그마 스타일 적용: 높이 44dp, 패딩 16dp
- Defaults object 패턴 적용 (Material3 컨벤션)

### CommonBottomButton
- Props 최소화: `text`, `onClick`, `enabled`만 유지
- 피그마 스타일 적용: padding 14dp/20dp
- KakaoLoginButton 별도 컴포넌트 분리
- 20+ 파일 사용처 수정

## Props 최소화 원칙

### 공통 컴포넌트의 본질

공통 컴포넌트는 **동일한 UI를 여러 곳에서 재사용**하기 위한 것.
스타일이 유동적이면 공통 컴포넌트의 의미가 없다.

### 받아야 할 것 (도메인 정보)

| 종류 | 예시 | 이유 |
|-----|------|------|
| 도메인 텍스트 | `text: String` | 화면마다 다른 문구 |
| 도메인 동작 | `onClick: () -> Unit` | 화면마다 다른 비즈니스 로직 |
| 도메인 상태 | `enabled: Boolean` | 비즈니스 로직에 따른 활성화 |

### 받으면 안 되는 것 (UI 요소)

| 종류 | 예시 | 이유 |
|-----|------|------|
| 색상 | `containerColor`, `contentColor` | 피그마 기준 고정 |
| 크기/여백 | `height`, `padding`, `modifier` | 피그마 기준 고정 |
| 폰트 스타일 | `textStyle`, `fontSize` | 디자인 시스템 고정 |
| 테두리 | `borderColor`, `borderWidth` | 피그마 기준 고정 |

### 스타일이 다르면 별도 컴포넌트

```
❌ CommonBottomButton(containerColor = KakaoYellow, ...)
✅ KakaoLoginButton(text, onClick)

❌ CommonTopBar(hasMenu = true, menuIcon = ...)
✅ CommonTopBarWithMenu(text, onClickBack, onClickMenu)
```

### 요약

> **공통 컴포넌트 = 도메인 정보만 받고, UI는 피그마대로 고정**

## Documentation

이 원칙은 `core/ui/AGENTS.md`에도 문서화되었습니다.