### PR TITLE
✨ : 예약 취소 다이얼로그 구현

### DIFF
--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -6,4 +6,10 @@ sealed interface DetailReservationIntent {
     data object NavigateToHistory : DetailReservationIntent
 
     data object ConfirmReservation : DetailReservationIntent
+
+    data object ShowCancelDialog : DetailReservationIntent
+
+    data object DismissCancelDialog : DetailReservationIntent
+
+    data object ConfirmCancel : DetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -71,6 +71,7 @@ private fun DetailReservationScreen(
         if (state.showCancelDialog) {
             ReservationCancelDialog(
                 status = state.reservationStatus,
+                refundReason = state.refundReason,
                 onDismiss = onCancelDialogDismiss,
                 onCancel = onCancelDialogDismiss,
                 onConfirm = onCancelDialogConfirm,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -16,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
@@ -40,6 +41,15 @@ fun DetailReservationScreen(
         onConfirmClick = {
             viewModel.handelIntent(DetailReservationIntent.ConfirmReservation)
         },
+        onCancelClick = {
+            viewModel.handelIntent(DetailReservationIntent.ShowCancelDialog)
+        },
+        onCancelDialogDismiss = {
+            viewModel.handelIntent(DetailReservationIntent.DismissCancelDialog)
+        },
+        onCancelDialogConfirm = {
+            viewModel.handelIntent(DetailReservationIntent.ConfirmCancel)
+        },
     )
 }
 
@@ -49,12 +59,24 @@ private fun DetailReservationScreen(
     onChatClick: () -> Unit,
     onHistoryClick: () -> Unit,
     onConfirmClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onCancelDialogDismiss: () -> Unit,
+    onCancelDialogConfirm: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
         modifier = modifier,
         containerColor = MainThemeColor.White,
     ) { innerPadding ->
+        if (state.showCancelDialog) {
+            ReservationCancelDialog(
+                status = state.reservationStatus,
+                onDismiss = onCancelDialogDismiss,
+                onCancel = onCancelDialogDismiss,
+                onConfirm = onCancelDialogConfirm,
+            )
+        }
+
         Column(modifier = Modifier.padding(innerPadding)) {
             DetailReservationMap(
                 modifier =
@@ -72,7 +94,7 @@ private fun DetailReservationScreen(
                     ReservationStatusHeader(
                         modifier = Modifier.padding(vertical = 20.dp),
                         currentReservationStatus = state.reservationStatus,
-                        onCancelClick = {},
+                        onCancelClick = onCancelClick,
                     )
                 }
 
@@ -104,11 +126,14 @@ private fun DetailReservationScreen(
 
 @Preview
 @Composable
-fun DetailReservationScreenPreview() {
+private fun DetailReservationScreenPreview() {
     DetailReservationScreen(
         state = DetailReservationState(),
         onChatClick = {},
         onHistoryClick = {},
         onConfirmClick = {},
+        onCancelClick = {},
+        onCancelDialogDismiss = {},
+        onCancelDialogConfirm = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -75,6 +75,9 @@ private fun DetailReservationScreen(
                 onDismiss = onCancelDialogDismiss,
                 onCancel = onCancelDialogDismiss,
                 onConfirm = onCancelDialogConfirm,
+                onInfoClick = {
+                    // TODO: 환불 규정 툴팁 표시
+                },
             )
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -71,7 +71,7 @@ private fun DetailReservationScreen(
         if (state.showCancelDialog) {
             ReservationCancelDialog(
                 status = state.reservationStatus,
-                refundReason = state.refundReason,
+                refundCondition = state.refundCondition,
                 onDismiss = onCancelDialogDismiss,
                 onCancel = onCancelDialogDismiss,
                 onConfirm = onCancelDialogConfirm,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -1,8 +1,13 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import java.time.LocalDateTime
 
 data class DetailReservationState(
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
     val showCancelDialog: Boolean = false,
+    val shootingDateTime: LocalDateTime? = null,
+    val confirmedDateTime: LocalDateTime? = null,
+    val refundReason: RefundReason? = null,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -1,13 +1,13 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
-import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import java.time.LocalDateTime
 
 data class DetailReservationState(
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
     val showCancelDialog: Boolean = false,
-    val shootingDateTime: LocalDateTime? = null,
-    val confirmedDateTime: LocalDateTime? = null,
-    val refundReason: RefundReason? = null,
+    val shootingDateTime: LocalDateTime = LocalDateTime.now(),
+    val confirmedDateTime: LocalDateTime = LocalDateTime.now(),
+    val refundCondition: RefundCondition = RefundCondition.Within24Hours,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -4,4 +4,5 @@ import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 
 data class DetailReservationState(
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
+    val showCancelDialog: Boolean = false,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -22,16 +22,28 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
             -> {
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
             }
+
+            is DetailReservationIntent.ShowCancelDialog -> {
+                _state.update { it.copy(showCancelDialog = true) }
+            }
+
+            is DetailReservationIntent.DismissCancelDialog -> {
+                _state.update { it.copy(showCancelDialog = false) }
+            }
+
+            is DetailReservationIntent.ConfirmCancel -> {
+                _state.update { it.copy(showCancelDialog = false) }
+                // TODO: 예약 취소 API 호출
+            }
         }
     }
 
     // 상태 변경 확인 테스트를 위한 코드입니다.
-    private fun ReservationStatus.next(): ReservationStatus {
-        return when (this) {
+    private fun ReservationStatus.next(): ReservationStatus =
+        when (this) {
             ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_PAYMENT
             ReservationStatus.WAITING_PAYMENT -> ReservationStatus.RESERVED
             ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
             ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
         }
-    }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -1,17 +1,33 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailReservationViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow(DetailReservationState())
     val state: StateFlow<DetailReservationState> get() = _state
+
+    init {
+        // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
+        // 임시로 더미 데이터 설정 (촬영일: 4일 후)
+        val dummyShootingDateTime = LocalDateTime.now().plusDays(4)
+        val dummyConfirmedDateTime = LocalDateTime.now().minusHours(12)
+
+        _state.update {
+            it.copy(
+                shootingDateTime = dummyShootingDateTime,
+                confirmedDateTime = dummyConfirmedDateTime,
+            )
+        }
+    }
 
     fun handelIntent(intent: DetailReservationIntent) {
         when (intent) {
@@ -24,7 +40,22 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
             }
 
             is DetailReservationIntent.ShowCancelDialog -> {
-                _state.update { it.copy(showCancelDialog = true) }
+                val currentState = _state.value
+                val refundReason =
+                    currentState.shootingDateTime?.let {
+                        RefundReason.calculate(
+                            currentDateTime = LocalDateTime.now(),
+                            shootingDateTime = currentState.shootingDateTime,
+                            confirmedDateTime = currentState.confirmedDateTime,
+                        )
+                    }
+
+                _state.update {
+                    it.copy(
+                        showCancelDialog = true,
+                        refundReason = refundReason,
+                    )
+                }
             }
 
             is DetailReservationIntent.DismissCancelDialog -> {

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -1,7 +1,7 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
-import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,19 +41,17 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
 
             is DetailReservationIntent.ShowCancelDialog -> {
                 val currentState = _state.value
-                val refundReason =
-                    currentState.shootingDateTime?.let {
-                        RefundReason.calculate(
-                            currentDateTime = LocalDateTime.now(),
-                            shootingDateTime = currentState.shootingDateTime,
-                            confirmedDateTime = currentState.confirmedDateTime,
-                        )
-                    }
+                val refundCondition =
+                    RefundCondition.calculate(
+                        currentDateTime = LocalDateTime.now(),
+                        shootingDateTime = currentState.shootingDateTime,
+                        confirmedDateTime = currentState.confirmedDateTime,
+                    )
 
                 _state.update {
                     it.copy(
                         showCancelDialog = true,
-                        refundReason = refundReason,
+                        refundCondition = refundCondition,
                     )
                 }
             }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -1,14 +1,18 @@
 package com.hm.picplz.ui.screen.detail_reservation.composable
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -20,8 +24,10 @@ import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonButtonModal
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStep
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.pretendardTypography
+import com.hm.picplz.core.ui.R as CoreR
 
 @Composable
 fun ReservationCancelDialog(
@@ -30,6 +36,7 @@ fun ReservationCancelDialog(
     onDismiss: () -> Unit,
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
+    onInfoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     CommonButtonModal(
@@ -43,6 +50,7 @@ fun ReservationCancelDialog(
         ReservationCancelDialogContent(
             status = status,
             refundReason = refundReason,
+            onInfoClick = onInfoClick,
         )
     }
 }
@@ -51,15 +59,34 @@ fun ReservationCancelDialog(
 private fun ReservationCancelDialogContent(
     status: ReservationStatus,
     refundReason: RefundReason?,
+    onInfoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 24.dp),
+                .padding(
+                    start = 12.dp,
+                    end = 12.dp,
+                    top = 10.dp,
+                    bottom = 20.dp,
+                ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        if (status.step != ReservationStep.WAITING) {
+            Image(
+                painter = painterResource(CoreR.drawable.info),
+                contentDescription = "환불 규정 안내",
+                modifier =
+                    Modifier
+                        .align(Alignment.End)
+                        .size(16.dp)
+                        .clickable(onClick = onInfoClick),
+            )
+        } else {
+            Spacer(modifier = Modifier.height(10.dp))
+        }
         Text(
             text = stringResource(R.string.reservation_cancel_dialog_title),
             style = pretendardTypography.titleSmall,
@@ -124,6 +151,7 @@ private fun ReservationCancelDialogWaitingApprovalPreview() {
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
+        onInfoClick = {},
     )
 }
 
@@ -136,6 +164,7 @@ private fun ReservationCancelDialogFullRefundPreview() {
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
+        onInfoClick = {},
     )
 }
 
@@ -148,5 +177,6 @@ private fun ReservationCancelDialogPartialRefundPreview() {
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
+        onInfoClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.pretendardTypography
@@ -25,6 +26,7 @@ import com.hm.picplz.ui.theme.pretendardTypography
 @Composable
 fun ReservationCancelDialog(
     status: ReservationStatus,
+    refundReason: RefundReason?,
     onDismiss: () -> Unit,
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
@@ -38,13 +40,17 @@ fun ReservationCancelDialog(
         onCancel = onCancel,
         onConfirm = onConfirm,
     ) {
-        ReservationCancelDialogContent(status = status)
+        ReservationCancelDialogContent(
+            status = status,
+            refundReason = refundReason,
+        )
     }
 }
 
 @Composable
 private fun ReservationCancelDialogContent(
     status: ReservationStatus,
+    refundReason: RefundReason?,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -61,9 +67,9 @@ private fun ReservationCancelDialogContent(
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(12.dp))
-        if (status == ReservationStatus.RESERVED) {
+        if (status == ReservationStatus.RESERVED && refundReason != null) {
             Text(
-                text = getPartialRefundAnnotatedText(refundPercent = 90),
+                text = getPartialRefundAnnotatedText(refundPercent = refundReason.percent),
                 style = pretendardTypography.bodyMedium,
                 color = MainThemeColor.Gray4,
                 textAlign = TextAlign.Center,
@@ -114,6 +120,7 @@ private fun getPartialRefundAnnotatedText(refundPercent: Int) =
 private fun ReservationCancelDialogWaitingApprovalPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.WAITING_APPROVAL,
+        refundReason = null,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -125,6 +132,7 @@ private fun ReservationCancelDialogWaitingApprovalPreview() {
 private fun ReservationCancelDialogFullRefundPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.WAITING_PAYMENT,
+        refundReason = null,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -136,6 +144,7 @@ private fun ReservationCancelDialogFullRefundPreview() {
 private fun ReservationCancelDialogPartialRefundPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.RESERVED,
+        refundReason = RefundReason.Before3Days,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -1,0 +1,121 @@
+package com.hm.picplz.ui.screen.detail_reservation.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.pretendardTypography
+
+@Composable
+fun ReservationCancelDialog(
+    status: ReservationStatus,
+    onDismiss: () -> Unit,
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonButtonModal(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        cancelText = stringResource(R.string.reservation_cancel_dialog_button_no),
+        confirmText = stringResource(R.string.reservation_cancel_dialog_button_yes),
+        onCancel = onCancel,
+        onConfirm = onConfirm,
+    ) {
+        ReservationCancelDialogContent(status = status)
+    }
+}
+
+@Composable
+private fun ReservationCancelDialogContent(
+    status: ReservationStatus,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.reservation_cancel_dialog_title),
+            style = pretendardTypography.titleSmall,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = getDescriptionText(status),
+            style = pretendardTypography.bodyMedium,
+            color = MainThemeColor.Gray4,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun getDescriptionText(status: ReservationStatus): String =
+    when (status) {
+        ReservationStatus.WAITING_APPROVAL -> {
+            stringResource(R.string.reservation_cancel_dialog_desc_waiting_approval)
+        }
+
+        ReservationStatus.WAITING_PAYMENT -> {
+            stringResource(R.string.reservation_cancel_dialog_desc_full_refund)
+        }
+
+        ReservationStatus.RESERVED -> {
+            stringResource(R.string.reservation_cancel_dialog_desc_partial_refund, 90)
+        }
+
+        ReservationStatus.COMPLETED -> {
+            ""
+        }
+    }
+
+@Preview
+@Composable
+private fun ReservationCancelDialogWaitingApprovalPreview() {
+    ReservationCancelDialog(
+        status = ReservationStatus.WAITING_APPROVAL,
+        onDismiss = {},
+        onCancel = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationCancelDialogFullRefundPreview() {
+    ReservationCancelDialog(
+        status = ReservationStatus.WAITING_PAYMENT,
+        onDismiss = {},
+        onCancel = {},
+        onConfirm = {},
+    )
+}
+
+@Preview
+@Composable
+private fun ReservationCancelDialogPartialRefundPreview() {
+    ReservationCancelDialog(
+        status = ReservationStatus.RESERVED,
+        onDismiss = {},
+        onCancel = {},
+        onConfirm = {},
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -10,7 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.reservation.R
@@ -58,12 +61,21 @@ private fun ReservationCancelDialogContent(
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(12.dp))
-        Text(
-            text = getDescriptionText(status),
-            style = pretendardTypography.bodyMedium,
-            color = MainThemeColor.Gray4,
-            textAlign = TextAlign.Center,
-        )
+        if (status == ReservationStatus.RESERVED) {
+            Text(
+                text = getPartialRefundAnnotatedText(refundPercent = 90),
+                style = pretendardTypography.bodyMedium,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+            )
+        } else {
+            Text(
+                text = getDescriptionText(status),
+                style = pretendardTypography.bodyMedium,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+            )
+        }
     }
 }
 
@@ -85,6 +97,16 @@ private fun getDescriptionText(status: ReservationStatus): String =
         ReservationStatus.COMPLETED -> {
             ""
         }
+    }
+
+@Composable
+private fun getPartialRefundAnnotatedText(refundPercent: Int) =
+    buildAnnotatedString {
+        append(stringResource(R.string.reservation_cancel_dialog_desc_partial_refund_prefix))
+        withStyle(style = SpanStyle(color = MainThemeColor.Red)) {
+            append(stringResource(R.string.reservation_cancel_dialog_desc_partial_refund_highlight, refundPercent))
+        }
+        append(stringResource(R.string.reservation_cancel_dialog_desc_partial_refund_suffix))
     }
 
 @Preview

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -22,9 +22,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonButtonModal
-import com.hm.picplz.ui.screen.detail_reservation.model.RefundReason
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
-import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStep
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.pretendardTypography
 import com.hm.picplz.core.ui.R as CoreR
@@ -32,7 +31,7 @@ import com.hm.picplz.core.ui.R as CoreR
 @Composable
 fun ReservationCancelDialog(
     status: ReservationStatus,
-    refundReason: RefundReason?,
+    refundCondition: RefundCondition,
     onDismiss: () -> Unit,
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
@@ -49,7 +48,7 @@ fun ReservationCancelDialog(
     ) {
         ReservationCancelDialogContent(
             status = status,
-            refundReason = refundReason,
+            refundCondition = refundCondition,
             onInfoClick = onInfoClick,
         )
     }
@@ -58,7 +57,7 @@ fun ReservationCancelDialog(
 @Composable
 private fun ReservationCancelDialogContent(
     status: ReservationStatus,
-    refundReason: RefundReason?,
+    refundCondition: RefundCondition,
     onInfoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -74,7 +73,7 @@ private fun ReservationCancelDialogContent(
                 ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        if (status.step != ReservationStep.WAITING) {
+        if (status == ReservationStatus.RESERVED) {
             Image(
                 painter = painterResource(CoreR.drawable.info),
                 contentDescription = "환불 규정 안내",
@@ -94,16 +93,16 @@ private fun ReservationCancelDialogContent(
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(12.dp))
-        if (status == ReservationStatus.RESERVED && refundReason != null) {
+        if (status == ReservationStatus.RESERVED && !refundCondition.isFullRefund()) {
             Text(
-                text = getPartialRefundAnnotatedText(refundPercent = refundReason.percent),
+                text = getPartialRefundAnnotatedText(refundPercent = refundCondition.percent),
                 style = pretendardTypography.bodyMedium,
                 color = MainThemeColor.Gray4,
                 textAlign = TextAlign.Center,
             )
         } else {
             Text(
-                text = getDescriptionText(status),
+                text = getDescriptionText(status, refundCondition),
                 style = pretendardTypography.bodyMedium,
                 color = MainThemeColor.Gray4,
                 textAlign = TextAlign.Center,
@@ -113,18 +112,32 @@ private fun ReservationCancelDialogContent(
 }
 
 @Composable
-private fun getDescriptionText(status: ReservationStatus): String =
+private fun getDescriptionText(
+    status: ReservationStatus,
+    refundCondition: RefundCondition,
+): String =
     when (status) {
-        ReservationStatus.WAITING_APPROVAL -> {
-            stringResource(R.string.reservation_cancel_dialog_desc_waiting_approval)
-        }
-
-        ReservationStatus.WAITING_PAYMENT -> {
-            stringResource(R.string.reservation_cancel_dialog_desc_full_refund)
-        }
-
         ReservationStatus.RESERVED -> {
-            stringResource(R.string.reservation_cancel_dialog_desc_partial_refund, 90)
+            when (refundCondition) {
+                RefundCondition.Within24Hours,
+                RefundCondition.Before7Days,
+                -> {
+                    stringResource(R.string.reservation_cancel_dialog_desc_full_refund)
+                }
+
+                else -> {
+                    stringResource(
+                        R.string.reservation_cancel_dialog_desc_partial_refund,
+                        refundCondition.percent,
+                    )
+                }
+            }
+        }
+
+        ReservationStatus.WAITING_APPROVAL,
+        ReservationStatus.WAITING_PAYMENT,
+        -> {
+            stringResource(R.string.reservation_cancel_dialog_desc_waiting_approval)
         }
 
         ReservationStatus.COMPLETED -> {
@@ -147,7 +160,7 @@ private fun getPartialRefundAnnotatedText(refundPercent: Int) =
 private fun ReservationCancelDialogWaitingApprovalPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.WAITING_APPROVAL,
-        refundReason = null,
+        refundCondition = RefundCondition.Within24Hours,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -159,8 +172,8 @@ private fun ReservationCancelDialogWaitingApprovalPreview() {
 @Composable
 private fun ReservationCancelDialogFullRefundPreview() {
     ReservationCancelDialog(
-        status = ReservationStatus.WAITING_PAYMENT,
-        refundReason = null,
+        status = ReservationStatus.RESERVED,
+        refundCondition = RefundCondition.Before7Days,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -173,7 +186,7 @@ private fun ReservationCancelDialogFullRefundPreview() {
 private fun ReservationCancelDialogPartialRefundPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.RESERVED,
-        refundReason = RefundReason.Before3Days,
+        refundCondition = RefundCondition.Before3Days,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
@@ -5,39 +5,41 @@ import com.hm.picplz.feature.reservation.R
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
-sealed class RefundReason(
+sealed class RefundCondition(
     val percent: Int,
     @StringRes val conditionResId: Int,
 ) {
-    data object Within24Hours : RefundReason(
+    data object Within24Hours : RefundCondition(
         percent = 100,
         conditionResId = R.string.refund_condition_within_24_hours,
     )
 
-    data object Before7Days : RefundReason(
+    data object Before7Days : RefundCondition(
         percent = 100,
         conditionResId = R.string.refund_condition_before_7_days,
     )
 
-    data object Before3Days : RefundReason(
+    data object Before3Days : RefundCondition(
         percent = 90,
         conditionResId = R.string.refund_condition_before_3_days,
     )
 
-    data object Before2Days : RefundReason(
+    data object Before2Days : RefundCondition(
         percent = 70,
         conditionResId = R.string.refund_condition_before_2_days,
     )
 
-    data object Before1Day : RefundReason(
+    data object Before1Day : RefundCondition(
         percent = 50,
         conditionResId = R.string.refund_condition_before_1_day,
     )
 
-    data object SameDay : RefundReason(
+    data object SameDay : RefundCondition(
         percent = 0,
         conditionResId = R.string.refund_condition_same_day,
     )
+
+    fun isFullRefund() = this == Within24Hours || this == Before7Days
 
     companion object {
         /**
@@ -55,7 +57,7 @@ sealed class RefundReason(
             currentDateTime: LocalDateTime,
             shootingDateTime: LocalDateTime,
             confirmedDateTime: LocalDateTime?,
-        ): RefundReason {
+        ): RefundCondition {
             // 촬영 확정 후 24시간 이내 체크
             confirmedDateTime?.let {
                 val hoursSinceConfirmed = ChronoUnit.HOURS.between(it, currentDateTime)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundReason.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundReason.kt
@@ -1,0 +1,83 @@
+package com.hm.picplz.ui.screen.detail_reservation.model
+
+import androidx.annotation.StringRes
+import com.hm.picplz.feature.reservation.R
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+sealed class RefundReason(
+    val percent: Int,
+    @StringRes val conditionResId: Int,
+) {
+    data object Within24Hours : RefundReason(
+        percent = 100,
+        conditionResId = R.string.refund_condition_within_24_hours,
+    )
+
+    data object Before7Days : RefundReason(
+        percent = 100,
+        conditionResId = R.string.refund_condition_before_7_days,
+    )
+
+    data object Before3Days : RefundReason(
+        percent = 90,
+        conditionResId = R.string.refund_condition_before_3_days,
+    )
+
+    data object Before2Days : RefundReason(
+        percent = 70,
+        conditionResId = R.string.refund_condition_before_2_days,
+    )
+
+    data object Before1Day : RefundReason(
+        percent = 50,
+        conditionResId = R.string.refund_condition_before_1_day,
+    )
+
+    data object SameDay : RefundReason(
+        percent = 0,
+        conditionResId = R.string.refund_condition_same_day,
+    )
+
+    companion object {
+        /**
+         * 환불 규정을 계산합니다.
+         *
+         * 환불 규정:
+         * - 촬영 확정 후 24시간 이내: 100%
+         * - 촬영일 기준 7일 전까지: 100%
+         * - 촬영일 기준 3일 전까지: 90%
+         * - 촬영일 기준 2일 전까지: 70%
+         * - 촬영일 기준 1일 전까지: 50%
+         * - 당일 취소: 0% (환불 불가)
+         */
+        fun calculate(
+            currentDateTime: LocalDateTime,
+            shootingDateTime: LocalDateTime,
+            confirmedDateTime: LocalDateTime?,
+        ): RefundReason {
+            // 촬영 확정 후 24시간 이내 체크
+            confirmedDateTime?.let {
+                val hoursSinceConfirmed = ChronoUnit.HOURS.between(it, currentDateTime)
+                if (hoursSinceConfirmed < 24) {
+                    return Within24Hours
+                }
+            }
+
+            // 촬영일까지 남은 일수 계산
+            val daysUntilShooting =
+                ChronoUnit.DAYS.between(
+                    currentDateTime.toLocalDate(),
+                    shootingDateTime.toLocalDate(),
+                )
+
+            return when {
+                daysUntilShooting >= 7 -> Before7Days
+                daysUntilShooting >= 3 -> Before3Days
+                daysUntilShooting >= 2 -> Before2Days
+                daysUntilShooting >= 1 -> Before1Day
+                else -> SameDay
+            }
+        }
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -26,4 +26,12 @@
     <string name="reservation_cancel_dialog_desc_partial_refund_suffix">가 환불됩니다.\n취소 후에는 이를 변경할 수 없어요.</string>
     <string name="reservation_cancel_dialog_button_no">아니오</string>
     <string name="reservation_cancel_dialog_button_yes">취소할래요</string>
+
+    <!-- 환불 조건 -->
+    <string name="refund_condition_within_24_hours">촬영 확정 후 24시간 이내</string>
+    <string name="refund_condition_before_7_days">촬영일 기준 7일 전까지</string>
+    <string name="refund_condition_before_3_days">촬영일 기준 3일 전까지</string>
+    <string name="refund_condition_before_2_days">촬영일 기준 2일 전까지</string>
+    <string name="refund_condition_before_1_day">촬영일 기준 1일 전까지</string>
+    <string name="refund_condition_same_day">당일 취소 or No-show</string>
 </resources>

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="reservation_cancel_dialog_desc_waiting_approval">결제 전에는 자유롭게 예약을\n취소할 수 있습니다.\n취소 후에는 이를 변경할 수 없어요.</string>
     <string name="reservation_cancel_dialog_desc_full_refund">취소 시 결제 금액이\n전액 환불됩니다. 취소 후에는 이를\n변경할 수 없어요.</string>
     <string name="reservation_cancel_dialog_desc_partial_refund">지금 취소하시면\n결제 금액의 %1$d%%가 환불됩니다.\n취소 후에는 이를 변경할 수 없어요.</string>
+    <string name="reservation_cancel_dialog_desc_partial_refund_prefix">지금 취소하시면\n</string>
+    <string name="reservation_cancel_dialog_desc_partial_refund_highlight">결제 금액의 %1$d%%</string>
+    <string name="reservation_cancel_dialog_desc_partial_refund_suffix">가 환불됩니다.\n취소 후에는 이를 변경할 수 없어요.</string>
     <string name="reservation_cancel_dialog_button_no">아니오</string>
     <string name="reservation_cancel_dialog_button_yes">취소할래요</string>
 </resources>

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -15,4 +15,12 @@
     <string name="reservation_button_chat">채팅 바로가기</string>
     <string name="reservation_button_history">내역 보기</string>
     <string name="reservation_button_confirm">거래 확정하기</string>
+
+    <!-- 예약 취소 다이얼로그 -->
+    <string name="reservation_cancel_dialog_title">예약을 취소하시겠습니까?</string>
+    <string name="reservation_cancel_dialog_desc_waiting_approval">결제 전에는 자유롭게 예약을\n취소할 수 있습니다.\n취소 후에는 이를 변경할 수 없어요.</string>
+    <string name="reservation_cancel_dialog_desc_full_refund">취소 시 결제 금액이\n전액 환불됩니다. 취소 후에는 이를\n변경할 수 없어요.</string>
+    <string name="reservation_cancel_dialog_desc_partial_refund">지금 취소하시면\n결제 금액의 %1$d%%가 환불됩니다.\n취소 후에는 이를 변경할 수 없어요.</string>
+    <string name="reservation_cancel_dialog_button_no">아니오</string>
+    <string name="reservation_cancel_dialog_button_yes">취소할래요</string>
 </resources>


### PR DESCRIPTION
# PR 초안: 예약 취소 다이얼로그 구현

## 개요
예약 상세 화면에서 예약 취소 시 환불 규정을 안내하는 다이얼로그를 구현했습니다. 촬영 확정 시점과 촬영일까지 남은 기간에 따라 환불 비율(100%, 90%, 70%, 50%, 0%)이 동적으로 계산되어 표시됩니다.

## 변경 사항
- **ReservationCancelDialog 컴포넌트 추가**
  - 예약 취소 확인 다이얼로그 UI 구현
  - 환불 비율 강조 표시 (빨간색)
  - 우측 상단 info 아이콘 추가 (환불 규정 상세 안내용)

- **환불 규정 계산 로직 구현**
  - `RefundCondition` sealed class 추가 (6가지 환불 조건)
  - 촬영 확정 후 24시간 이내: 100% 환불
  - 촬영일 기준 7일/3일/2일/1일 전: 100%/90%/70%/50% 환불
  - 당일 취소: 환불 불가
  - 다이얼로그 열 때마다 현재 시각 기준으로 환불 조건 재계산

- **MVI 패턴 적용**
  - `DetailReservationState`에 환불 조건 상태 추가
  - `DetailReservationIntent`에 다이얼로그 관련 Intent 추가
  - `DetailReservationViewModel`에서 환불 조건 계산 및 상태 관리

- **문자열 리소스 추가**
  - 다이얼로그 제목, 버튼, 설명 문구
  - 환불 조건별 안내 문구 (6가지)
  - 부분 환불 안내 문구 (강조 표시용으로 3개로 분리)


https://github.com/user-attachments/assets/3a40f3a3-4217-4551-926b-e1b7cc5781f0



## 파일 변경 사항
```
feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/
├── detail_reservation/
│   ├── DetailReservationIntent.kt      # ShowCancelDialog, DismissCancelDialog, ConfirmCancel Intent 추가
│   ├── DetailReservationScreen.kt      # 다이얼로그 연동
│   ├── DetailReservationState.kt       # shootingDateTime, confirmedDateTime, refundCondition 추가
│   ├── DetailReservationViewModel.kt   # 환불 조건 계산 로직
│   ├── composable/
│   │   └── ReservationCancelDialog.kt  # 새 파일: 다이얼로그 UI 컴포넌트
│   └── model/
│       └── RefundCondition.kt          # 새 파일: 환불 규정 sealed class + 계산 로직
└── main/res/values/strings.xml         # 다이얼로그 관련 문자열 19개 추가
```

## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #109
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 