### PR TITLE
✨ : 취소 수수료 규정 툴팁 다이얼로그 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ fabric.properties
 .DS_Store
 
 /.idea
+
+.claude/

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -72,6 +72,6 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
     }
 
     composable<DetailReservation> {
-        DetailReservationScreen()
+        DetailReservationScreen(onNavigateBack = { navController.popBackStack() })
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -12,4 +12,6 @@ sealed interface DetailReservationIntent {
     data object DismissCancelDialog : DetailReservationIntent
 
     data object ConfirmCancel : DetailReservationIntent
+
+    data object ToggleRefundPolicyTooltip : DetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -16,4 +16,6 @@ sealed interface DetailReservationIntent {
     data object ShowRefundPolicyDialog : DetailReservationIntent
 
     data object DismissRefundPolicyTooltip : DetailReservationIntent
+
+    data object NavigateBack : DetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -13,5 +13,7 @@ sealed interface DetailReservationIntent {
 
     data object ConfirmCancel : DetailReservationIntent
 
-    data object ToggleRefundPolicyTooltip : DetailReservationIntent
+    data object ShowRefundPolicyDialog : DetailReservationIntent
+
+    data object DismissRefundPolicyTooltip : DetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,10 +26,19 @@ import com.hm.picplz.ui.theme.MainThemeColor
 
 @Composable
 fun DetailReservationScreen(
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is DetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
+            }
+        }
+    }
 
     DetailReservationScreen(
         modifier = modifier,
@@ -57,6 +67,9 @@ fun DetailReservationScreen(
         onRefundPolicyDismiss = {
             viewModel.handelIntent(DetailReservationIntent.DismissRefundPolicyTooltip)
         },
+        onCloseClick = {
+            viewModel.handelIntent(DetailReservationIntent.NavigateBack)
+        },
     )
 }
 
@@ -71,6 +84,7 @@ private fun DetailReservationScreen(
     onCancelDialogConfirm: () -> Unit,
     onInfoClick: () -> Unit,
     onRefundPolicyDismiss: () -> Unit,
+    onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -100,7 +114,7 @@ private fun DetailReservationScreen(
                     Modifier
                         .fillMaxWidth()
                         .height(230.dp),
-                onCloseClick = {},
+                onCloseClick = onCloseClick,
             )
 
             LazyColumn(
@@ -154,5 +168,6 @@ private fun DetailReservationScreenPreview() {
         onCancelDialogConfirm = {},
         onInfoClick = {},
         onRefundPolicyDismiss = {},
+        onCloseClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -19,6 +19,7 @@ import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMa
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
 import com.hm.picplz.ui.theme.MainThemeColor
 
@@ -50,6 +51,9 @@ fun DetailReservationScreen(
         onCancelDialogConfirm = {
             viewModel.handelIntent(DetailReservationIntent.ConfirmCancel)
         },
+        onInfoClick = {
+            viewModel.handelIntent(DetailReservationIntent.ToggleRefundPolicyTooltip)
+        },
     )
 }
 
@@ -62,6 +66,7 @@ private fun DetailReservationScreen(
     onCancelClick: () -> Unit,
     onCancelDialogDismiss: () -> Unit,
     onCancelDialogConfirm: () -> Unit,
+    onInfoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -69,16 +74,18 @@ private fun DetailReservationScreen(
         containerColor = MainThemeColor.White,
     ) { innerPadding ->
         if (state.showCancelDialog) {
-            ReservationCancelDialog(
-                status = state.reservationStatus,
-                refundCondition = state.refundCondition,
-                onDismiss = onCancelDialogDismiss,
-                onCancel = onCancelDialogDismiss,
-                onConfirm = onCancelDialogConfirm,
-                onInfoClick = {
-                    // TODO: 환불 규정 툴팁 표시
-                },
-            )
+            if (state.showRefundPolicyTooltip) {
+                ReservationRefundPolicyDialog()
+            } else {
+                ReservationCancelDialog(
+                    status = state.reservationStatus,
+                    refundCondition = state.refundCondition,
+                    onDismiss = onCancelDialogDismiss,
+                    onCancel = onCancelDialogDismiss,
+                    onConfirm = onCancelDialogConfirm,
+                    onInfoClick = onInfoClick,
+                )
+            }
         }
 
         Column(modifier = Modifier.padding(innerPadding)) {
@@ -139,5 +146,6 @@ private fun DetailReservationScreenPreview() {
         onCancelClick = {},
         onCancelDialogDismiss = {},
         onCancelDialogConfirm = {},
+        onInfoClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -52,7 +52,10 @@ fun DetailReservationScreen(
             viewModel.handelIntent(DetailReservationIntent.ConfirmCancel)
         },
         onInfoClick = {
-            viewModel.handelIntent(DetailReservationIntent.ToggleRefundPolicyTooltip)
+            viewModel.handelIntent(DetailReservationIntent.ShowRefundPolicyDialog)
+        },
+        onRefundPolicyDismiss = {
+            viewModel.handelIntent(DetailReservationIntent.DismissRefundPolicyTooltip)
         },
     )
 }
@@ -67,6 +70,7 @@ private fun DetailReservationScreen(
     onCancelDialogDismiss: () -> Unit,
     onCancelDialogConfirm: () -> Unit,
     onInfoClick: () -> Unit,
+    onRefundPolicyDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -74,18 +78,20 @@ private fun DetailReservationScreen(
         containerColor = MainThemeColor.White,
     ) { innerPadding ->
         if (state.showCancelDialog) {
-            if (state.showRefundPolicyTooltip) {
-                ReservationRefundPolicyDialog()
-            } else {
-                ReservationCancelDialog(
-                    status = state.reservationStatus,
-                    refundCondition = state.refundCondition,
-                    onDismiss = onCancelDialogDismiss,
-                    onCancel = onCancelDialogDismiss,
-                    onConfirm = onCancelDialogConfirm,
-                    onInfoClick = onInfoClick,
-                )
-            }
+            ReservationCancelDialog(
+                status = state.reservationStatus,
+                refundCondition = state.refundCondition,
+                onDismiss = onCancelDialogDismiss,
+                onCancel = onCancelDialogDismiss,
+                onConfirm = onCancelDialogConfirm,
+                onInfoClick = onInfoClick,
+            )
+        }
+
+        if (state.showRefundPolicyTooltip) {
+            ReservationRefundPolicyDialog(
+                onDismissRequest = onRefundPolicyDismiss,
+            )
         }
 
         Column(modifier = Modifier.padding(innerPadding)) {
@@ -147,5 +153,6 @@ private fun DetailReservationScreenPreview() {
         onCancelDialogDismiss = {},
         onCancelDialogConfirm = {},
         onInfoClick = {},
+        onRefundPolicyDismiss = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
@@ -1,3 +1,5 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
-sealed interface DetailReservationSideEffect
+sealed interface DetailReservationSideEffect {
+    data object NavigateToPrev : DetailReservationSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -9,5 +9,6 @@ data class DetailReservationState(
     val showCancelDialog: Boolean = false,
     val shootingDateTime: LocalDateTime = LocalDateTime.now(),
     val confirmedDateTime: LocalDateTime = LocalDateTime.now(),
-    val refundCondition: RefundCondition = RefundCondition.Within24Hours,
+    val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
+    val showRefundPolicyTooltip: Boolean = false,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -1,12 +1,16 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -14,6 +18,9 @@ import javax.inject.Inject
 class DetailReservationViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow(DetailReservationState())
     val state: StateFlow<DetailReservationState> get() = _state
+
+    private val _sideEffect = MutableSharedFlow<DetailReservationSideEffect>()
+    val sideEffect: SharedFlow<DetailReservationSideEffect> get() = _sideEffect
 
     init {
         // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
@@ -80,6 +87,12 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                         showRefundPolicyTooltip = false,
                         showCancelDialog = true,
                     )
+                }
+            }
+
+            is DetailReservationIntent.NavigateBack -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(DetailReservationSideEffect.NavigateToPrev)
                 }
             }
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -65,8 +65,22 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                 // TODO: 예약 취소 API 호출
             }
 
-            is DetailReservationIntent.ToggleRefundPolicyTooltip -> {
-                _state.update { it.copy(showRefundPolicyTooltip = !it.showRefundPolicyTooltip) }
+            is DetailReservationIntent.ShowRefundPolicyDialog -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = true,
+                        showCancelDialog = false,
+                    )
+                }
+            }
+
+            is DetailReservationIntent.DismissRefundPolicyTooltip -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = false,
+                        showCancelDialog = true,
+                    )
+                }
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -64,6 +64,10 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                 _state.update { it.copy(showCancelDialog = false) }
                 // TODO: 예약 취소 API 호출
             }
+
+            is DetailReservationIntent.ToggleRefundPolicyTooltip -> {
+                _state.update { it.copy(showRefundPolicyTooltip = !it.showRefundPolicyTooltip) }
+            }
         }
     }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/RefundPolicyTable.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/RefundPolicyTable.kt
@@ -59,7 +59,7 @@ fun RefundPolicyTable(modifier: Modifier = Modifier) {
         }
 
         // 각 행
-        RefundCondition.allCases.forEach { condition ->
+        RefundCondition.entries.forEach { condition ->
             HorizontalDivider(color = MainThemeColor.Gray3, thickness = 1.dp)
 
             Row(

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/RefundPolicyTable.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/RefundPolicyTable.kt
@@ -1,0 +1,131 @@
+package com.hm.picplz.ui.screen.detail_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
+import com.hm.picplz.ui.theme.MainFontFamily.buttonChat
+import com.hm.picplz.ui.theme.MainFontFamily.caption
+import com.hm.picplz.ui.theme.MainThemeColor
+
+@Composable
+fun RefundPolicyTable(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .border(
+                    width = 1.dp,
+                    color = MainThemeColor.Gray3,
+                    shape = RoundedCornerShape(8.dp),
+                ),
+    ) {
+        // 헤더
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Max)
+                    .background(MainThemeColor.Black),
+        ) {
+            TableHeaderCell(
+                text = stringResource(R.string.refund_policy_table_header_period),
+                weight = 0.6f,
+            )
+            TableHeaderCell(
+                text = stringResource(R.string.refund_policy_table_header_refund),
+                weight = 0.4f,
+            )
+        }
+
+        // 각 행
+        RefundCondition.allCases.forEach { condition ->
+            HorizontalDivider(color = MainThemeColor.Gray3, thickness = 1.dp)
+
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Max),
+            ) {
+                TableCell(
+                    text = stringResource(condition.conditionResId),
+                    weight = 0.6f,
+                )
+                VerticalDivider(color = MainThemeColor.Gray3, thickness = 1.dp)
+                TableCell(
+                    text =
+                        if (condition.percent == 0) {
+                            stringResource(R.string.refund_policy_no_refund)
+                        } else {
+                            "${condition.percent}%"
+                        },
+                    weight = 0.4f,
+                    textColor = Color(0xFFFF7E7E),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.TableHeaderCell(
+    text: String,
+    weight: Float,
+    textColor: Color = MainThemeColor.White,
+) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .weight(weight)
+                .padding(vertical = 12.dp, horizontal = 8.dp),
+        color = textColor,
+        style = buttonChat,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+private fun RowScope.TableCell(
+    text: String,
+    weight: Float,
+    textColor: Color = MainThemeColor.Gray4,
+) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .weight(weight)
+                .padding(vertical = 12.dp, horizontal = 8.dp),
+        color = textColor,
+        style = caption,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Preview
+@Composable
+private fun RefundPolicyTablePreview() {
+    RefundPolicyTable()
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -119,8 +119,8 @@ private fun getDescriptionText(
     when (status) {
         ReservationStatus.RESERVED -> {
             when (refundCondition) {
-                RefundCondition.Within24Hours,
-                RefundCondition.Before7Days,
+                RefundCondition.WITHIN_24_HOURS,
+                RefundCondition.BEFORE_7_DAYS,
                 -> {
                     stringResource(R.string.reservation_cancel_dialog_desc_full_refund)
                 }
@@ -160,7 +160,7 @@ private fun getPartialRefundAnnotatedText(refundPercent: Int) =
 private fun ReservationCancelDialogWaitingApprovalPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.WAITING_APPROVAL,
-        refundCondition = RefundCondition.Within24Hours,
+        refundCondition = RefundCondition.WITHIN_24_HOURS,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -173,7 +173,7 @@ private fun ReservationCancelDialogWaitingApprovalPreview() {
 private fun ReservationCancelDialogFullRefundPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.RESERVED,
-        refundCondition = RefundCondition.Before7Days,
+        refundCondition = RefundCondition.BEFORE_7_DAYS,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},
@@ -186,7 +186,7 @@ private fun ReservationCancelDialogFullRefundPreview() {
 private fun ReservationCancelDialogPartialRefundPreview() {
     ReservationCancelDialog(
         status = ReservationStatus.RESERVED,
-        refundCondition = RefundCondition.Before3Days,
+        refundCondition = RefundCondition.BEFORE_3_DAYS,
         onDismiss = {},
         onCancel = {},
         onConfirm = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationRefundPolicyDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationRefundPolicyDialog.kt
@@ -1,0 +1,75 @@
+package com.hm.picplz.ui.screen.detail_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.pretendardTypography
+import com.hm.picplz.feature.reservation.R as ReservationResource
+
+@Composable
+fun ReservationRefundPolicyDialog(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier =
+                modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MainThemeColor.White)
+                    .padding(
+                        top = 10.dp,
+                        bottom = 20.dp,
+                    ),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.triangle_left),
+                contentDescription = "arrow left",
+                modifier =
+                    Modifier
+                        .padding(start = 10.dp)
+                        .size(18.dp)
+                        .clickable { onDismissRequest() },
+            )
+
+            Text(
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+                text = stringResource(ReservationResource.string.refund_policy_table_title),
+                style = pretendardTypography.titleSmall,
+                color = MainThemeColor.Black,
+            )
+            RefundPolicyTable(
+                modifier =
+                    Modifier
+                        .padding(horizontal = 20.dp)
+                        .fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ReservationRefundPolicyDialogPreview() {
+    ReservationRefundPolicyDialog(
+        onDismissRequest = {},
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
@@ -43,6 +43,19 @@ sealed class RefundCondition(
 
     companion object {
         /**
+         * 모든 환불 조건 목록 (툴팁 테이블 표시용)
+         */
+        val allCases: List<RefundCondition> =
+            listOf(
+                Within24Hours,
+                Before7Days,
+                Before3Days,
+                Before2Days,
+                Before1Day,
+                SameDay,
+            )
+
+        /**
          * 환불 규정을 계산합니다.
          *
          * 환불 규정:

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
@@ -5,56 +5,44 @@ import com.hm.picplz.feature.reservation.R
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
-sealed class RefundCondition(
+enum class RefundCondition(
     val percent: Int,
     @StringRes val conditionResId: Int,
 ) {
-    data object Within24Hours : RefundCondition(
+    WITHIN_24_HOURS(
         percent = 100,
         conditionResId = R.string.refund_condition_within_24_hours,
-    )
+    ),
 
-    data object Before7Days : RefundCondition(
+    BEFORE_7_DAYS(
         percent = 100,
         conditionResId = R.string.refund_condition_before_7_days,
-    )
+    ),
 
-    data object Before3Days : RefundCondition(
+    BEFORE_3_DAYS(
         percent = 90,
         conditionResId = R.string.refund_condition_before_3_days,
-    )
+    ),
 
-    data object Before2Days : RefundCondition(
+    BEFORE_2_DAYS(
         percent = 70,
         conditionResId = R.string.refund_condition_before_2_days,
-    )
+    ),
 
-    data object Before1Day : RefundCondition(
+    BEFORE_1_DAY(
         percent = 50,
         conditionResId = R.string.refund_condition_before_1_day,
-    )
+    ),
 
-    data object SameDay : RefundCondition(
+    SAME_DAY(
         percent = 0,
         conditionResId = R.string.refund_condition_same_day,
-    )
+    ),
+    ;
 
-    fun isFullRefund() = this == Within24Hours || this == Before7Days
+    fun isFullRefund() = this == WITHIN_24_HOURS || this == BEFORE_7_DAYS
 
     companion object {
-        /**
-         * 모든 환불 조건 목록 (툴팁 테이블 표시용)
-         */
-        val allCases: List<RefundCondition> =
-            listOf(
-                Within24Hours,
-                Before7Days,
-                Before3Days,
-                Before2Days,
-                Before1Day,
-                SameDay,
-            )
-
         /**
          * 환불 규정을 계산합니다.
          *
@@ -75,7 +63,7 @@ sealed class RefundCondition(
             confirmedDateTime?.let {
                 val hoursSinceConfirmed = ChronoUnit.HOURS.between(it, currentDateTime)
                 if (hoursSinceConfirmed < 24) {
-                    return Within24Hours
+                    return WITHIN_24_HOURS
                 }
             }
 
@@ -87,11 +75,11 @@ sealed class RefundCondition(
                 )
 
             return when {
-                daysUntilShooting >= 7 -> Before7Days
-                daysUntilShooting >= 3 -> Before3Days
-                daysUntilShooting >= 2 -> Before2Days
-                daysUntilShooting >= 1 -> Before1Day
-                else -> SameDay
+                daysUntilShooting >= 7 -> BEFORE_7_DAYS
+                daysUntilShooting >= 3 -> BEFORE_3_DAYS
+                daysUntilShooting >= 2 -> BEFORE_2_DAYS
+                daysUntilShooting >= 1 -> BEFORE_1_DAY
+                else -> SAME_DAY
             }
         }
     }

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -34,4 +34,10 @@
     <string name="refund_condition_before_2_days">촬영일 기준 2일 전까지</string>
     <string name="refund_condition_before_1_day">촬영일 기준 1일 전까지</string>
     <string name="refund_condition_same_day">당일 취소 or No-show</string>
+
+    <!-- 환불 규정 테이블 -->
+    <string name="refund_policy_table_title">예약 취소 수수료 안내</string>
+    <string name="refund_policy_table_header_period">기한</string>
+    <string name="refund_policy_table_header_refund">환불 금액</string>
+    <string name="refund_policy_no_refund">환불 불가</string>
 </resources>


### PR DESCRIPTION
## 개요
예약 취소 다이얼로그에 환불 규정 안내 기능을 추가하고, 촬영까지의 남은 기간에 따라 동적으로 환불 조건을 계산하는 기능을 구현했습니다.

## 변경 사항
- **예약 취소 다이얼로그 UI**: 취소 다이얼로그에 info 아이콘을 추가하고, 클릭 시 환불 규정 테이블을 표시하는 기능 구현
- **환불 규정 테이블**: 6가지 환불 조건(촬영 확정 후 24시간, 촬영일 7일 전 등)과 환불 비율을 표시하는 테이블 컴포넌트 추가
- **동적 환불 조건 계산**: RefundCondition enum class를 통해 현재 시간과 촬영 예정일을 기반으로 환불 비율을 자동으로 계산
- **상태 관리**: State/Intent/ViewModel을 확장하여 환불 규정 툴팁 표시 여부를 관리
- **네비게이션**: 상세 화면의 닫기 버튼 클릭 시 이전 화면으로 돌아가는 SideEffect 기반 네비게이션 처리

[Screen_recording_20260311_123118.webm](https://github.com/user-attachments/assets/fa325c91-4e3a-492c-90f4-55702dac7bdd)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #110
