### PR TITLE
♻️ 회원가입 플로우 UI 기획 개선 반영

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,26 @@ All features must follow this 5-file structure:
 - `Intent`: User actions
 - `SideEffect`: One-off events (Navigation, Toast)
 
+### SideEffect Channel Rule (Boy Scout Rule)
+**일회성 SideEffect는 `Channel` 사용** (SharedFlow 금지)
+
+```kotlin
+// ✅ 권장
+private val _sideEffect = Channel<SideEffect>(Channel.BUFFERED)
+val sideEffect = _sideEffect.receiveAsFlow()
+
+// ❌ 금지 - 여러 화면이 백스택에 있으면 중복 실행됨
+private val _sideEffect = MutableSharedFlow<SideEffect>()
+```
+
+| | SharedFlow | Channel |
+|---|---|---|
+| 소비자 | 모든 collector | 단일 collector |
+| 용도 | 상태 브로드캐스트 | 일회성 이벤트 |
+
+- **적용 시점**: 해당 ViewModel 수정 시 함께 변경 (Boy Scout Rule)
+- **신규 작성 시**: 처음부터 Channel 사용
+
 ### Module Dependencies
 ```
 app → features

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,10 @@
                     android:host="signup"
                     android:pathPrefix="/photographer"
                     android:scheme="picplz" />
+                <data
+                    android:host="signup"
+                    android:pathPrefix="/common"
+                    android:scheme="picplz" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,17 @@
                     android:host="oauth"
                     android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="signup"
+                    android:pathPrefix="/photographer"
+                    android:scheme="picplz" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
@@ -20,11 +20,19 @@ import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerSc
 fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
     composable<Login> { LoginIntroScreen(navController = navController) }
 
-    composable<SignUpIntro> { backStackEntry ->
+    composable<SignUpIntro>(
+        deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "picplz://signup/common/{startAt}"
+                },
+            ),
+    ) { backStackEntry ->
         val args = backStackEntry.toRoute<SignUpIntro>()
         SignUpScreen(
             mainNavController = navController,
             profileImageUri = args.profileImageUri,
+            startAt = args.startAt,
         )
     }
 

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.navigation.graph
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
 import com.hm.picplz.navigation.UserTypeMap
 import com.hm.picplz.navigation.model.Login
@@ -35,11 +36,20 @@ fun NavGraphBuilder.authNavGraph(navController: NavHostController) {
         )
     }
 
-    composable<SignUpPhotographer>(typeMap = UserTypeMap) { backStackEntry ->
+    composable<SignUpPhotographer>(
+        typeMap = UserTypeMap,
+        deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "picplz://signup/photographer/{startAt}"
+                },
+            ),
+    ) { backStackEntry ->
         val args = backStackEntry.toRoute<SignUpPhotographer>()
         SignUpPhotographerScreen(
             mainNavController = navController,
             userInfo = args.userInfo,
+            startAt = args.startAt,
         )
     }
 

--- a/core/common/src/main/kotlin/com/hm/picplz/common/util/StringExtensions.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/util/StringExtensions.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.common.util
+
+fun String.filterWhitespace(): String = this.replace(" ", "")

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/NavTypes.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/NavTypes.kt
@@ -34,4 +34,37 @@ val UserNavType =
         }
     }
 
-val UserTypeMap = mapOf(typeOf<User>() to UserNavType)
+val NullableUserNavType =
+    object : NavType<User?>(isNullableAllowed = true) {
+        override fun get(
+            bundle: Bundle,
+            key: String,
+        ): User? {
+            return bundle.getString(key)?.let {
+                if (it == "null") null else Json.decodeFromString(it)
+            }
+        }
+
+        override fun parseValue(value: String): User? {
+            if (value == "null") return null
+            return Json.decodeFromString(Uri.decode(value))
+        }
+
+        override fun serializeAsValue(value: User?): String {
+            return value?.let { Uri.encode(Json.encodeToString(it)) } ?: "null"
+        }
+
+        override fun put(
+            bundle: Bundle,
+            key: String,
+            value: User?,
+        ) {
+            bundle.putString(key, value?.let { Json.encodeToString(it) } ?: "null")
+        }
+    }
+
+val UserTypeMap =
+    mapOf(
+        typeOf<User>() to UserNavType,
+        typeOf<User?>() to NullableUserNavType,
+    )

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -16,7 +16,10 @@ sealed interface NavigationRoute
 @Serializable object Login : NavigationRoute
 
 @Serializable
-data class SignUpIntro(val profileImageUri: String? = null) : NavigationRoute
+data class SignUpIntro(
+    val profileImageUri: String? = null,
+    val startAt: String? = null,
+) : NavigationRoute
 
 @Serializable
 data class SignUpClient(val userInfo: User) : NavigationRoute

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -22,7 +22,10 @@ data class SignUpIntro(val profileImageUri: String? = null) : NavigationRoute
 data class SignUpClient(val userInfo: User) : NavigationRoute
 
 @Serializable
-data class SignUpPhotographer(val userInfo: User) : NavigationRoute
+data class SignUpPhotographer(
+    val userInfo: User? = null,
+    val startAt: String? = null,
+) : NavigationRoute
 
 @Serializable
 data class SignUpCompletion(val userInfo: User) : NavigationRoute

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/AreaTag.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/AreaTag.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,7 +31,6 @@ fun AreaTag(
     Row(
         modifier =
             modifier
-                .height(28.dp)
                 .background(
                     color = MainThemeColor.White,
                     shape = RoundedCornerShape(5.dp),
@@ -42,7 +40,7 @@ fun AreaTag(
                     color = MainThemeColor.Black,
                     shape = RoundedCornerShape(5.dp),
                 )
-                .padding(horizontal = 11.dp),
+                .padding(horizontal = 12.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonAddButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonAddButton.kt
@@ -1,8 +1,8 @@
 package com.hm.picplz.ui.screen.common
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -22,10 +22,7 @@ fun CommonAddButton(
     onClick: () -> Unit,
 ) {
     Button(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .height(42.dp),
+        modifier = modifier.fillMaxWidth(),
         onClick = onClick,
         shape = RoundedCornerShape(5.dp),
         colors =
@@ -38,6 +35,7 @@ fun CommonAddButton(
                 width = 1.dp,
                 color = MainThemeColor.Gray3,
             ),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 11.dp),
     ) {
         Text(
             text = text,

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSearchField.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSearchField.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
@@ -39,6 +40,7 @@ fun CommonSearchField(
     enabled: Boolean = true,
     imeAction: ImeAction = ImeAction.Search,
     keyboardActions: (() -> Unit)? = null,
+    onFocusChanged: ((Boolean) -> Unit)? = null,
 ) {
     Box(
         modifier =
@@ -60,7 +62,10 @@ fun CommonSearchField(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .padding(end = 8.dp),
+                        .padding(end = 8.dp)
+                        .onFocusChanged { focusState ->
+                            onFocusChanged?.invoke(focusState.isFocused)
+                        },
                 enabled = enabled,
                 textStyle =
                     MaterialTheme.typography.bodyLarge.copy(

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonToast.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonToast.kt
@@ -9,113 +9,76 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.theme.MainThemeColor
-import com.hm.picplz.ui.theme.pretendardTypography
+import com.hm.picplz.ui.theme.MainThemeFont
 import kotlinx.coroutines.delay
 
-enum class ToastPosition {
-    TOP,
-    CENTER,
-    BOTTOM,
+private object CommonToastDefaults {
+    val Height = 45.dp
+    val HorizontalPadding = 15.dp
+    val ContentPadding = 16.dp
+    val CornerRadius = 50.dp
+    val BottomOffset = 50.dp
+    const val BACKGROUND_ALPHA = 0.6f
+    const val DURATION_MS = 2000L
 }
 
 @Composable
 fun CommonToast(
-    modifier: Modifier = Modifier,
     message: String,
     isVisible: Boolean,
     onDismiss: () -> Unit,
-    position: ToastPosition = ToastPosition.BOTTOM,
-    offset: Dp = 26.dp,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Center,
 ) {
-    var showToast by remember(isVisible) { mutableStateOf(isVisible) }
-
     LaunchedEffect(isVisible) {
         if (isVisible) {
-            showToast = true
-            delay(2000)
-            showToast = false
-            delay(300)
+            delay(CommonToastDefaults.DURATION_MS)
             onDismiss()
         }
     }
 
-    val alignment =
-        when (position) {
-            ToastPosition.TOP -> Alignment.TopCenter
-            ToastPosition.CENTER -> Alignment.Center
-            ToastPosition.BOTTOM -> Alignment.BottomCenter
-        }
-
-    val (slideIn, slideOut) =
-        when (position) {
-            ToastPosition.TOP ->
-                Pair(
-                    slideInVertically { -it },
-                    slideOutVertically { -it },
-                )
-            ToastPosition.CENTER ->
-                Pair(
-                    slideInVertically { it / 2 },
-                    slideOutVertically { it / 2 },
-                )
-            ToastPosition.BOTTOM ->
-                Pair(
-                    slideInVertically { it },
-                    slideOutVertically { it },
-                )
-        }
-
     AnimatedVisibility(
-        visible = showToast,
-        enter = slideIn + fadeIn(),
-        exit = slideOut + fadeOut(),
+        visible = isVisible,
+        enter = slideInVertically { it } + fadeIn(),
+        exit = slideOutVertically { it } + fadeOut(),
     ) {
         Box(
             modifier =
                 modifier
                     .fillMaxSize()
-                    .padding(horizontal = 17.dp)
-                    .then(
-                        when (position) {
-                            ToastPosition.BOTTOM -> Modifier.padding(bottom = offset)
-                            ToastPosition.TOP -> Modifier.padding(top = offset)
-                            ToastPosition.CENTER -> Modifier
-                        },
-                    ),
-            contentAlignment = alignment,
+                    .padding(horizontal = CommonToastDefaults.HorizontalPadding)
+                    .padding(bottom = CommonToastDefaults.BottomOffset),
+            contentAlignment = Alignment.BottomCenter,
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
+                        .height(CommonToastDefaults.Height)
                         .background(
-                            color = Color.Black.copy(alpha = 0.8f),
-                            shape = RoundedCornerShape(50.dp),
+                            color = MainThemeColor.Black.copy(alpha = CommonToastDefaults.BACKGROUND_ALPHA),
+                            shape = RoundedCornerShape(CommonToastDefaults.CornerRadius),
                         )
-                        .padding(horizontal = 24.dp, vertical = 12.dp),
+                        .padding(horizontal = CommonToastDefaults.ContentPadding),
+                contentAlignment =
+                    if (textAlign == TextAlign.Start) Alignment.CenterStart else Alignment.Center,
             ) {
                 Text(
                     text = message,
-                    modifier = Modifier.fillMaxWidth(),
-                    style = pretendardTypography.bodyMedium,
+                    style = MainThemeFont.Body,
                     color = MainThemeColor.White,
-                    textAlign = TextAlign.Center,
+                    textAlign = textAlign,
                 )
             }
         }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonTopBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -24,7 +23,6 @@ import com.hm.picplz.ui.theme.pretendardTypography
 
 private object CommonTopBarDefaults {
     val Height = 44.dp
-    val HorizontalPadding = 16.dp
     val IconSize = 18.dp
 }
 
@@ -38,8 +36,7 @@ fun CommonTopBar(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(CommonTopBarDefaults.Height)
-                .padding(horizontal = CommonTopBarDefaults.HorizontalPadding),
+                .height(CommonTopBarDefaults.Height),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/common_chip/CommonChip.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/common_chip/CommonChip.kt
@@ -2,15 +2,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -141,10 +137,10 @@ fun CommonChip(
         }
     }
 
-    val chipHeight =
+    val chipVerticalPadding =
         when (height ?: ChipHeight.MEDIUM) {
-            ChipHeight.MEDIUM -> 30.dp
-            ChipHeight.BIG -> 40.dp
+            ChipHeight.MEDIUM -> 6.dp
+            ChipHeight.BIG -> 10.dp
         }
 
     when (currentState.chipMode) {
@@ -155,7 +151,6 @@ fun CommonChip(
                         .clickable {
                             onClickDefaultMode()
                         }
-                        .height(chipHeight)
                         .background(
                             color = backgroundColor,
                             shape = RoundedCornerShape(5.dp),
@@ -165,13 +160,12 @@ fun CommonChip(
                             color = if (isSelected) selectedBorderColor else unselectedBorderColor,
                             shape = RoundedCornerShape(5.dp),
                         )
-                        .widthIn(min = 20.dp),
+                        .padding(horizontal = 12.dp, vertical = chipVerticalPadding),
+                verticalAlignment = CenterVertically,
             ) {
                 Row(
                     modifier =
                         Modifier
-                            .fillMaxHeight()
-                            .padding(horizontal = 12.dp)
                             .onGloballyPositioned { layoutCoordinates ->
                                 val widthInPx = layoutCoordinates.size.width
                                 val widthInDp = with(density) { widthInPx.toDp() }
@@ -209,30 +203,28 @@ fun CommonChip(
                 modifier =
                     Modifier
                         .clickable { onEdit() }
-                        .height(chipHeight)
+                        .background(
+                            color = MainThemeColor.Gray1,
+                            shape = RoundedCornerShape(5.dp),
+                        )
                         .border(
                             width = 1.dp,
                             color = MainThemeColor.Gray3,
                             shape = RoundedCornerShape(5.dp),
                         )
-                        .background(color = MainThemeColor.Gray1),
+                        .padding(horizontal = 12.dp, vertical = chipVerticalPadding),
+                verticalAlignment = CenterVertically,
             ) {
-                Row(
-                    modifier = Modifier.fillMaxHeight(),
-                    verticalAlignment = CenterVertically,
-                ) {
-                    Text(
-                        text = "+직접 적어주세요",
-                        modifier = Modifier.padding(horizontal = 12.dp),
-                        style =
-                            TextStyle(
-                                fontFamily = Pretendard,
-                                fontWeight = FontWeight.Normal,
-                                fontSize = 14.sp,
-                            ),
-                        color = MainThemeColor.Gray3,
-                    )
-                }
+                Text(
+                    text = "+직접 적어주세요",
+                    style =
+                        TextStyle(
+                            fontFamily = Pretendard,
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 14.sp,
+                        ),
+                    color = MainThemeColor.Gray3,
+                )
             }
         }
 
@@ -271,7 +263,7 @@ fun CommonChip(
                         keyboardType = KeyboardType.Text,
                     ),
                 decorationBox = { innerTextField ->
-                    Box(
+                    Row(
                         modifier =
                             Modifier
                                 .border(
@@ -279,16 +271,11 @@ fun CommonChip(
                                     color = if (isSelected) selectedBorderColor else unselectedBorderColor,
                                     shape = RoundedCornerShape(5.dp),
                                 )
-                                .height(chipHeight)
                                 .width(currentState.textFieldWidth + 24.dp)
-                                .padding(horizontal = 12.dp),
+                                .padding(horizontal = 12.dp, vertical = chipVerticalPadding),
+                        verticalAlignment = CenterVertically,
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxHeight(),
-                            verticalAlignment = CenterVertically,
-                        ) {
-                            innerTextField()
-                        }
+                        innerTextField()
                     }
                 },
             )

--- a/feature/auth/src/main/kotlin/com/hm/picplz/navigation/SignUpCommonNavHost.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/navigation/SignUpCommonNavHost.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.hm.picplz.navigation.model.NavigationRoute
 import com.hm.picplz.navigation.model.SignUpNickname
 import com.hm.picplz.navigation.model.SignUpProfile
 import com.hm.picplz.navigation.model.SignUpSelectType
@@ -20,10 +21,19 @@ fun SignUpCommonNavHost(
     signUpCommonNavController: NavHostController,
     modifier: Modifier = Modifier,
     viewModel: SignUpCommonViewModel = viewModel(),
+    startAt: String? = null,
 ) {
+    val startDestination: NavigationRoute =
+        when (startAt) {
+            "select-type" -> SignUpSelectType
+            "nickname" -> SignUpNickname
+            "profile" -> SignUpProfile
+            else -> SignUpSelectType
+        }
+
     NavHost(
         navController = signUpCommonNavController,
-        startDestination = SignUpSelectType,
+        startDestination = startDestination,
         modifier = modifier,
     ) {
         composable<SignUpNickname> {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/navigation/SignUpPhothgrapherNavHost.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/navigation/SignUpPhothgrapherNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.hm.picplz.domain.model.DeviceCategory
+import com.hm.picplz.navigation.model.NavigationRoute
 import com.hm.picplz.navigation.model.SignUpAddDevice
 import com.hm.picplz.navigation.model.SignUpCareerPeriod
 import com.hm.picplz.navigation.model.SignUpDetailExperience
@@ -30,15 +31,25 @@ fun SignUpPhotographerNavHost(
     signUpPhotographerNavController: NavHostController,
     modifier: Modifier = Modifier,
     viewModel: SignUpPhotographerViewModel = viewModel(),
+    startAt: String? = null,
 ) {
+    val startDestination: NavigationRoute =
+        when (startAt) {
+            "device" -> SignUpDevice
+            "vibe" -> SignUpPhotographyVibe
+            "career" -> SignUpCareerPeriod
+            "experience" -> SignUpExperience
+            "detail-experience" -> SignUpDetailExperience
+            else -> SignUpMainLocation
+        }
+
     NavHost(
         navController = signUpPhotographerNavController,
-        startDestination = SignUpMainLocation,
+        startDestination = startDestination,
         modifier = modifier,
     ) {
         composable<SignUpExperience> {
             SignUpExperienceScreen(
-                modifier = modifier,
                 mainNavController = mainNavController,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 viewModel = viewModel,
@@ -46,14 +57,12 @@ fun SignUpPhotographerNavHost(
         }
         composable<SignUpDetailExperience> {
             SignUpDetailExpScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 viewModel = viewModel,
             )
         }
         composable<SignUpPhotographyVibe> {
             SignUpPhotographyVibeScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 mainNavController = mainNavController,
                 viewModel = viewModel,
@@ -61,14 +70,12 @@ fun SignUpPhotographerNavHost(
         }
         composable<SignUpCareerPeriod> {
             SignUpCareerPeriodScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 viewModel = viewModel,
             )
         }
         composable<SignUpMainLocation> {
             SignUpMainLocationScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 mainNavController = mainNavController,
                 viewModel = viewModel,
@@ -76,7 +83,6 @@ fun SignUpPhotographerNavHost(
         }
         composable<SignUpDevice> {
             SignUpDeviceScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 viewModel = viewModel,
             )
@@ -90,7 +96,6 @@ fun SignUpPhotographerNavHost(
                     else -> DeviceCategory.PHONE
                 }
             SignUpAddDeviceScreen(
-                modifier = modifier,
                 signUpPhotographerNavController = signUpPhotographerNavController,
                 viewModel = viewModel,
                 category = category,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonScreen.kt
@@ -14,6 +14,7 @@ fun SignUpScreen(
     viewModel: SignUpCommonViewModel = viewModel(),
     mainNavController: NavHostController,
     profileImageUri: String? = null,
+    startAt: String? = null,
 ) {
     val signUpCommonNavController = rememberNavController()
 
@@ -28,5 +29,6 @@ fun SignUpScreen(
         signUpCommonNavController = signUpCommonNavController,
         viewModel = viewModel,
         modifier = modifier,
+        startAt = startAt,
     )
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/validator/NicknameValidator.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/validator/NicknameValidator.kt
@@ -7,19 +7,18 @@ object NicknameValidator {
         val errors = mutableListOf<NicknameFieldError>()
         if (newNickname.isEmpty()) {
             errors.add(NicknameFieldError.Required())
+            return errors
         }
-        if (newNickname.length < 2 || newNickname.length > 15) {
-            errors.add(NicknameFieldError.Length())
-        }
-        if (!newNickname.matches(Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s]+$"))) {
+        // 우선순위: 형식 > 길이 > 중복
+        if (!newNickname.matches(Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$"))) {
             errors.add(NicknameFieldError.InvalidChar())
+            return errors
         }
-        if (newNickname.contains(Regex("[\\p{So}\\p{Cn}\\p{Sk}\\p{Sc}\\p{Sm}]"))) {
-            errors.add(NicknameFieldError.InvalidSpecialCharacter())
+        if (newNickname.length !in 2..15) {
+            errors.add(NicknameFieldError.Length())
+            return errors
         }
-        if (newNickname.startsWith(" ") || newNickname.endsWith(" ")) {
-            errors.add(NicknameFieldError.Whitespace())
-        }
+        // 중복 검사는 서버에서 처리
         return errors
     }
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,7 +32,6 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
 import com.hm.picplz.common.mockdata.emptyUserData
 import com.hm.picplz.common.model.User
-import com.hm.picplz.common.model.UserType
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.ui.screen.common.CommonBottomButton
@@ -88,11 +86,7 @@ fun SignUpCompletionScreen(
                             painterResource(id = R.drawable.default_profile_large)
                         }
                     Text(
-                        text =
-                            buildAnnotatedString {
-                                append("안녕하세요 ")
-                                append("${userInfo.nickname}님!")
-                            },
+                        text = "안녕하세요 ${userInfo.nickname}님!",
                         style = MaterialTheme.typography.titleLarge,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth(),
@@ -118,15 +112,7 @@ fun SignUpCompletionScreen(
                                 .height(74.dp),
                     )
                     Text(
-                        text =
-                            buildAnnotatedString {
-                                append("가입을 축하드려요.\n")
-                                when (userInfo.userType) {
-                                    UserType.Photographer -> append("함께 사진 촬영하러 가볼까요?")
-                                    UserType.User -> append("인생샷 건지러 가볼까요")
-                                    null -> append("인생샷 건지러 가볼까요")
-                                }
-                            },
+                        text = "가입을 축하드려요.\n함께 사진 촬영하러 가볼까요?",
                         style = MaterialTheme.typography.titleLarge,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth(),

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpNicknameScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,16 +19,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.hm.picplz.common.util.filterWhitespace
 import com.hm.picplz.navigation.model.SignUpProfile
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonFilledTextField
@@ -39,6 +35,7 @@ import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.Navigat
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonViewModel
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpSideEffect
 import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.util.SetStatusBarStyle
 import kotlinx.coroutines.flow.collectLatest
@@ -76,10 +73,10 @@ fun SignUpNicknameScreen(
                 text = "닉네임 설정하기",
                 onClickBack = { viewModel.handleIntent(SignUpCommonIntent.NavigateToPrev) },
             )
-            Box(
+            Spacer(modifier = Modifier.height(144.dp))
+            Column(
                 modifier =
                     Modifier
-                        .weight(1f)
                         .fillMaxWidth()
                         .padding(horizontal = 15.dp)
                         .pointerInput(Unit) {
@@ -87,55 +84,34 @@ fun SignUpNicknameScreen(
                                 focusManager.clearFocus()
                             })
                         },
-                contentAlignment = Alignment.Center,
+                horizontalAlignment = Alignment.Start,
             ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxSize(),
-                    horizontalAlignment = Alignment.Start,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        text = "닉네임을 설정해주세요",
-                        modifier = Modifier,
-                        style = MaterialTheme.typography.headlineMedium,
-                    )
-                    Spacer(modifier = modifier.height(14.dp))
-                    CommonFilledTextField(
-                        value = currentState.nickname,
-                        onValueChange = { newNickname ->
-                            viewModel.handleIntent(SignUpCommonIntent.SetNickname(newNickname))
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        placeholder = "닉네임 입력",
-                        errors = currentState.nicknameFieldErrors,
-                        imeAction = ImeAction.Done,
-                        keyboardActions = {
-                            focusManager.clearFocus()
-                        },
-                    )
-                    Text(
-                        modifier =
-                            Modifier
-                                .padding(top = 5.dp),
-                        text =
-                            buildAnnotatedString {
-                                append("∙  한글, 영문, 숫자 입력 가능 (2~15자)\n")
-                                append("∙  중복 닉네임은 불가\n")
-                                append("∙  닉네임의 처음과 마지막 부분 공백 사용 불가")
-                            },
-                        style =
-                            TextStyle(
-                                fontWeight = FontWeight.Normal,
-                                fontSize = 12.sp,
-                                lineHeight = 16.8.sp,
-                                letterSpacing = 0.sp,
-                                color = MainThemeColor.Gray3,
-                            ),
-                    )
-                }
+                Text(
+                    text = "닉네임을 설정해주세요",
+                    style = MainThemeFont.Title,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                CommonFilledTextField(
+                    value = currentState.nickname,
+                    onValueChange = { newNickname ->
+                        viewModel.handleIntent(SignUpCommonIntent.SetNickname(newNickname.filterWhitespace()))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = "닉네임 입력",
+                    errors = currentState.nicknameFieldErrors,
+                    imeAction = ImeAction.Done,
+                    keyboardActions = {
+                        focusManager.clearFocus()
+                    },
+                )
+                Text(
+                    modifier = Modifier.padding(vertical = 4.dp),
+                    text = "∙  한글, 영문, 숫자 입력 가능 (2~15자)\n∙  중복 닉네임은 불가",
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Gray3,
+                )
             }
+            Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier =
                     Modifier

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -154,41 +153,22 @@ fun SignUpProfileImageScreen(
                             )
                         }
                     }
-                    Spacer(
-                        modifier =
-                            Modifier
-                                .height(80.dp),
-                    )
-                    Text(
-                        text =
-                            if (currentState.profileImageUri === null) {
-                                buildAnnotatedString {
-                                    append("프로필 이미지를\n")
-                                    append("설정해 주세요.")
-                                }
-                            } else {
-                                when (currentState.selectedUserType) {
-                                    UserType.User ->
-                                        buildAnnotatedString {
-                                            append("프로필 이미지 설정이\n")
-                                            append("완료되었습니다.")
-                                        }
-                                    UserType.Photographer ->
-                                        buildAnnotatedString {
-                                            append("이제 주 촬영지와 촬영 기기를\n")
-                                            append("입력해볼까요?")
-                                        }
-                                    else ->
-                                        buildAnnotatedString {
-                                            append("다음 단계로\n")
-                                            append("넘어갈게요.")
-                                        }
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    Spacer(modifier = Modifier.height(70.dp))
+                    val guideText =
+                        when {
+                            currentState.profileImageUri == null -> "프로필 이미지를\n설정해 주세요."
+                            currentState.selectedUserType == UserType.Photographer ->
+                                "이제 촬영지와 촬영 기기를\n선택할 거예요"
+                            else -> null
+                        }
+                    if (guideText != null) {
+                        Text(
+                            text = guideText,
+                            style = MaterialTheme.typography.titleMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             }
             Box(

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpSelectTypeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -88,22 +87,12 @@ fun SignUpSelectTypeScreen(
                     verticalArrangement = Arrangement.Center,
                 ) {
                     Text(
-                        text =
-                            buildAnnotatedString {
-                                append("가입하실 회원 타입을\n")
-                                append("선택해주세요.")
-                            },
-                        modifier =
-                            Modifier
-                                .fillMaxWidth(),
+                        text = "가입하실 회원 타입을\n선택해주세요.",
+                        modifier = Modifier.fillMaxWidth(),
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.Center,
                     )
-                    Spacer(
-                        modifier =
-                            Modifier
-                                .height(30.dp),
-                    )
+                    Spacer(modifier = Modifier.height(38.dp))
                     Row(
                         modifier =
                             Modifier

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerScreen.kt
@@ -15,16 +15,18 @@ fun SignUpPhotographerScreen(
     modifier: Modifier = Modifier,
     viewModel: SignUpPhotographerViewModel = hiltViewModel(),
     mainNavController: NavHostController,
-    userInfo: User = emptyUserData,
+    userInfo: User? = null,
+    startAt: String? = null,
 ) {
     val signUpPhotographerNavController = rememberNavController()
 
-    viewModel.handleIntent(SignUpPhotographerIntent.SetUserInfo(userInfo))
+    viewModel.handleIntent(SignUpPhotographerIntent.SetUserInfo(userInfo ?: emptyUserData))
 
     SignUpPhotographerNavHost(
         mainNavController = mainNavController,
         signUpPhotographerNavController = signUpPhotographerNavController,
         viewModel = viewModel,
         modifier = modifier,
+        startAt = startAt,
     )
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
@@ -64,11 +64,17 @@ data class SignUpPhotographerState(
 
         private fun defaultVibeChipList(): List<ChipItem> {
             return listOf(
-                ChipItem(id = "1", label = "MZ 감성"),
-                ChipItem(id = "2", label = "을지로 감성"),
-                ChipItem(id = "3", label = "키치 감성"),
-                ChipItem(id = "4", label = "퇴폐 감성"),
-                ChipItem(id = "5", label = "올드머니 감성"),
+                ChipItem(id = "1", label = "캐주얼"),
+                ChipItem(id = "2", label = "고급미"),
+                ChipItem(id = "3", label = "심플"),
+                ChipItem(id = "4", label = "단아"),
+                ChipItem(id = "5", label = "몽환적"),
+                ChipItem(id = "6", label = "빈티지"),
+                ChipItem(id = "7", label = "청량"),
+                ChipItem(id = "8", label = "화려"),
+                ChipItem(id = "9", label = "퇴폐적"),
+                ChipItem(id = "10", label = "키치"),
+                ChipItem(id = "11", label = "힙스터"),
             )
         }
 

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
@@ -137,6 +137,10 @@ class SignUpPhotographerViewModel
                     handleSearchAreaIntent(intent)
                 }
 
+                is SignUpPhotographerIntent.AddCurrentDeviceToList -> {
+                    handleAddCurrentDeviceToList(intent)
+                }
+
                 else -> {
                     val newState =
                         vibeChipHandler.handleIntent(intent, _state.value)
@@ -145,6 +149,18 @@ class SignUpPhotographerViewModel
                             ?: careerHandler.handleIntent(intent, _state.value)
 
                     newState?.let { _state.value = it }
+                }
+            }
+        }
+
+        private fun handleAddCurrentDeviceToList(intent: SignUpPhotographerIntent.AddCurrentDeviceToList) {
+            val newState = deviceHandler.handleIntent(intent, _state.value)
+            newState?.let { state ->
+                _state.value = state
+                if (!state.showToast) {
+                    viewModelScope.launch {
+                        _sideEffect.send(SignUpPhotographerSideEffect.NavigateToPrev)
+                    }
                 }
             }
         }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
@@ -10,10 +10,10 @@ import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.handler.CareerHandle
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.handler.DeviceHandler
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.handler.VibeChipHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,8 +28,8 @@ class SignUpPhotographerViewModel
         private val _state = MutableStateFlow<SignUpPhotographerState>(SignUpPhotographerState.idle())
         val state: StateFlow<SignUpPhotographerState> get() = _state
 
-        private val _sideEffect = MutableSharedFlow<SignUpPhotographerSideEffect>()
-        val sideEffect: SharedFlow<SignUpPhotographerSideEffect> get() = _sideEffect
+        private val _sideEffect = Channel<SignUpPhotographerSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
 
         private val vibeChipHandler = VibeChipHandler()
         private val areaSearchHandler = AreaSearchHandler()
@@ -102,7 +102,7 @@ class SignUpPhotographerViewModel
             when (intent) {
                 is SignUpPhotographerIntent.NavigateToPrev -> {
                     viewModelScope.launch {
-                        _sideEffect.emit(SignUpPhotographerSideEffect.NavigateToPrev)
+                        _sideEffect.send(SignUpPhotographerSideEffect.NavigateToPrev)
                     }
                 }
 
@@ -120,14 +120,14 @@ class SignUpPhotographerViewModel
 
                 is SignUpPhotographerIntent.Navigate -> {
                     viewModelScope.launch {
-                        _sideEffect.emit(SignUpPhotographerSideEffect.Navigate(intent.destination))
+                        _sideEffect.send(SignUpPhotographerSideEffect.Navigate(intent.destination))
                     }
                 }
 
                 is SignUpPhotographerIntent.NavigateWithSubmit -> {
                     viewModelScope.launch {
                         val user = _state.value.userInfo
-                        _sideEffect.emit(
+                        _sideEffect.send(
                             SignUpPhotographerSideEffect.NavigateToSignUpCompletion(user),
                         )
                     }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/AreaListItem.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/AreaListItem.kt
@@ -40,7 +40,7 @@ fun AreaListItem(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 15.dp),
+                    .padding(vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/AreaListItem.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/AreaListItem.kt
@@ -1,23 +1,17 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer.composable
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.domain.model.Area
-import com.hm.picplz.ui.screen.common.CommonCheckbox
 import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
-import com.hm.picplz.ui.theme.pretendardTypography
 
 @Composable
 fun AreaListItem(
@@ -26,35 +20,16 @@ fun AreaListItem(
     isSelected: Boolean = false,
     onItemClick: (Area) -> Unit,
 ) {
-    Card(
+    Text(
+        text = area.name,
+        style = if (isSelected) MainThemeFont.BodyBold else MainThemeFont.Body,
+        color = MainThemeColor.Black,
         modifier =
             modifier
                 .fillMaxWidth()
-                .clickable { onItemClick(area) },
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MainThemeColor.White,
-            ),
-    ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = area.name,
-                style = pretendardTypography.bodyMedium,
-                color = MainThemeColor.Black,
-            )
-            CommonCheckbox(
-                checked = isSelected,
-                onCheckedChange = { onItemClick(area) },
-            )
-        }
-    }
+                .clickable { onItemClick(area) }
+                .padding(vertical = 16.dp),
+    )
 }
 
 @Preview(showBackground = true)
@@ -76,7 +51,7 @@ fun AreaListItemPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun AreaListItemCheckedPreview() {
+fun AreaListItemSelectedPreview() {
     PicplzTheme {
         AreaListItem(
             area =

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceItem.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceItem.kt
@@ -5,13 +5,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -38,62 +35,47 @@ fun DeviceItem(
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(
+    Row(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(42.dp),
+                .clip(RoundedCornerShape(5.dp))
+                .background(MainThemeColor.Gray1)
+                .border(
+                    width = 1.dp,
+                    color = MainThemeColor.Gray2,
+                    shape = RoundedCornerShape(5.dp),
+                )
+                .padding(horizontal = 15.dp, vertical = 11.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(42.dp)
-                    .clip(RoundedCornerShape(5.dp))
-                    .background(MainThemeColor.Gray1)
-                    .border(
-                        width = 1.dp,
-                        color = MainThemeColor.Gray2,
-                        shape = RoundedCornerShape(5.dp),
-                    )
-                    .padding(horizontal = 10.dp),
-            contentAlignment = Alignment.CenterStart,
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Row(
-                    modifier = Modifier.weight(1f),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = device.companyName,
-                        style = pretendardTypography.bodyMedium,
-                        color = MainThemeColor.Gray4,
-                    )
-                    Spacer(modifier = Modifier.width(14.dp))
-                    Text(
-                        text =
-                            when (device) {
-                                is Device.PhoneDevice -> device.modelName ?: "모델명 없음"
-                                is Device.CameraDevice -> "${device.modelName ?: "모델명 없음"} (${device.cameraType})"
-                            },
-                        style = MainFontFamily.bodyBold,
-                        color = MainThemeColor.Gray5,
-                    )
-                }
-            }
+            Text(
+                text = device.companyName,
+                style = pretendardTypography.bodyMedium,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                text =
+                    when (device) {
+                        is Device.PhoneDevice -> device.modelName ?: "모델명 없음"
+                        is Device.CameraDevice -> "${device.modelName ?: "모델명 없음"} (${device.cameraType})"
+                    },
+                style = MainFontFamily.bodyBold,
+                color = MainThemeColor.Gray5,
+            )
         }
         Image(
             painter = painterResource(id = R.drawable.close_circle),
             contentDescription = "삭제",
             modifier =
                 Modifier
-                    .size(22.dp)
-                    .offset(x = (10).dp, y = (-10).dp)
-                    .align(Alignment.TopEnd)
+                    .size(20.dp)
                     .clickable { onRemove() },
         )
     }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceSelectorBottomSheet.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceSelectorBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer.composable
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,17 +25,34 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
+
+@Composable
+private fun DragHandle() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .width(40.dp)
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(MainThemeColor.Gray3),
+        )
+    }
+}
 
 @Composable
 fun DeviceSelectorContent(
@@ -46,10 +64,9 @@ fun DeviceSelectorContent(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .navigationBarsPadding(),
+                .heightIn(max = 540.dp)
+                .padding(horizontal = 20.dp),
     ) {
-        Spacer(modifier = Modifier.height(20.dp))
         if (onDirectInput != null) {
             OutlinedButton(
                 onClick = onDirectInput,
@@ -78,6 +95,7 @@ fun DeviceSelectorContent(
                     style = pretendardTypography.bodyMedium,
                 )
             }
+            Spacer(modifier = Modifier.height(8.dp))
         }
         LazyColumn(
             modifier = Modifier.fillMaxWidth(),
@@ -105,6 +123,7 @@ fun DeviceSelectorContent(
                 )
             }
         }
+        Spacer(modifier = Modifier.navigationBarsPadding())
     }
 }
 
@@ -125,13 +144,9 @@ fun DeviceSelectorBottomSheet(
         ModalBottomSheet(
             onDismissRequest = onDismiss,
             sheetState = bottomSheetState,
-            containerColor = Color.White,
-            dragHandle = null,
-            modifier =
-                Modifier.heightIn(
-                    min = 200.dp,
-                    max = LocalConfiguration.current.screenHeightDp.dp * 0.867f,
-                ),
+            containerColor = MainThemeColor.White,
+            dragHandle = { DragHandle() },
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
         ) {
             DeviceSelectorContent(
                 options = options,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceSelectorBox.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/composable/DeviceSelectorBox.kt
@@ -1,17 +1,13 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer.composable
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -20,14 +16,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
@@ -72,14 +65,13 @@ fun DeviceSelectorBox(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .height(40.dp)
                             .border(
                                 width = 1.dp,
                                 color =
                                     when {
                                         !enabled -> MainThemeColor.Gray2
                                         inputText.isNotEmpty() -> MainThemeColor.Black
-                                        else -> Color(0xFFB0BCC4)
+                                        else -> MainThemeColor.Gray3
                                     },
                                 RoundedCornerShape(5.dp),
                             )
@@ -87,14 +79,14 @@ fun DeviceSelectorBox(
                                 color = MainThemeColor.Gray1,
                                 RoundedCornerShape(5.dp),
                             )
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = 14.dp, vertical = 11.dp),
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     if (inputText.isEmpty()) {
                         Text(
                             text = placeholder,
                             style = pretendardTypography.bodyMedium,
-                            color = MainThemeColor.Gray,
+                            color = MainThemeColor.Gray3,
                         )
                     }
                     innerTextField()
@@ -106,14 +98,13 @@ fun DeviceSelectorBox(
             modifier =
                 modifier
                     .fillMaxWidth()
-                    .height(40.dp)
                     .border(
                         width = 1.dp,
                         color =
                             when {
                                 !enabled -> MainThemeColor.Gray2
                                 isSelected -> MainThemeColor.Black
-                                else -> Color(0xFFB0BCC4)
+                                else -> MainThemeColor.Gray3
                             },
                         RoundedCornerShape(5.dp),
                     )
@@ -128,31 +119,19 @@ fun DeviceSelectorBox(
                             boxModifier
                         }
                     }
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 14.dp, vertical = 11.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = text ?: placeholder,
-                    style = pretendardTypography.bodyMedium,
-                    color =
-                        when {
-                            !enabled -> MainThemeColor.Gray3
-                            text == null -> MainThemeColor.Gray
-                            else -> MainThemeColor.Black
-                        },
-                )
-                Image(
-                    painter = painterResource(id = R.drawable.triangle_down),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    alpha = if (enabled) 1f else 0.3f,
-                )
-            }
+            Text(
+                text = text ?: placeholder,
+                style = pretendardTypography.bodyMedium,
+                color =
+                    when {
+                        !enabled -> MainThemeColor.Gray3
+                        text == null -> MainThemeColor.Gray3
+                        else -> MainThemeColor.Black
+                    },
+            )
         }
     }
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/AreaSearchHandler.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/AreaSearchHandler.kt
@@ -32,9 +32,9 @@ class AreaSearchHandler {
                 val isAlreadySelected =
                     currentState.selectedAreas.any { it.id == intent.area.id }
 
-                if (!isAlreadySelected && currentState.selectedAreas.size >= 10) {
+                if (!isAlreadySelected && currentState.selectedAreas.size >= 5) {
                     return currentState.copy(
-                        toastMessage = "활동 지역은 최대 10개까지 선택할 수 있습니다.",
+                        toastMessage = "활동 지역은 최대 5개까지 선택할 수 있습니다.",
                         showToast = true,
                     )
                 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/DeviceHandler.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/DeviceHandler.kt
@@ -110,27 +110,49 @@ class DeviceHandler {
                 when (intent.category) {
                     DeviceCategory.PHONE -> {
                         currentState.currentPhone?.let { phone ->
-                            currentState.copy(
-                                phoneDevices = currentState.phoneDevices + phone,
-                                currentPhone = null,
-                                brandExpanded = false,
-                                modelExpanded = false,
-                                phoneBrandDirectInput = false,
-                                phoneModelDirectInput = false,
-                            )
+                            val isDuplicate =
+                                currentState.phoneDevices.any {
+                                    it.companyName == phone.companyName && it.modelName == phone.modelName
+                                }
+                            if (isDuplicate) {
+                                currentState.copy(
+                                    showToast = true,
+                                    toastMessage = "이미 추가된 기기입니다.",
+                                )
+                            } else {
+                                currentState.copy(
+                                    phoneDevices = currentState.phoneDevices + phone,
+                                    currentPhone = null,
+                                    brandExpanded = false,
+                                    modelExpanded = false,
+                                    phoneBrandDirectInput = false,
+                                    phoneModelDirectInput = false,
+                                )
+                            }
                         } ?: currentState
                     }
 
                     DeviceCategory.CAMERA -> {
                         currentState.currentCamera?.let { camera ->
-                            currentState.copy(
-                                cameraDevices = currentState.cameraDevices + camera,
-                                currentCamera = null,
-                                brandExpanded = false,
-                                modelExpanded = false,
-                                cameraTypeExpanded = false,
-                                cameraBrandDirectInput = false,
-                            )
+                            val isDuplicate =
+                                currentState.cameraDevices.any {
+                                    it.companyName == camera.companyName && it.modelName == camera.modelName
+                                }
+                            if (isDuplicate) {
+                                currentState.copy(
+                                    showToast = true,
+                                    toastMessage = "이미 추가된 기기입니다.",
+                                )
+                            } else {
+                                currentState.copy(
+                                    cameraDevices = currentState.cameraDevices + camera,
+                                    currentCamera = null,
+                                    brandExpanded = false,
+                                    modelExpanded = false,
+                                    cameraTypeExpanded = false,
+                                    cameraBrandDirectInput = false,
+                                )
+                            }
                         } ?: currentState
                     }
                 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
@@ -55,6 +55,7 @@ import com.hm.picplz.ui.theme.pretendardTypography
 import kotlinx.coroutines.flow.collectLatest
 import java.util.UUID
 
+// TODO: #99 직접입력 버튼 플로우 개선 - Input 전환 시 자동 포커스 구현
 @Composable
 fun SignUpAddDeviceScreen(
     modifier: Modifier = Modifier,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpAddDeviceScreen.kt
@@ -30,8 +30,10 @@ import com.hm.picplz.data.model.DeviceData
 import com.hm.picplz.domain.model.Device
 import com.hm.picplz.domain.model.DeviceCategory
 import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.AddCurrentDeviceToList
+import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.DismissToast
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.NavigateToPrev
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.ResetCurrentDevice
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.SetBrandExpanded
@@ -138,7 +140,6 @@ fun SignUpAddDeviceScreen(
                     text = "추가하기",
                     onClick = {
                         viewModel.handleIntent(AddCurrentDeviceToList(category))
-                        viewModel.handleIntent(NavigateToPrev)
                     },
                     enabled =
                         when (category) {
@@ -277,6 +278,16 @@ fun SignUpAddDeviceScreen(
         },
         visible = currentState.modelExpanded,
     )
+
+    currentState.toastMessage?.let { message ->
+        CommonToast(
+            message = message,
+            isVisible = currentState.showToast,
+            onDismiss = {
+                viewModel.handleIntent(DismissToast)
+            },
+        )
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collectLatest { sideEffect ->

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDeviceScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpDeviceScreen.kt
@@ -80,7 +80,7 @@ fun SignUpDeviceScreen(
                             .padding(top = 16.dp),
                 ) {
                     Text(
-                        text = "활용 기기를 선택해 주세요.",
+                        text = "촬영 기기를 선택해 주세요.",
                         style = pretendardTypography.titleMedium,
                     )
                     Spacer(modifier = Modifier.height(30.dp))
@@ -88,32 +88,26 @@ fun SignUpDeviceScreen(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .height(220.dp),
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(40.dp),
                     ) {
-                        Text(
-                            text = "내 핸드폰",
-                            style = pretendardTypography.titleSmall,
-                        )
                         Column(
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .verticalScroll(rememberScrollState())
-                                    .padding(top = 10.dp, end = 10.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(10.dp),
                         ) {
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(17.dp),
-                            ) {
-                                currentState.phoneDevices.forEach { device ->
-                                    DeviceItem(
-                                        device = device,
-                                        onRemove = {
-                                            viewModel.handleIntent(RemoveDeviceFromCategory(device))
-                                        },
-                                    )
-                                }
+                            Text(
+                                text = "내 핸드폰",
+                                style = pretendardTypography.titleSmall,
+                            )
+                            currentState.phoneDevices.forEach { device ->
+                                DeviceItem(
+                                    device = device,
+                                    onRemove = {
+                                        viewModel.handleIntent(RemoveDeviceFromCategory(device))
+                                    },
+                                )
                             }
-                            Spacer(modifier = Modifier.height(10.dp))
                             CommonAddButton(
                                 text = "추가하기 +",
                                 onClick = {
@@ -121,38 +115,22 @@ fun SignUpDeviceScreen(
                                 },
                             )
                         }
-                    }
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Column(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(220.dp),
-                    ) {
-                        Text(
-                            text = "내 카메라",
-                            style = pretendardTypography.titleSmall,
-                        )
                         Column(
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .verticalScroll(rememberScrollState())
-                                    .padding(top = 10.dp, end = 10.dp),
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(10.dp),
                         ) {
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(17.dp),
-                            ) {
-                                currentState.cameraDevices.forEach { device ->
-                                    DeviceItem(
-                                        device = device,
-                                        onRemove = {
-                                            viewModel.handleIntent(RemoveDeviceFromCategory(device))
-                                        },
-                                    )
-                                }
+                            Text(
+                                text = "내 카메라",
+                                style = pretendardTypography.titleSmall,
+                            )
+                            currentState.cameraDevices.forEach { device ->
+                                DeviceItem(
+                                    device = device,
+                                    onRemove = {
+                                        viewModel.handleIntent(RemoveDeviceFromCategory(device))
+                                    },
+                                )
                             }
-                            Spacer(modifier = Modifier.height(10.dp))
                             CommonAddButton(
                                 text = "추가하기 +",
                                 onClick = {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
@@ -240,7 +240,7 @@ fun SignUpMainLocationScreen(
                                         )
                                         if (index < currentState.searchResults.size - 1) {
                                             HorizontalDivider(
-                                                thickness = 0.98.dp,
+                                                thickness = 1.dp,
                                                 color = MainThemeColor.Gray2,
                                             )
                                         }
@@ -272,24 +272,16 @@ fun SignUpMainLocationScreen(
                                         style = pretendardTypography.titleSmall,
                                         color = MainThemeColor.Gray6,
                                     )
-                                    Spacer(
-                                        modifier =
-                                            Modifier
-                                                .height(18.dp),
-                                    )
-                                    Box(
+                                    Spacer(modifier = Modifier.height(10.dp))
+                                    Image(
+                                        painter = painterResource(id = R.drawable.user_undefined),
+                                        contentDescription = "아이콘",
                                         modifier =
                                             Modifier
                                                 .height(60.68.dp)
                                                 .width(52.39.dp),
-                                    ) {
-                                        Image(
-                                            painter = painterResource(id = R.drawable.user_undefined),
-                                            contentDescription = "아이콘",
-                                            modifier = Modifier.fillMaxSize(),
-                                        )
-                                    }
-                                    Spacer(modifier = Modifier.height(22.dp))
+                                    )
+                                    Spacer(modifier = Modifier.height(30.dp))
                                     Text(
                                         text = "다른 지역으로\n이동해 보는 건 어때요?",
                                         style = pretendardTypography.bodyMedium,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
@@ -29,7 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
@@ -71,6 +73,7 @@ fun SignUpMainLocationScreen(
 ) {
     val currentState by viewModel.state.collectAsState()
     val focusManager = LocalFocusManager.current
+    var isSearchFieldFocused by remember { mutableStateOf(false) }
 
     LaunchedEffect(currentState.searchQuery) {
         if (currentState.searchQuery.isNotBlank()) {
@@ -118,7 +121,7 @@ fun SignUpMainLocationScreen(
                     modifier =
                         Modifier
                             .padding(top = 16.dp),
-                    text = "주 촬영지(동)를 선택해 주세요.",
+                    text = "주 촬영지를 선택해 주세요.",
                     style = MaterialTheme.typography.titleMedium,
                 )
                 CommonSearchField(
@@ -129,7 +132,7 @@ fun SignUpMainLocationScreen(
                             SignUpPhotographerIntent.UpdateSearchQuery(searchText),
                         )
                     },
-                    placeholder = "동명(동, 면)으로 검색 (ex, 연남동)",
+                    placeholder = "구 단위로 검색 (ex, 마포구)",
                     onSearchClick = {
                         viewModel.handleIntent(
                             SignUpPhotographerIntent.SearchArea(
@@ -143,6 +146,9 @@ fun SignUpMainLocationScreen(
                                 currentState.searchQuery,
                             ),
                         )
+                    },
+                    onFocusChanged = { isFocused ->
+                        isSearchFieldFocused = isFocused
                     },
                 )
                 if (currentState.selectedAreas.isNotEmpty()) {
@@ -165,33 +171,36 @@ fun SignUpMainLocationScreen(
                             )
                         }
                     }
-                } else {
-                    Spacer(modifier = Modifier.height(10.dp))
-                }
-                Spacer(modifier = Modifier.height(30.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.marker_icon),
-                        contentDescription = "아이콘",
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text =
-                            when {
-                                currentState.searchQuery.isBlank() -> "근처 동네"
-                                else -> "'${currentState.searchQuery}' 검색 결과"
-                            },
-                        style = MainFontFamily.buttonDefault,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MainThemeColor.Black,
-                    )
                 }
 
-                Spacer(modifier = Modifier.height(12.dp))
+                val spacingToIconText = if (currentState.hasSearchCompleted) 40.dp else 20.dp
+                Spacer(modifier = Modifier.height(spacingToIconText))
+
+                val showIconText = !isSearchFieldFocused || currentState.hasSearchCompleted
+
+                if (showIconText) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.marker_icon),
+                            contentDescription = "아이콘",
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text =
+                                when {
+                                    currentState.searchQuery.isBlank() -> "인근 지역"
+                                    else -> "'${currentState.searchQuery}' 검색 결과"
+                                },
+                            style = MainFontFamily.buttonDefault,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MainThemeColor.Black,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
                 Box(
                     modifier =
                         Modifier

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
@@ -49,7 +49,6 @@ import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonSearchField
 import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
-import com.hm.picplz.ui.screen.common.ToastPosition
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.Navigate
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.NavigateToPrev
@@ -315,8 +314,6 @@ fun SignUpMainLocationScreen(
             CommonToast(
                 message = message,
                 isVisible = currentState.showToast,
-                position = ToastPosition.BOTTOM,
-                offset = 120.dp,
                 onDismiss = {
                     viewModel.handleIntent(SignUpPhotographerIntent.DismissToast)
                 },

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpPhotographyVibeScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpPhotographyVibeScreen.kt
@@ -108,20 +108,20 @@ fun SignUpPhotographyVibeScreen(
                                 .height(80.dp),
                     )
                     Text(
-                        text = "자신 있는 촬영 감성을 선택해 주세요.",
+                        text = "자신 있는 분위기 키워드를 선택해 주세요.",
                         style = MaterialTheme.typography.titleMedium,
                     )
                     Spacer(
                         modifier =
                             Modifier
-                                .height(30.dp),
+                                .height(20.dp),
                     )
                     FlowRow(
                         modifier =
                             Modifier
                                 .fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
                         currentState.vibeChipList.map { chip ->
                             CommonChip(

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -77,6 +77,9 @@ fun DevScreen(navController: NavHostController) {
             DevButton("SignUpClient") { navController.navigate(SignUpClient(userInfo = emptyUserData)) }
             DevButton("SignUpPhotographer") { navController.navigate(SignUpPhotographer(userInfo = emptyUserData)) }
             DevButton("SignUpDevice (Direct)") { navController.navigate(SignUpPhotographer(startAt = "device")) }
+            DevButton("SignUpPhotographyVibe (분위기 키워드)") {
+                navController.navigate(SignUpPhotographer(startAt = "vibe"))
+            }
             DevButton("SignUpCompletion") { navController.navigate(SignUpCompletion(userInfo = emptyUserData)) }
 
             // === Main Tabs ===

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -74,6 +74,15 @@ fun DevScreen(navController: NavHostController) {
             SectionTitle("Auth")
             DevButton("Login") { navController.navigate(Login) }
             DevButton("SignUpIntro") { navController.navigate(SignUpIntro()) }
+            DevButton("SignUpSelectType (유형 선택)") {
+                navController.navigate(SignUpIntro(startAt = "select-type"))
+            }
+            DevButton("SignUpNickname (닉네임)") {
+                navController.navigate(SignUpIntro(startAt = "nickname"))
+            }
+            DevButton("SignUpProfile (프로필 이미지)") {
+                navController.navigate(SignUpIntro(startAt = "profile"))
+            }
             DevButton("SignUpClient") { navController.navigate(SignUpClient(userInfo = emptyUserData)) }
             DevButton("SignUpPhotographer") { navController.navigate(SignUpPhotographer(userInfo = emptyUserData)) }
             DevButton("SignUpDevice (Direct)") { navController.navigate(SignUpPhotographer(startAt = "device")) }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -76,6 +76,7 @@ fun DevScreen(navController: NavHostController) {
             DevButton("SignUpIntro") { navController.navigate(SignUpIntro()) }
             DevButton("SignUpClient") { navController.navigate(SignUpClient(userInfo = emptyUserData)) }
             DevButton("SignUpPhotographer") { navController.navigate(SignUpPhotographer(userInfo = emptyUserData)) }
+            DevButton("SignUpDevice (Direct)") { navController.navigate(SignUpPhotographer(startAt = "device")) }
             DevButton("SignUpCompletion") { navController.navigate(SignUpCompletion(userInfo = emptyUserData)) }
 
             // === Main Tabs ===


### PR DESCRIPTION
## 개요

피그마 기획에 맞게 **회원가입(SignUp) 플로우 전체 UI를 개선**했습니다.


## 화면별 변경 사항

| 화면 | 변경 내용 |
|------|----------|
| `SignUpNicknameScreen` | 레이아웃 TopBar+144dp 고정, 공백 입력 차단, NicknameValidator 우선순위 정리 |
| `SignUpCompletionScreen` | 가입 완료 멘트 통일 ("함께 사진 촬영하러 가볼까요?") |
| `SignUpSelectTypeScreen` | Title↔버튼 간격 30→38dp |
| `SignUpMainLocationScreen` | 피그마 기획 전면 반영 |
| `SignUpDeviceScreen` | 중복 기기 추가 시 토스트, DeviceItem 레이아웃 개선 |
| `SignUpAddDeviceScreen` | DeviceSelectorBox/BottomSheet UI 개선 |
| `SignUpPhotographyVibeScreen` | 11개 키워드, FlowRow 갭 조정 |

### 공통 컴포넌트 변경

| 컴포넌트 | 변경 내용 |
|----------|----------|
| `CommonToast` | 높이 45dp, 바닥 offset 50dp, 배경 60% 불투명도 |
| `CommonChip` | 패딩 로직 개선 (BIG: 10dp, MEDIUM: 6dp), 라디우스 5dp |
| `CommonSearchField` | `onFocusChanged` 콜백 추가 |
| `CommonTopBar` | 불필요한 패딩 제거 |
| `AreaTag` | 패딩 조정 |
| `AreaListItem` | 체크박스 제거, 선택 시 Bold 스타일 |
| `DeviceSelectorBox` | 화살표 아이콘 제거, 패딩 14h/11v |
| `DeviceSelectorBottomSheet` | 드래그 핸들 추가, heightIn 540dp 제한 |

---

## 확인 방법

### 1. DevScreen에서 테스트
앱 실행 후 DevScreen에서 각 버튼을 눌러 화면 확인:

```
DevScreen 버튼 목록:
- SignUpNickname (닉네임)
- SignUpProfileImage (프로필)
- SignUpSelectType (유형 선택)
- SignUpPhotographer (작가 가입)
- SignUpDevice (Direct) → 기기 추가 화면 직접 진입
- SignUpPhotographyVibe (분위기 키워드) → 분위기 키워드 화면 직접 진입
- SignUpCompletion (가입 완료)
```

### 2. 확인 체크리스트

- [x] **SignUpNicknameScreen**: 공백 입력 시 필터링되는지, 유효성 검사 메시지 순서 확인
- [x] **SignUpMainLocationScreen**: 지역 검색 및 선택 시 Bold 스타일 적용 확인
- [x] **SignUpDeviceScreen**: 동일 기기 추가 시 "이미 추가된 기기입니다" 토스트 표시
- [x] **SignUpAddDeviceScreen**: DeviceSelectorBox 클릭 시 BottomSheet 열림, 드래그 핸들 표시
- [x] **SignUpPhotographyVibeScreen**: 11개 키워드 표시, 칩 간격 확인
- [x] **CommonToast**: 바닥에서 50dp 위치, 60% 불투명도 배경


---

## 관련 이슈

- Resolves #89 

## Todo

- #99: SignUpAddDeviceScreen 직접입력 버튼 플로우 개선 
  - 이 플로우가 워낙 복잡하기도 하고 좀더 커뮤니케이션 해보고 별개 이슈로 개선하겠습니다.
- 지역 검색 백엔드 수정반영

---

## 스크린샷 / 영상

![KakaoTalk_Video_2026-01-27-00-11-27](https://github.com/user-attachments/assets/f654c70e-7d1f-4310-b699-7e697297c757)
![KakaoTalk_Video_2026-01-27-00-11-20](https://github.com/user-attachments/assets/9e2d6577-9a39-40b5-b463-4e3ea3ec9af3)