### PR TITLE
✨ 작가 상세 페이지 차단 계정 배너 UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ core:ui → core:common
 ### Issue-Driven Development
 1. **모든 작업은 GitHub Issue 기반** - 이슈 먼저 생성/확인 후 작업 시작
 2. **1 Issue = 1 Branch = 1 PR** - 이슈와 브랜치, PR이 1:1 대응
+3. **커밋/푸시/PR 생성 전 반드시 사용자 확인** - 임의로 올리지 않는다
 
 ### Branch Strategy
 ```

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -149,6 +149,7 @@ fun DevScreen(navController: NavHostController) {
             // === Detail Photographer ===
             SectionTitle("Detail Photographer")
             DevButton("DetailPhotographer") { navController.navigate(DetailPhotographer(1)) }
+            DevButton("DetailPhotographer (차단)") { navController.navigate(DetailPhotographer(-1)) }
             DevButton("ReviewPhotographer") { navController.navigate(ReviewPhotographer(1)) }
             DevButton("DetailPhotographerPhotoReviews") {
                 navController.navigate(

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/BlockedBanner.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/BlockedBanner.kt
@@ -39,7 +39,7 @@ fun BlockedBanner(
         Spacer(modifier = Modifier.weight(1f))
         Text(
             text = stringResource(R.string.unblock_button),
-            style = MainThemeFont.Caption,
+            style = MainThemeFont.Body,
             color = Color.White,
             modifier = Modifier.clickable { onUnblock() },
         )

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/BlockedBanner.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/BlockedBanner.kt
@@ -1,0 +1,47 @@
+package com.hm.picplz.ui.screen.detail_photographer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.photographer.R
+import com.hm.picplz.ui.theme.MainThemeFont
+
+private val BannerRed = Color(0xFFE53935)
+
+@Composable
+fun BlockedBanner(
+    onUnblock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(BannerRed)
+                .padding(horizontal = 15.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.blocked_account_message),
+            style = MainThemeFont.BodyBold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(R.string.unblock_button),
+            style = MainThemeFont.Caption,
+            color = Color.White,
+            modifier = Modifier.clickable { onUnblock() },
+        )
+    }
+}

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
@@ -6,4 +6,6 @@ sealed interface DetailPhotographerIntent {
     data object ToggleFollow : DetailPhotographerIntent
 
     data object ToggleInfoExpanded : DetailPhotographerIntent
+
+    data object ToggleBlock : DetailPhotographerIntent
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
@@ -87,6 +87,14 @@ fun DetailPhotographerScreen(
                         .fillMaxWidth()
                         .verticalScroll(rememberScrollState()),
             ) {
+                if (state.isBlocked) {
+                    BlockedBanner(
+                        onUnblock = {
+                            viewModel.handleIntent(DetailPhotographerIntent.ToggleBlock)
+                        },
+                    )
+                }
+
                 DetailProfileSection(
                     modifier = paddingModifier,
                     profileInfo = state.profileInfo,

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
@@ -19,10 +19,15 @@ data class DetailPhotographerState(
     val shootingPackages: List<ShootingPackage> = mockShootingPackages,
     val isFollow: Boolean = mockPhotographerInfo.isFollow,
     val isInfoExpanded: Boolean = false,
+    val isBlocked: Boolean = false,
 ) {
     companion object {
         fun idle(): DetailPhotographerState {
             return DetailPhotographerState()
+        }
+
+        fun blocked(): DetailPhotographerState {
+            return DetailPhotographerState(isBlocked = true)
         }
     }
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
@@ -22,7 +22,13 @@ open class DetailPhotographerViewModel
     ) : ViewModel() {
         val photographerId: Int = savedStateHandle.get<Int>("photographerId") ?: 0
 
-        private val _state = MutableStateFlow(DetailPhotographerState.idle())
+        private val _state = MutableStateFlow(
+            if (photographerId == DEV_BLOCKED_PHOTOGRAPHER_ID) {
+                DetailPhotographerState.blocked()
+            } else {
+                DetailPhotographerState.idle()
+            },
+        )
         val state: StateFlow<DetailPhotographerState> = _state
 
         private val _sideEffect = Channel<DetailPhotographerSideEffect>(Channel.BUFFERED)
@@ -45,7 +51,14 @@ open class DetailPhotographerViewModel
                 is DetailPhotographerIntent.ToggleInfoExpanded -> {
                     _state.update { it.copy(isInfoExpanded = !it.isInfoExpanded) }
                 }
+                is DetailPhotographerIntent.ToggleBlock -> {
+                    _state.update { it.copy(isBlocked = !it.isBlocked) }
+                }
             }
+        }
+
+        companion object {
+            const val DEV_BLOCKED_PHOTOGRAPHER_ID = -1
         }
 
         private fun loadPhotographerInfo() {

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -28,4 +28,8 @@
     <string name="quick_shoot_empty_char_desc">주변 작가 없음 캐릭터</string>
     <string name="quick_shoot_empty_guide_prefix">다른 지역으로</string>
     <string name="quick_shoot_empty_guide_suffix">이동해 보는 건 어때요?</string>
+
+    <!-- 작가 상세 - 차단 배너 -->
+    <string name="blocked_account_message">차단된 계정입니다.</string>
+    <string name="unblock_button">차단 해제</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
closes #125

## 변경 사항

### 신규 컴포넌트
- `BlockedBanner`: 빨간 배너 ('차단된 계정입니다.' + '차단 해제' 버튼)
- TopBar 아래, 콘텐츠 위에 위치

### MVI
- `DetailPhotographerState`: `isBlocked: Boolean` 추가
- `DetailPhotographerIntent`: `ToggleBlock` 추가
- `DetailPhotographerViewModel`: ToggleBlock 핸들러

### 문자열
- `blocked_account_message`: 차단된 계정입니다.
- `unblock_button`: 차단 해제
<img width="315" alt="image" src="https://github.com/user-attachments/assets/dcda6127-6970-4f8c-9e73-848223bbdcb4" />

## 참고
- mockdata 기반 (`isBlocked = false` 기본값)
- 차단 API 연동은 별도
- #120 UI PR과 독립 (develop 기준)