### PR TITLE
✨ 작가 상세 API 엔드포인트 추가 (core:data)

### DIFF
--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
@@ -4,6 +4,8 @@ import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotographerDetailDto
 import com.hm.picplz.data.model.PhotographerRatingDto
+import com.hm.picplz.data.model.PortfolioDto
+import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ReviewListDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -42,4 +44,14 @@ interface PhotographerApi {
         @Query("size") size: Int = 10,
         @Query("sort") sort: String = "RECOMMENDED",
     ): Response<ReviewListDto>
+
+    @GET("api/v1/photographers/{photographerId}/products")
+    suspend fun getPhotographerProducts(
+        @Path("photographerId") photographerId: Long,
+    ): Response<List<ProductDto>>
+
+    @GET("api/v1/portfolios/{portfolioId}")
+    suspend fun getPortfolio(
+        @Path("portfolioId") portfolioId: Long,
+    ): Response<PortfolioDto>
 }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/ProductDto.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/ProductDto.kt
@@ -1,0 +1,25 @@
+package com.hm.picplz.data.model
+
+data class ProductDto(
+    val productId: Long,
+    val title: String?,
+    val price: Int?,
+    val description: String?,
+    val shootingTime: String?,
+    val imageUrl: String?,
+)
+
+data class PortfolioDto(
+    val portfolioId: Long,
+    val photos: List<PortfolioPhotoDto>?,
+    val location: String?,
+    val uploadDate: String?,
+    val scrapCount: Long?,
+    val scrapYN: Boolean?,
+)
+
+data class PortfolioPhotoDto(
+    val portfolioPhotoId: Long?,
+    val image: String?,
+    val photoOrder: Int?,
+)

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -5,6 +5,8 @@ import com.hm.picplz.data.mapper.toPhotographerInfo
 import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.PhotographerInfo
 import com.hm.picplz.data.model.PhotographerRatingDto
+import com.hm.picplz.data.model.PortfolioDto
+import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.source.PhotographerSource
 import com.hm.picplz.domain.model.FilteredPhotographers
@@ -29,6 +31,10 @@ interface PhotographerService {
         size: Int = 10,
         sort: String = "RECOMMENDED",
     ): Result<ReviewListDto>
+
+    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>>
+
+    suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto>
 }
 
 class PhotographerServiceImpl
@@ -65,4 +71,10 @@ class PhotographerServiceImpl
             size: Int,
             sort: String,
         ): Result<ReviewListDto> = photographerSource.getPhotographerReviews(photographerId, page, size, sort)
+
+        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+            photographerSource.getPhotographerProducts(photographerId)
+
+        override suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto> =
+            photographerSource.getPortfolio(portfolioId)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
@@ -5,6 +5,8 @@ import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotographerDetailDto
 import com.hm.picplz.data.model.PhotographerRatingDto
+import com.hm.picplz.data.model.PortfolioDto
+import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.util.safeApiCall
 import com.hm.picplz.data.util.safeApiCallUnit
@@ -29,6 +31,10 @@ interface PhotographerSource {
         size: Int = 10,
         sort: String = "RECOMMENDED",
     ): Result<ReviewListDto>
+
+    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>>
+
+    suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto>
 }
 
 class PhotographerSourceImpl
@@ -59,4 +65,10 @@ class PhotographerSourceImpl
             sort: String,
         ): Result<ReviewListDto> =
             safeApiCall { photographerApi.getPhotographerReviews(photographerId, page, size, sort) }
+
+        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+            safeApiCall { photographerApi.getPhotographerProducts(photographerId) }
+
+        override suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto> =
+            safeApiCall { photographerApi.getPortfolio(portfolioId) }
     }


### PR DESCRIPTION
## 관련 이슈
closes #122

## 변경 사항

### 신규 엔드포인트
- `GET /photographers/{id}/products` — 촬영 패키지 목록
- `GET /portfolios/{id}` — 포트폴리오 단건 조회

### 신규 모델
- `ProductDto`: productId, title, price, description, shootingTime, imageUrl
- `PortfolioDto`: portfolioId, photos, location, uploadDate, scrapCount, scrapYN
- `PortfolioPhotoDto`: portfolioPhotoId, image, photoOrder

### 레이어 추가
- `PhotographerApi`: 엔드포인트 2개 추가
- `PhotographerSource`: 메서드 2개 추가
- `PhotographerService`: 메서드 2개 추가

## 참고
- ViewModel 연결 없음 (별도 이슈 #123)
- `GET /photographers/{id}/portfolios` (목록)은 백엔드 미구현
- `products` Swagger 문서가 부정확 (`Detail` 스키마로 기재) → ProductDto는 합리적 추정 기반, 실제 테스트 후 조정 필요