### PR TITLE
✨ 리뷰 페이지 피그마 디자인 반영

### DIFF
--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.ui.screen.detail_photographer
 
+import com.hm.picplz.ui.screen.detail_photographer.review.ReviewSortType
+
 sealed interface DetailPhotographerIntent {
     data object NavigateToPrev : DetailPhotographerIntent
 
@@ -8,4 +10,8 @@ sealed interface DetailPhotographerIntent {
     data object ToggleInfoExpanded : DetailPhotographerIntent
 
     data object ToggleBlock : DetailPhotographerIntent
+
+    data class SelectReviewSort(val sortType: ReviewSortType) : DetailPhotographerIntent
+
+    data object ToggleSortSheet : DetailPhotographerIntent
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerReviewScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerReviewScreen.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.detail_photographer
 
-import CommonChip
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,11 +21,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,38 +38,32 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.navigation.model.DetailPhotographerPhotoReviews
-import com.hm.picplz.ui.screen.common.CommonDropdownMenu
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
 import com.hm.picplz.ui.screen.common.CommonIconButton
-import com.hm.picplz.ui.screen.common.DropdownMenuItemData
-import com.hm.picplz.ui.screen.detail_photographer.review.ReviewBars
+import com.hm.picplz.ui.screen.detail_photographer.review.ReviewSortBottomSheet
 import com.hm.picplz.ui.screen.detail_photographer.review.SingleReview
 import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
-import com.hm.picplz.ui.theme.buttonText
-import com.hm.picplz.ui.theme.pretendardTypography
 import com.hm.picplz.ui.util.ReviewUtil
 import com.hm.picplz.ui.util.StarType
 import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.feature.photographer.R as PhotographerR
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 fun DetailPhotographerReviewScreen(
     navController: NavController,
     photographerId: Int,
     viewModel: DetailPhotographerViewModel = hiltViewModel(),
 ) {
-    val currentState = viewModel.state.collectAsState().value
+    val state by viewModel.state.collectAsState()
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
 
-    val reviewSummary = currentState.reviewSummary
-    val reviews = currentState.reviews
-
+    val reviewSummary = state.reviewSummary
+    val reviews = state.reviews
     val totalRating = reviewSummary.averageRating
     val starList = ReviewUtil.calculateStarRating(totalRating, StarType.MAIN)
-
     val images = reviewSummary.photoReviews
-    val reviewBarItems = reviewSummary.keywordBars
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -80,117 +75,78 @@ fun DetailPhotographerReviewScreen(
                         .padding(innerPadding)
                         .fillMaxWidth(),
             ) {
-                CommonFixedTopBar(title = "리뷰") {
+                CommonFixedTopBar(
+                    title = stringResource(PhotographerR.string.review_title),
+                ) {
                     viewModel.handleIntent(DetailPhotographerIntent.NavigateToPrev)
                 }
 
                 Column(
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                 ) {
-                    Column(modifier = paddingModifier) {
+                    Column(
+                        modifier = paddingModifier.padding(top = 20.dp),
+                    ) {
+                        // 촬영 만족도 + 별
+                        Text(
+                            text =
+                                stringResource(
+                                    PhotographerR.string.shooting_satisfaction,
+                                ),
+                            style = MainThemeFont.TitleSmall,
+                            color = MainThemeColor.Black,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(text = "촬영 만족도", style = buttonText)
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                starList.forEach { star ->
-                                    Image(
-                                        painter = painterResource(id = star),
-                                        contentDescription = "별점",
-                                    )
-                                }
-                                Spacer(modifier = Modifier.width(3.dp))
-                                Text(
-                                    text = totalRating.toString(),
-                                    style = pretendardTypography.labelLarge,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = MainThemeColor.Gray4,
+                            starList.forEach { star ->
+                                Image(
+                                    painter = painterResource(id = star),
+                                    contentDescription =
+                                        stringResource(
+                                            PhotographerR.string.star_rating,
+                                        ),
+                                    modifier = Modifier.height(20.dp),
                                 )
                             }
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = totalRating.toString(),
+                                style = MainThemeFont.BodyBold,
+                                color = MainThemeColor.Gray4,
+                            )
                         }
 
-                        Spacer(modifier = Modifier.height(11.dp))
+                        Spacer(modifier = Modifier.height(20.dp))
 
-                        ReviewBars(items = reviewBarItems)
-
-                        Spacer(modifier = Modifier.height(28.dp))
-
+                        // 리뷰 N
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(text = "리뷰", style = buttonText)
-                            Spacer(modifier = Modifier.width(4.dp)) // 텍스트 사이에 간격 추가
-                            Text(text = reviewSummary.totalReviewCount.toString())
+                            Text(
+                                text = stringResource(PhotographerR.string.review_title),
+                                style = MainThemeFont.ButtonDefault,
+                                color = MainThemeColor.Black,
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = reviewSummary.totalReviewCount.toString(),
+                                style = MainThemeFont.Body,
+                                color = MainThemeColor.Gray3,
+                            )
                         }
 
                         Spacer(modifier = Modifier.height(9.dp))
 
-                        // 리뷰 사진 모아보기
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(2.dp),
-                        ) {
-                            images.take(3).forEach { image ->
-                                Image(
-                                    painter = rememberAsyncImagePainter(model = image.photoReviewUri),
-                                    contentDescription = "리뷰 사진",
-                                    modifier =
-                                        Modifier
-                                            .weight(1f)
-                                            .aspectRatio(1f),
-                                    contentScale = ContentScale.Crop,
+                        // 리뷰 사진 그리드
+                        ReviewPhotoGrid(
+                            images = images.map { it.photoReviewUri },
+                            onShowAll = {
+                                navController.navigate(
+                                    DetailPhotographerPhotoReviews(photographerId),
                                 )
-                            }
-
-                            // 4개 이상일 경우 마지막 사진에 원본 이미지 + 어두운 오버레이 + "+N" 표시
-                            if (images.size > 4) {
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .weight(1f)
-                                            .aspectRatio(1f)
-                                            .clickable {
-                                                navController.navigate(DetailPhotographerPhotoReviews(photographerId))
-                                            },
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    // 원본 이미지
-                                    Image(
-                                        painter = rememberAsyncImagePainter(model = images[3].photoReviewUri),
-                                        contentDescription = "리뷰 사진",
-                                        modifier =
-                                            Modifier
-                                                .matchParentSize()
-                                                .drawWithContent {
-                                                    drawContent()
-                                                    drawRect(
-                                                        color = MainThemeColor.Black.copy(alpha = 0.5f),
-                                                        size = size,
-                                                    )
-                                                },
-                                        contentScale = ContentScale.Crop,
-                                    )
-
-                                    // "+N" 텍스트 오버레이
-                                    Text(
-                                        text = "+${images.size - 4}",
-                                        color = MainThemeColor.White,
-                                        fontWeight = FontWeight.Bold,
-                                        fontSize = 20.sp,
-                                    )
-                                }
-                            } else if (images.size == 4) {
-                                Image(
-                                    painter = rememberAsyncImagePainter(model = images[3]),
-                                    contentDescription = "리뷰 사진",
-                                    modifier =
-                                        Modifier
-                                            .weight(1f)
-                                            .aspectRatio(1f),
-                                    contentScale = ContentScale.Crop,
-                                )
-                            }
-                        }
+                            },
+                        )
                     }
 
                     HorizontalDivider(
@@ -199,51 +155,52 @@ fun DetailPhotographerReviewScreen(
                                 .fillMaxWidth()
                                 .padding(vertical = 20.dp),
                         thickness = 10.dp,
-                        color = MainThemeColor.Gray2,
+                        color = MainThemeColor.Gray1,
                     )
 
                     Column(modifier = paddingModifier) {
-                        // chip 필터링
-                        // TODO: 디자인 적용
-                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                            CommonChip(label = "프로필 Only", isSelected = true, isEditable = false)
-                            CommonChip(label = "카카오톡 패키지", isSelected = false, isEditable = false)
-                            CommonChip(label = "인스타그램 패키지", isSelected = false, isEditable = false)
-                        }
-
-                        Spacer(modifier = Modifier.height(14.dp))
-
-                        // 추천순 / 최신순
-                        CommonDropdownMenu(
-                            initialSelectedText = "최신순",
-                            triggerButton = { label ->
-                                CommonIconButton(
-                                    label = label,
-                                    backgroundColor = MainThemeColor.Transparent,
-                                    textColor = MainThemeColor.Gray5,
-                                    textStyle = pretendardTypography.bodySmall,
-                                    iconResId = R.drawable.arrow_down,
-                                    location = "right",
-                                    horizontalPadding = 0.dp,
-                                    verticalPadding = 0.dp,
-                                    gap = 4.dp,
-                                    borderRadius = 10.dp,
+                        // 정렬 버튼
+                        CommonIconButton(
+                            label = state.reviewSortType.label,
+                            backgroundColor = MainThemeColor.Transparent,
+                            textColor = MainThemeColor.Gray5,
+                            textStyle = MainThemeFont.Caption,
+                            iconResId = R.drawable.arrow_down,
+                            iconSize = 12.dp,
+                            location = "right",
+                            horizontalPadding = 0.dp,
+                            verticalPadding = 0.dp,
+                            gap = 2.dp,
+                            onClick = {
+                                viewModel.handleIntent(
+                                    DetailPhotographerIntent.ToggleSortSheet,
                                 )
                             },
-                            menuItems =
-                                listOf(
-                                    DropdownMenuItemData("추천순", MainThemeColor.Gray5, itemOnClick = {}),
-                                    DropdownMenuItemData("최신순", MainThemeColor.Gray5),
-                                ),
+                            modifier =
+                                Modifier.padding(top = 20.dp, bottom = 8.dp),
                         )
 
-                        // 리스트 형식 (싱글 리뷰)
+                        // 리뷰 리스트
                         reviews.forEach { item ->
                             SingleReview(navController, item)
                         }
                     }
                 }
             }
+        },
+    )
+
+    // 정렬 바텀시트
+    ReviewSortBottomSheet(
+        visible = state.isSortSheetVisible,
+        selectedSortType = state.reviewSortType,
+        onDismiss = {
+            viewModel.handleIntent(DetailPhotographerIntent.ToggleSortSheet)
+        },
+        onSelect = { sortType ->
+            viewModel.handleIntent(
+                DetailPhotographerIntent.SelectReviewSort(sortType),
+            )
         },
     )
 
@@ -258,12 +215,85 @@ fun DetailPhotographerReviewScreen(
     }
 }
 
+@Composable
+private fun ReviewPhotoGrid(
+    images: List<String>,
+    onShowAll: () -> Unit,
+) {
+    if (images.isEmpty()) return
+
+    val hasOverflow = images.size > 4
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        images.take(minOf(3, images.size)).forEach { imageUri ->
+            Image(
+                painter = rememberAsyncImagePainter(model = imageUri),
+                contentDescription = stringResource(PhotographerR.string.review_photo),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .aspectRatio(1f),
+                contentScale = ContentScale.Crop,
+            )
+        }
+
+        if (hasOverflow) {
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .aspectRatio(1f)
+                        .clickable { onShowAll() },
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painter = rememberAsyncImagePainter(model = images[3]),
+                    contentDescription = stringResource(PhotographerR.string.review_photo),
+                    modifier =
+                        Modifier
+                            .matchParentSize()
+                            .drawWithContent {
+                                drawContent()
+                                drawRect(
+                                    color = MainThemeColor.Black.copy(alpha = 0.5f),
+                                    size = size,
+                                )
+                            },
+                    contentScale = ContentScale.Crop,
+                )
+                Text(
+                    text = "+${images.size - 4}",
+                    color = MainThemeColor.White,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 16.sp,
+                )
+            }
+        } else if (images.size == 4) {
+            Image(
+                painter = rememberAsyncImagePainter(model = images[3]),
+                contentDescription = stringResource(PhotographerR.string.review_photo),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .aspectRatio(1f),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun DetailPhotographerReviewScreenPreview() {
     val navController = rememberNavController()
 
     PicplzTheme {
-        DetailPhotographerReviewScreen(navController = navController, photographerId = 1)
+        DetailPhotographerReviewScreen(
+            navController = navController,
+            photographerId = 1,
+        )
     }
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
@@ -10,6 +10,7 @@ import com.hm.picplz.data.model.PhotographerPortfolio
 import com.hm.picplz.data.model.PhotographerReview
 import com.hm.picplz.data.model.PhotographerReviewSummary
 import com.hm.picplz.data.model.ShootingPackage
+import com.hm.picplz.ui.screen.detail_photographer.review.ReviewSortType
 
 data class DetailPhotographerState(
     val profileInfo: PhotographerInfo = mockPhotographerInfo,
@@ -20,6 +21,8 @@ data class DetailPhotographerState(
     val isFollow: Boolean = mockPhotographerInfo.isFollow,
     val isInfoExpanded: Boolean = false,
     val isBlocked: Boolean = false,
+    val reviewSortType: ReviewSortType = ReviewSortType.LATEST,
+    val isSortSheetVisible: Boolean = false,
 ) {
     companion object {
         fun idle(): DetailPhotographerState {

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
@@ -22,13 +22,14 @@ open class DetailPhotographerViewModel
     ) : ViewModel() {
         val photographerId: Int = savedStateHandle.get<Int>("photographerId") ?: 0
 
-        private val _state = MutableStateFlow(
-            if (photographerId == DEV_BLOCKED_PHOTOGRAPHER_ID) {
-                DetailPhotographerState.blocked()
-            } else {
-                DetailPhotographerState.idle()
-            },
-        )
+        private val _state =
+            MutableStateFlow(
+                if (photographerId == DEV_BLOCKED_PHOTOGRAPHER_ID) {
+                    DetailPhotographerState.blocked()
+                } else {
+                    DetailPhotographerState.idle()
+                },
+            )
         val state: StateFlow<DetailPhotographerState> = _state
 
         private val _sideEffect = Channel<DetailPhotographerSideEffect>(Channel.BUFFERED)
@@ -53,6 +54,17 @@ open class DetailPhotographerViewModel
                 }
                 is DetailPhotographerIntent.ToggleBlock -> {
                     _state.update { it.copy(isBlocked = !it.isBlocked) }
+                }
+                is DetailPhotographerIntent.SelectReviewSort -> {
+                    _state.update {
+                        it.copy(
+                            reviewSortType = intent.sortType,
+                            isSortSheetVisible = false,
+                        )
+                    }
+                }
+                is DetailPhotographerIntent.ToggleSortSheet -> {
+                    _state.update { it.copy(isSortSheetVisible = !it.isSortSheetVisible) }
                 }
             }
         }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewSortBottomSheet.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewSortBottomSheet.kt
@@ -1,0 +1,79 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.screen.common.CommonModalBottomSheet
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+
+private const val ITEM_HEIGHT = 57
+private const val SHEET_PADDING = 80
+
+enum class ReviewSortType(val label: String) {
+    LATEST("최신순"),
+    LIKES("좋아요순"),
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReviewSortBottomSheet(
+    visible: Boolean,
+    selectedSortType: ReviewSortType,
+    onDismiss: () -> Unit,
+    onSelect: (ReviewSortType) -> Unit,
+) {
+    CommonModalBottomSheet(
+        visible = visible,
+        visibleCloseButton = false,
+        onDismissRequest = onDismiss,
+        dragHandle = null,
+        sheetMaxHeight = (ITEM_HEIGHT * ReviewSortType.entries.size + SHEET_PADDING).dp,
+    ) {
+        Spacer(modifier = Modifier.height(20.dp))
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 15.dp)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
+        ) {
+            ReviewSortType.entries.forEachIndexed { index, type ->
+                val isSelected = type == selectedSortType
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(57.dp)
+                            .clickable {
+                                onSelect(type)
+                            },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = type.label,
+                        style = MainThemeFont.TitleSmall,
+                        color = if (isSelected) MainThemeColor.Black else MainThemeColor.Gray3,
+                    )
+                }
+                if (index != ReviewSortType.entries.toTypedArray().lastIndex) {
+                    HorizontalDivider(color = MainThemeColor.Gray2, thickness = 0.96.dp)
+                }
+            }
+        }
+    }
+}

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -32,4 +32,10 @@
     <!-- 작가 상세 - 차단 배너 -->
     <string name="blocked_account_message">차단된 계정입니다.</string>
     <string name="unblock_button">차단 해제</string>
+
+    <!-- 리뷰 페이지 -->
+    <string name="review_title">리뷰</string>
+    <string name="shooting_satisfaction">촬영 만족도</string>
+    <string name="star_rating">별점</string>
+    <string name="review_photo">리뷰 사진</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
closes #127

## 변경 사항

### UI 변경
- ReviewBars(키워드 막대그래프) 제거
- 칩 필터 (프로필 Only / 카카오톡 / 인스타그램) 제거
- 정렬 드롭다운 → `ReviewSortBottomSheet` 바텀시트 (최신순 / 좋아요순)
- 촬영 만족도: `TitleSmall` Black, 별 높이 20dp
- 별점 숫자: `BodyBold` Gray4, 별↔숫자 간격 4dp
- '리뷰' 텍스트: `ButtonDefault` Black, 갯수: `Body` Gray3
- 리뷰 사진 그리드: `weight(1f) + aspectRatio(1f)` (1/4 비율)
- "+N" 오버레이: SemiBold 16sp White
- 정렬 버튼: `Caption` Gray5, 간격 2dp, 패딩 상20 하8
- 바텀시트 하단 네비게이션바 겹침 수정 (`windowInsetsPadding`)

### MVI
- `DetailPhotographerState`: `reviewSortType`, `isSortSheetVisible` 추가
- `DetailPhotographerIntent`: `SelectReviewSort`, `ToggleSortSheet` 추가
- ViewModel에서 정렬 상태 관리

### 신규 파일
- `ReviewSortBottomSheet.kt`: 최신순/좋아요순 선택 바텀시트

## 머지 후 자동 반영 예정
- **별 아이콘 테두리 제거** — #120 머지 시 `star_empty.xml`, `star_half.xml` 변경 반영
- **리뷰 카드(SingleReview) 스타일** — #120 머지 시 피그마 타이포그래피/컬러 반영 (BodyBold, InnerTag, 신고 Gray3 등)

## API 연동 시 반영 예정 (#123)
- 정렬 선택 시 실제 리스트 재정렬 (현재는 UI만 변경, mockdata 고정)
- API `sort` 파라미터 (`LATEST`, `LIKES`) 연결

## 스크린샷

![KakaoTalk_Video_2026-03-24-13-17-48](https://github.com/user-attachments/assets/4e3d6318-b0f0-4722-856e-5686f35755fd)