### PR TITLE
✨ : 예약 상세 페이지 예약 상태에 따른 UI 변경 처리

### DIFF
--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
@@ -1,10 +1,12 @@
 package com.hm.picplz.ui.screen.common
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -52,6 +54,37 @@ fun CommonBottomButton(
     }
 }
 
+@Composable
+fun CommonBottomOutlinedButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MainThemeColor.White,
+                contentColor = MainThemeColor.Black,
+            ),
+        shape = RoundedCornerShape(CommonBottomButtonDefaults.CornerRadius),
+        border = BorderStroke(1.dp, MainThemeColor.Gray3),
+        contentPadding =
+            PaddingValues(
+                vertical = CommonBottomButtonDefaults.VerticalPadding,
+                horizontal = CommonBottomButtonDefaults.HorizontalPadding,
+            ),
+        enabled = enabled,
+    ) {
+        Text(
+            text = text,
+            style = pretendardTypography.labelLarge,
+        )
+    }
+}
+
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
@@ -74,6 +107,19 @@ private fun CommonBottomButtonDisabledPreview() {
             text = "다음",
             onClick = {},
             enabled = false,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CommonBottomOutlinedButtonPreview() {
+    PicplzTheme {
+        CommonBottomOutlinedButton(
+            text = "다음",
+            onClick = {},
+            enabled = true,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -1,3 +1,9 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
-sealed interface DetailReservationIntent
+sealed interface DetailReservationIntent {
+    data object NavigateToChat : DetailReservationIntent
+
+    data object NavigateToHistory : DetailReservationIntent
+
+    data object ConfirmReservation : DetailReservationIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -43,8 +43,6 @@ fun DetailReservationScreen(modifier: Modifier = Modifier) {
                 item {
                     ReservationStatusHeader(
                         modifier = Modifier.padding(vertical = 20.dp),
-                        title = "예약 승인 대기중...",
-                        description = "n분 이내로 승인되지 않으면 자동 취소됩니다.",
                         onCancelClick = {},
                     )
                 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
@@ -35,12 +35,24 @@ fun DetailReservationScreen(
     DetailReservationScreen(
         modifier = modifier,
         state = state,
+        onChatClick = {
+            viewModel.handelIntent(DetailReservationIntent.NavigateToChat)
+        },
+        onHistoryClick = {
+            viewModel.handelIntent(DetailReservationIntent.NavigateToHistory)
+        },
+        onConfirmClick = {
+            viewModel.handelIntent(DetailReservationIntent.ConfirmReservation)
+        },
     )
 }
 
 @Composable
 private fun DetailReservationScreen(
     state: DetailReservationState,
+    onChatClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onConfirmClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -88,10 +100,12 @@ private fun DetailReservationScreen(
                 }
             }
 
-            CommonBottomButton(
+            DetailReservationBottomButtons(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
-                text = "채팅 바로가기",
-                onClick = {},
+                currentReservationStatus = state.reservationStatus,
+                onChatClick = onChatClick,
+                onHistoryClick = onHistoryClick,
+                onConfirmClick = onConfirmClick,
             )
         }
     }
@@ -102,5 +116,8 @@ private fun DetailReservationScreen(
 fun DetailReservationScreenPreview() {
     DetailReservationScreen(
         state = DetailReservationState(),
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
@@ -23,13 +26,35 @@ import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHe
 import com.hm.picplz.ui.theme.MainThemeColor
 
 @Composable
-fun DetailReservationScreen(modifier: Modifier = Modifier) {
+fun DetailReservationScreen(
+    modifier: Modifier = Modifier,
+    viewModel: DetailReservationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    DetailReservationScreen(
+        modifier = modifier,
+        state = state,
+    )
+}
+
+@Composable
+private fun DetailReservationScreen(
+    state: DetailReservationState,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(
         modifier = modifier,
         containerColor = MainThemeColor.White,
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
-            Box(modifier = Modifier.fillMaxWidth().height(230.dp).background(Color.LightGray)) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(230.dp)
+                        .background(Color.LightGray),
+            ) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
                     text = "지도 영역",
@@ -43,13 +68,18 @@ fun DetailReservationScreen(modifier: Modifier = Modifier) {
                 item {
                     ReservationStatusHeader(
                         modifier = Modifier.padding(vertical = 20.dp),
+                        currentReservationStatus = state.reservationStatus,
                         onCancelClick = {},
                     )
                 }
 
                 item {
                     ReservationProgressStepper(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp),
+                        currentReservationStep = state.reservationStatus.step,
                     )
                 }
 
@@ -70,5 +100,7 @@ fun DetailReservationScreen(modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun DetailReservationScreenPreview() {
-    DetailReservationScreen()
+    DetailReservationScreen(
+        state = DetailReservationState(),
+    )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -1,3 +1,7 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
-class DetailReservationState
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+
+data class DetailReservationState(
+    val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
+)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -1,13 +1,37 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailReservationViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow(DetailReservationState())
     val state: StateFlow<DetailReservationState> get() = _state
+
+    fun handelIntent(intent: DetailReservationIntent) {
+        when (intent) {
+            // 상태 변경 확인 테스트를 위한 코드입니다.
+            is DetailReservationIntent.NavigateToChat,
+            is DetailReservationIntent.NavigateToHistory,
+            is DetailReservationIntent.ConfirmReservation,
+            -> {
+                _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
+            }
+        }
+    }
+
+    // 상태 변경 확인 테스트를 위한 코드입니다.
+    private fun ReservationStatus.next(): ReservationStatus {
+        return when (this) {
+            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_PAYMENT
+            ReservationStatus.WAITING_PAYMENT -> ReservationStatus.RESERVED
+            ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
+            ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
+        }
+    }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -2,7 +2,12 @@ package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class DetailReservationViewModel @Inject constructor() : ViewModel()
+class DetailReservationViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow(DetailReservationState())
+    val state: StateFlow<DetailReservationState> get() = _state
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
@@ -1,0 +1,145 @@
+package com.hm.picplz.ui.screen.detail_reservation.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+
+@Composable
+fun DetailReservationBottomButtons(
+    currentReservationStatus: ReservationStatus,
+    onChatClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (currentReservationStatus) {
+        ReservationStatus.WAITING_APPROVAL,
+        ReservationStatus.WAITING_PAYMENT,
+        -> {
+            ChatButton(
+                modifier = modifier,
+                onClick = onChatClick,
+            )
+        }
+        ReservationStatus.RESERVED -> {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                HistoryButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onHistoryClick,
+                )
+
+                ConfirmButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onConfirmClick,
+                )
+            }
+        }
+        ReservationStatus.COMPLETED -> {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                HistoryButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onHistoryClick,
+                )
+
+                ChatButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onChatClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_chat),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun HistoryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomOutlinedButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_history),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun ConfirmButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_confirm),
+        onClick = onClick,
+    )
+}
+
+@Preview
+@Composable
+private fun DetailReservationBottomButtonsWaitingApprovalPreview() {
+    DetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.WAITING_APPROVAL,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun DetailReservationBottomButtonsWaitingPaymentPreview() {
+    DetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.WAITING_PAYMENT,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun DetailReservationBottomButtonsReservedPreview() {
+    DetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.RESERVED,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun DetailReservationBottomButtonsCompletedPreview() {
+    DetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.COMPLETED,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationProgressStepper.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationProgressStepper.kt
@@ -16,35 +16,31 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.core.ui.R
-import com.hm.picplz.feature.reservation.R.string
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStep
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStep.Companion.hasPassed
 import com.hm.picplz.ui.theme.MainFontFamily.bodyBold
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.pretendardTypography
 
 @Composable
-fun ReservationProgressStepper(modifier: Modifier = Modifier) {
+fun ReservationProgressStepper(
+    modifier: Modifier = Modifier,
+    currentReservationStep: ReservationStep = ReservationStep.WAITING,
+) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(4.dp, alignment = Alignment.CenterHorizontally),
     ) {
-        ReservationStepItem(
-            isActive = true,
-            label = stringResource(string.reservation_step_waiting),
-        )
+        ReservationStep.entries.forEachIndexed { index, step ->
+            ReservationStepItem(
+                isActive = step.hasPassed(currentReservationStep),
+                label = stringResource(step.nameResId),
+            )
 
-        DashLine()
-
-        ReservationStepItem(
-            isActive = false,
-            label = stringResource(string.reservation_step_in_progress),
-        )
-
-        DashLine()
-
-        ReservationStepItem(
-            isActive = false,
-            label = stringResource(string.reservation_step_confirmed),
-        )
+            if (index < ReservationStep.entries.lastIndex) {
+                DashLine()
+            }
+        }
     }
 }
 
@@ -105,6 +101,24 @@ private fun DashLine(modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-private fun ReservationProgressStepperPreview() {
-    ReservationProgressStepper()
+private fun ReservationProgressStepperWaitingPreview() {
+    ReservationProgressStepper(
+        currentReservationStep = ReservationStep.WAITING,
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationProgressStepperWaitingInProgress() {
+    ReservationProgressStepper(
+        currentReservationStep = ReservationStep.IN_PROGRESS,
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationProgressStepperWaitingConfirmed() {
+    ReservationProgressStepper(
+        currentReservationStep = ReservationStep.CONFIRMED,
+    )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationProgressStepper.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationProgressStepper.kt
@@ -24,8 +24,8 @@ import com.hm.picplz.ui.theme.pretendardTypography
 
 @Composable
 fun ReservationProgressStepper(
+    currentReservationStep: ReservationStep,
     modifier: Modifier = Modifier,
-    currentReservationStep: ReservationStep = ReservationStep.WAITING,
 ) {
     Row(
         modifier = modifier,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus.Companion.showCancelButton
 import com.hm.picplz.ui.theme.MainFontFamily.bodyBold
 import com.hm.picplz.ui.theme.MainFontFamily.caption
 import com.hm.picplz.ui.theme.MainThemeColor
@@ -31,22 +33,24 @@ import com.hm.picplz.ui.theme.pretendardTypography
 
 @Composable
 fun ReservationStatusHeader(
-    title: String,
-    description: String,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
+    currentReservationStatus: ReservationStatus = ReservationStatus.RESERVED,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         ReservationStatusInfo(
-            title = title,
-            description = description,
+            title = stringResource(currentReservationStatus.titleResId),
+            description = stringResource(currentReservationStatus.descriptionResId),
         )
-        ReservationCancelButton(
-            onClick = onCancelClick,
-        )
+
+        if (currentReservationStatus.showCancelButton()) {
+            ReservationCancelButton(
+                onClick = onCancelClick,
+            )
+        }
     }
 }
 
@@ -118,10 +122,36 @@ class CustomViewConfiguration(
 
 @Preview
 @Composable
-private fun ReservationStatusHeaderPreview() {
+private fun ReservationStatusHeaderWaitingApprovalPreview() {
     ReservationStatusHeader(
-        title = "예약 승인 대기 중...",
-        description = "n분 이내로 승인되지 않으면 자동 취소됩니다.",
+        currentReservationStatus = ReservationStatus.WAITING_APPROVAL,
+        onCancelClick = { },
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationStatusHeaderWaitingPaymentPreview() {
+    ReservationStatusHeader(
+        currentReservationStatus = ReservationStatus.WAITING_PAYMENT,
+        onCancelClick = { },
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationStatusHeaderReservedPreview() {
+    ReservationStatusHeader(
+        currentReservationStatus = ReservationStatus.RESERVED,
+        onCancelClick = { },
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationStatusHeaderCompletedPreview() {
+    ReservationStatusHeader(
+        currentReservationStatus = ReservationStatus.COMPLETED,
         onCancelClick = { },
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
@@ -33,9 +33,9 @@ import com.hm.picplz.ui.theme.pretendardTypography
 
 @Composable
 fun ReservationStatusHeader(
+    currentReservationStatus: ReservationStatus,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
-    currentReservationStatus: ReservationStatus = ReservationStatus.RESERVED,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStatus.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStatus.kt
@@ -1,0 +1,36 @@
+package com.hm.picplz.ui.screen.detail_reservation.model
+
+import androidx.annotation.StringRes
+import com.hm.picplz.feature.reservation.R
+
+enum class ReservationStatus(
+    val step: ReservationStep,
+    @get:StringRes val titleResId: Int,
+    @get:StringRes val descriptionResId: Int,
+) {
+    WAITING_APPROVAL(
+        step = ReservationStep.WAITING,
+        titleResId = R.string.reservation_status_title_waiting_approval,
+        descriptionResId = R.string.reservation_status_description_waiting_approval,
+    ),
+    WAITING_PAYMENT(
+        step = ReservationStep.WAITING,
+        titleResId = R.string.reservation_status_title_waiting_payment,
+        descriptionResId = R.string.reservation_status_description_waiting_payment,
+    ),
+    RESERVED(
+        step = ReservationStep.IN_PROGRESS,
+        titleResId = R.string.reservation_status_title_reserved,
+        descriptionResId = R.string.reservation_status_description_reserved,
+    ),
+    COMPLETED(
+        step = ReservationStep.CONFIRMED,
+        titleResId = R.string.reservation_status_title_completed,
+        descriptionResId = R.string.reservation_status_description_completed,
+    ),
+    ;
+
+    companion object {
+        fun ReservationStatus.showCancelButton(): Boolean = this != COMPLETED
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStep.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStep.kt
@@ -1,0 +1,17 @@
+package com.hm.picplz.ui.screen.detail_reservation.model
+
+import androidx.annotation.StringRes
+import com.hm.picplz.feature.reservation.R
+
+enum class ReservationStep(
+    @get:StringRes val nameResId: Int,
+) {
+    WAITING(R.string.reservation_step_waiting),
+    IN_PROGRESS(R.string.reservation_step_in_progress),
+    CONFIRMED(R.string.reservation_step_confirmed),
+    ;
+
+    companion object {
+        fun ReservationStep.hasPassed(target: ReservationStep): Boolean = this.ordinal <= target.ordinal
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -4,4 +4,12 @@
     <string name="reservation_step_waiting">예약 대기</string>
     <string name="reservation_step_in_progress">촬영 진행</string>
     <string name="reservation_step_confirmed">거래 확정</string>
+    <string name="reservation_status_title_waiting_approval">예약 승인 대기중…</string>
+    <string name="reservation_status_title_waiting_payment">결제 및 촬영 일시 확정 대기중…</string>
+    <string name="reservation_status_title_reserved">예약 확정</string>
+    <string name="reservation_status_title_completed">거래 확정</string>
+    <string name="reservation_status_description_waiting_approval">n분 이내로 승인되지 않으면 자동 취소됩니다.</string>
+    <string name="reservation_status_description_waiting_payment">결제 및 촬영 일시 확정을 진행해 주세요.</string>
+    <string name="reservation_status_description_reserved">작가와 촬영을 진행해주세요!</string>
+    <string name="reservation_status_description_completed">이미 완료된 촬영입니다.</string>
 </resources>

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="reservation_status_description_waiting_payment">결제 및 촬영 일시 확정을 진행해 주세요.</string>
     <string name="reservation_status_description_reserved">작가와 촬영을 진행해주세요!</string>
     <string name="reservation_status_description_completed">이미 완료된 촬영입니다.</string>
+    <string name="reservation_button_chat">채팅 바로가기</string>
+    <string name="reservation_button_history">내역 보기</string>
+    <string name="reservation_button_confirm">거래 확정하기</string>
 </resources>


### PR DESCRIPTION
## 개요
예약 상세 화면의 상태 모델을 정의하고 하단 버튼 영역을 구현합니다.

## 변경 사항
- 예약 상태 모델 정의
  - `ReservationStep` enum: 스텝퍼용 (WAITING, IN_PROGRESS, CONFIRMED)
  - `ReservationStatus` enum: 비즈니스 상태 (WAITING_APPROVAL, WAITING_PAYMENT, RESERVED, COMPLETED)
- 하단 버튼 영역 구현 (`DetailReservationBottomButtons`)
  - 상태별 버튼 구성: 채팅 바로가기, 내역 보기, 거래 확정하기
- `CommonBottomOutlinedButton` 공통 컴포넌트 추가
- ViewModel 상태 관리 및 Intent 처리 추가
- 관련 string 리소스 추가

[Screen_recording_20260203_160041.webm](https://github.com/user-attachments/assets/69821391-bc3c-4c87-9b89-595563db7bd0)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #98 
