### PR TITLE
✨ 사진 리뷰 그리드 + 리뷰 상세 피그마 반영

### DIFF
--- a/core/data/src/main/kotlin/com/hm/picplz/data/mockdata/MockPhotographerData.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mockdata/MockPhotographerData.kt
@@ -160,9 +160,14 @@ val mockReviews =
             photoReviewCount = 3,
             option = "프로필 Only",
             location = "서울 강남",
-            reviewText = "하나하나 신경써서 해주시고 잘 알려주세요 사진 처음찍거나 잘 못찍으시는 분들 하시면 후회 안하십니다!",
+            reviewText =
+                "하나하나 신경써서 해주시고 잘 알려주세요 사진 처음찍거나 잘 " +
+                    "못찍으시는 분들 하시면 후회 안하십니다하나하나 신경써서 해주시고 잘 " +
+                    "알려주세요 사진 처음찍거나 잘 못찍으시는 분들 하시면 후회 " +
+                    "안하십니다하나하나 신경써서 해주시고 잘 알려주세요 사진 처음찍거나 잘 " +
+                    "못찍으시는 분들 하시면 후회 안하십니다!",
             isRecommended = true,
-            recommendationCount = 3,
+            recommendationCount = 4,
         ),
         PhotographerReview(
             reviewId = 1,

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
@@ -14,4 +14,12 @@ sealed interface DetailPhotographerIntent {
     data class SelectReviewSort(val sortType: ReviewSortType) : DetailPhotographerIntent
 
     data object ToggleSortSheet : DetailPhotographerIntent
+
+    data class ShowFullScreenPhoto(val imageUri: String) : DetailPhotographerIntent
+
+    data object DismissFullScreenPhoto : DetailPhotographerIntent
+
+    data object ToggleReportSheet : DetailPhotographerIntent
+
+    data class SwitchReview(val reviewIndex: Int) : DetailPhotographerIntent
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoReviewsScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerPhotoReviewsScreen.kt
@@ -16,31 +16,34 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
 import com.hm.picplz.core.ui.R
-import com.hm.picplz.data.mockdata.mockReviewSummary
 import com.hm.picplz.navigation.model.DetailPhotographerSingleReview
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
 import com.hm.picplz.ui.theme.MainThemeColor
-import com.hm.picplz.ui.theme.pretendardTypography
+import com.hm.picplz.ui.theme.MainThemeFont
+import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.feature.photographer.R as PhotographerR
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 fun DetailPhotographerPhotoReviewsScreen(
     navController: NavController,
     photographerId: Int,
+    viewModel: DetailPhotographerViewModel = hiltViewModel(),
 ) {
-    // TODO: photographerId로 데이터 로드
-    val photoReviews = mockReviewSummary.photoReviews
-    val paddingModifier = Modifier.padding(horizontal = 15.dp)
+    val state by viewModel.state.collectAsState()
+    val photoReviews = state.reviewSummary.photoReviews
     val chunkedImages = photoReviews.chunked(3)
 
     Scaffold(
@@ -53,15 +56,17 @@ fun DetailPhotographerPhotoReviewsScreen(
                         .padding(innerPadding)
                         .fillMaxWidth(),
             ) {
-                CommonFixedTopBar(title = "사진 리뷰") {
-                    navController.popBackStack()
+                CommonFixedTopBar(
+                    title = stringResource(PhotographerR.string.photo_review_title),
+                ) {
+                    viewModel.handleIntent(DetailPhotographerIntent.NavigateToPrev)
                 }
 
                 Column(
                     modifier =
-                        paddingModifier
+                        Modifier
                             .fillMaxSize()
-                            .padding(top = 7.dp, bottom = 20.dp)
+                            .padding(horizontal = 16.dp)
                             .verticalScroll(rememberScrollState()),
                 ) {
                     if (chunkedImages.isEmpty()) {
@@ -75,58 +80,57 @@ fun DetailPhotographerPhotoReviewsScreen(
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Image(
                                     painter = painterResource(id = R.drawable.user_undefined),
-                                    contentDescription = "user-undefined",
+                                    contentDescription =
+                                        stringResource(
+                                            PhotographerR.string.photo_review_empty_icon,
+                                        ),
                                 )
                                 Spacer(modifier = Modifier.height(12.dp))
                                 Text(
-                                    text = "등록된 사진 리뷰가 없습니다",
-                                    style = pretendardTypography.titleSmall,
+                                    text =
+                                        stringResource(
+                                            PhotographerR.string.photo_review_empty,
+                                        ),
+                                    style = MainThemeFont.TitleSmall,
                                 )
                             }
                         }
                     } else {
                         chunkedImages.forEach { rowImages ->
                             Row(modifier = Modifier.fillMaxWidth()) {
-                                rowImages.forEach { imageRes ->
-//                                TODO: 기본 로드 이미지 변경
+                                rowImages.forEach { photo ->
                                     Image(
                                         painter =
                                             rememberAsyncImagePainter(
-                                                model =
-                                                    ImageRequest.Builder(
-                                                        LocalContext.current,
-                                                    )
-                                                        .data(imageRes.photoReviewUri) // 실제 로드할 이미지
-                                                        .placeholder(R.drawable.center_char) // 로드되기 전 기본 이미지
-                                                        .error(R.drawable.center_char) // 로드 실패 시 보여줄 이미지
-                                                        .crossfade(true) // 부드러운 전환 효과
-                                                        .build(),
+                                                model = photo.photoReviewUri,
                                             ),
-                                        contentDescription = "포트폴리오 이미지",
+                                        contentDescription =
+                                            stringResource(
+                                                PhotographerR.string.review_photo,
+                                            ),
                                         modifier =
                                             Modifier
-                                                .weight(1f) // 각 이미지가 동일한 크기를 가짐
-                                                .aspectRatio(1f) // 1:1 비율
-                                                .padding(2.dp)
+                                                .weight(1f)
+                                                .aspectRatio(1f)
+                                                .padding(1.dp)
                                                 .clickable {
                                                     navController.navigate(
                                                         DetailPhotographerSingleReview(
-                                                            reviewId = imageRes.reviewId,
-                                                            photoIndex = imageRes.index,
+                                                            reviewId = photo.reviewId,
+                                                            photoIndex = photo.index,
                                                         ),
                                                     )
                                                 },
                                         contentScale = ContentScale.Crop,
                                     )
                                 }
-                                // 남은 빈 공간 채우기
                                 repeat(3 - rowImages.size) {
                                     Spacer(
                                         modifier =
                                             Modifier
                                                 .weight(1f)
                                                 .aspectRatio(1f)
-                                                .padding(2.dp),
+                                                .padding(1.dp),
                                     )
                                 }
                             }
@@ -136,4 +140,14 @@ fun DetailPhotographerPhotoReviewsScreen(
             }
         },
     )
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            when (sideEffect) {
+                is DetailPhotographerSideEffect.NavigateToPrev -> {
+                    navController.popBackStack()
+                }
+            }
+        }
+    }
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerSingleReviewScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerSingleReviewScreen.kt
@@ -1,50 +1,36 @@
 package com.hm.picplz.ui.screen.detail_photographer
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import coil.compose.rememberAsyncImagePainter
-import com.hm.picplz.common.model.PhotoReview
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
-import com.hm.picplz.ui.screen.detail_photographer.review.SingleReview
+import com.hm.picplz.ui.screen.detail_photographer.review.FullScreenPhotoView
+import com.hm.picplz.ui.screen.detail_photographer.review.PhotoCarousel
+import com.hm.picplz.ui.screen.detail_photographer.review.PhotographerInfoSection
+import com.hm.picplz.ui.screen.detail_photographer.review.ReportBottomSheet
+import com.hm.picplz.ui.screen.detail_photographer.review.ReviewHeader
+import com.hm.picplz.ui.screen.detail_photographer.review.ReviewThumbnailBar
 import com.hm.picplz.ui.theme.MainThemeColor
-import com.hm.picplz.ui.util.SingleReviewType
+import com.hm.picplz.ui.theme.MainThemeFont
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 
 @Composable
 fun DetailPhotographerSingleReviewScreen(
@@ -53,67 +39,80 @@ fun DetailPhotographerSingleReviewScreen(
     reviewId: Int,
     photoIndex: Int = 0,
 ) {
+    val state by viewModel.state.collectAsState()
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
 
-    val currentState = viewModel.state.collectAsState().value
-    val singleReview = currentState.reviews[reviewId]
+    val currentIndex = state.currentReviewIndex
+    val review = state.reviews.getOrNull(currentIndex) ?: return
 
-    val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
-    val screenWidthPx = with(LocalDensity.current) { screenWidthDp.toPx() } // Dp -> Px 변환
-
-    // 값들 추출
-    val imageWidth = 40.dp
-    val selectedImageWidth = 50.dp
-    val imageSpacing = 1.dp
-
-    val imageWidthPx = with(LocalDensity.current) { imageWidth.toPx() }
-    val selectedImageWidthPx = with(LocalDensity.current) { selectedImageWidth.toPx() }
-    val imageSpacingPx = with(LocalDensity.current) { imageSpacing.toPx() }
-    val horizontalPaddingPx = with(LocalDensity.current) { (screenWidthDp / 2).toPx() }
-
-    val scrollState = rememberScrollState()
-    var currentPhotoIndex by remember { mutableStateOf(photoIndex) }
-
-    val coroutineScope = rememberCoroutineScope()
-
-    // 스크롤 위치 계산 함수 개선
-    fun calculateScrollOffset(index: Int): Int {
-        val offsetFromStart = index * (imageWidthPx + imageSpacingPx)
-        val adjustedOffsetFromStart =
-            if (index == currentPhotoIndex) {
-                offsetFromStart - (selectedImageWidthPx - imageWidthPx) / 2
-            } else {
-                offsetFromStart
+    // 모든 리뷰의 대표 사진 (첫 번째 사진)
+    val allThumbnails =
+        remember(state.reviews) {
+            state.reviews.mapNotNull { r ->
+                r.photoReviews.firstOrNull()?.photoReviewUri
             }
-
-        // 더 정확한 계산 방식 적용
-        return (adjustedOffsetFromStart - (screenWidthPx / 2) + (imageWidthPx / 2) + horizontalPaddingPx).toInt()
-    }
-
-    // 화면 로드 시 초기 scroll position 계산
-    LaunchedEffect(photoIndex) {
-        val offsetFromCenter = calculateScrollOffset(photoIndex)
-        scrollState.animateScrollTo(offsetFromCenter)
-    }
-
-    // 스크롤 중앙 이미지 인덱스 업데이트
-    LaunchedEffect(scrollState.value) {
-        val centerPosition = scrollState.value + (screenWidthPx / 2)
-        val newPhotoIndex =
-            ((centerPosition - horizontalPaddingPx) / (imageWidthPx + imageSpacingPx)).toInt()
-
-        if (newPhotoIndex in 0 until singleReview.photoReviewCount && newPhotoIndex != currentPhotoIndex) {
-            currentPhotoIndex = newPhotoIndex
         }
+
+    // 사진이 있는 리뷰만의 인덱스 매핑
+    val reviewsWithPhotos =
+        remember(state.reviews) {
+            state.reviews.mapIndexedNotNull { index, r ->
+                if (r.photoReviews.isNotEmpty()) index else null
+            }
+        }
+
+    val thumbnailIndex =
+        remember(currentIndex, reviewsWithPhotos) {
+            reviewsWithPhotos.indexOf(currentIndex).coerceAtLeast(0)
+        }
+
+    val photoCount = review.photoReviews.size.coerceAtLeast(1)
+    val initialPage =
+        if (currentIndex == reviewId) photoIndex else 0
+    val pagerState =
+        key(currentIndex) {
+            rememberPagerState(
+                initialPage = initialPage.coerceIn(0, photoCount - 1),
+                pageCount = { photoCount },
+            )
+        }
+
+    // 초기 진입 시 reviewId를 State에 반영
+    LaunchedEffect(Unit) {
+        viewModel.handleIntent(DetailPhotographerIntent.SwitchReview(reviewId))
     }
 
-    // UI 구성
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        containerColor = MainThemeColor.White,
-        content = { innerPadding ->
-            Box(modifier = Modifier.fillMaxSize()) {
-                // Main content area (scrollable)
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = MainThemeColor.White,
+            bottomBar = {
+                if (allThumbnails.size > 1) {
+                    ReviewThumbnailBar(
+                        thumbnails = allThumbnails,
+                        selectedIndex = thumbnailIndex,
+                        onSelect = { index ->
+                            if (index < reviewsWithPhotos.size) {
+                                viewModel.handleIntent(
+                                    DetailPhotographerIntent.SwitchReview(
+                                        reviewsWithPhotos[index],
+                                    ),
+                                )
+                            }
+                        },
+                        onCenterChanged = { index ->
+                            if (index < reviewsWithPhotos.size) {
+                                viewModel.handleIntent(
+                                    DetailPhotographerIntent.SwitchReview(
+                                        reviewsWithPhotos[index],
+                                    ),
+                                )
+                            }
+                        },
+                    )
+                }
+            },
+            content = { innerPadding ->
                 Column(
                     modifier =
                         Modifier
@@ -121,54 +120,82 @@ fun DetailPhotographerSingleReviewScreen(
                             .fillMaxWidth()
                             .verticalScroll(rememberScrollState()),
                 ) {
-                    CommonFixedTopBar(title = "${currentPhotoIndex + 1} / ${singleReview.photoReviewCount}") {
-                        viewModel.handleIntent(DetailPhotographerIntent.NavigateToPrev)
-                    }
-
-                    Column(modifier = paddingModifier.fillMaxSize()) {
-                        SingleReview(
-                            navController = navController,
-                            review = singleReview,
-                            type = SingleReviewType.DETAIL,
-                            photoIndex = currentPhotoIndex,
+                    CommonFixedTopBar(title = "") {
+                        viewModel.handleIntent(
+                            DetailPhotographerIntent.NavigateToPrev,
                         )
-
-                        Spacer(modifier = Modifier.height(80.dp)) // Ensure there's space at the bottom
                     }
-                }
 
-                // Floating PhotoScroller at the bottom, with zIndex to stay on top
-                Box(
-                    modifier =
-                        Modifier
-                            .align(Alignment.BottomEnd)
-                            .zIndex(1f)
-                            .height(80.dp)
-                            .background(MainThemeColor.White),
-                ) {
-                    Box(
-                        modifier = Modifier.align(Alignment.Center),
-                    ) {
-                        PhotoScroller(
-                            scrollState = scrollState,
-                            photoIndex = currentPhotoIndex,
-                            images = singleReview.photoReviews,
-//                            calculateScrollOffset = ::calculateScrollOffset,
-                            onImageClick = { index ->
-                                if (index != currentPhotoIndex) {
-                                    // 클릭 시 currentPhotoIndex를 바로 업데이트하고 스크롤 애니메이션 적용
-                                    currentPhotoIndex = index
-                                    coroutineScope.launch {
-                                        val offset = calculateScrollOffset(index)
-                                        scrollState.animateScrollTo(offset)
-                                    }
-                                }
+                    ReviewHeader(
+                        modifier = paddingModifier.padding(vertical = 12.dp),
+                        review = review,
+                        onReport = {
+                            viewModel.handleIntent(
+                                DetailPhotographerIntent.ToggleReportSheet,
+                            )
+                        },
+                    )
+
+                    if (review.photoReviews.isNotEmpty()) {
+                        PhotoCarousel(
+                            photos = review.photoReviews.map { it.photoReviewUri },
+                            pagerState = pagerState,
+                            onPhotoClick = { uri ->
+                                viewModel.handleIntent(
+                                    DetailPhotographerIntent.ShowFullScreenPhoto(
+                                        uri,
+                                    ),
+                                )
                             },
                         )
                     }
+
+                    PhotographerInfoSection(
+                        modifier = paddingModifier,
+                        profileImageUri = state.profileInfo.profileImageUri,
+                        photographerName = state.profileInfo.name,
+                        photographerId = state.profileInfo.id,
+                        review = review,
+                        navController = navController,
+                    )
+
+                    HorizontalDivider(
+                        color = MainThemeColor.Gray2,
+                        thickness = 1.dp,
+                        modifier = paddingModifier.fillMaxWidth(),
+                    )
+
+                    Text(
+                        text = review.reviewText,
+                        style = MainThemeFont.Body,
+                        color = MainThemeColor.Black,
+                        modifier =
+                            paddingModifier
+                                .fillMaxWidth()
+                                .padding(vertical = 20.dp),
+                    )
                 }
-            }
+            },
+        )
+
+        state.fullScreenImageUri?.let { uri ->
+            FullScreenPhotoView(
+                imageUri = uri,
+                onDismiss = {
+                    viewModel.handleIntent(
+                        DetailPhotographerIntent.DismissFullScreenPhoto,
+                    )
+                },
+            )
+        }
+    }
+
+    ReportBottomSheet(
+        visible = state.isReportSheetVisible,
+        onDismiss = {
+            viewModel.handleIntent(DetailPhotographerIntent.ToggleReportSheet)
         },
+        onSelect = { /* TODO: 신고 API 연동 */ },
     )
 
     LaunchedEffect(Unit) {
@@ -178,52 +205,6 @@ fun DetailPhotographerSingleReviewScreen(
                     navController.popBackStack()
                 }
             }
-        }
-    }
-}
-
-// 이미지 스크롤러 컴포저블
-@Composable
-fun PhotoScroller(
-    scrollState: ScrollState,
-    photoIndex: Int,
-    images: List<PhotoReview>,
-    onImageClick: (Int) -> Unit,
-) {
-    val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
-    val imageWidth = 40.dp
-    val selectedImageWidth = 50.dp
-    val imageSpacing = 1.dp
-
-    Row(
-        modifier =
-            Modifier
-                .horizontalScroll(scrollState)
-                .padding(horizontal = screenWidthDp / 2),
-        horizontalArrangement = Arrangement.spacedBy(imageSpacing),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        images.forEachIndexed { index, image ->
-            val isSelected = index == photoIndex
-            val animatedSize by animateDpAsState(
-                targetValue = if (isSelected) selectedImageWidth else imageWidth,
-            )
-
-            if (isSelected) Spacer(modifier = Modifier.width(10.dp))
-
-            Image(
-                painter = rememberAsyncImagePainter(model = image.photoReviewUri),
-                contentDescription = "review-image",
-                modifier =
-                    Modifier
-                        .size(animatedSize)
-                        .clickable {
-                            onImageClick(index)
-                        },
-                contentScale = ContentScale.Crop,
-            )
-
-            if (isSelected) Spacer(modifier = Modifier.width(10.dp))
         }
     }
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
@@ -23,6 +23,9 @@ data class DetailPhotographerState(
     val isBlocked: Boolean = false,
     val reviewSortType: ReviewSortType = ReviewSortType.LATEST,
     val isSortSheetVisible: Boolean = false,
+    val currentReviewIndex: Int = 0,
+    val fullScreenImageUri: String? = null,
+    val isReportSheetVisible: Boolean = false,
 ) {
     companion object {
         fun idle(): DetailPhotographerState {

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
@@ -66,6 +66,20 @@ open class DetailPhotographerViewModel
                 is DetailPhotographerIntent.ToggleSortSheet -> {
                     _state.update { it.copy(isSortSheetVisible = !it.isSortSheetVisible) }
                 }
+                is DetailPhotographerIntent.ShowFullScreenPhoto -> {
+                    _state.update { it.copy(fullScreenImageUri = intent.imageUri) }
+                }
+                is DetailPhotographerIntent.DismissFullScreenPhoto -> {
+                    _state.update { it.copy(fullScreenImageUri = null) }
+                }
+                is DetailPhotographerIntent.ToggleReportSheet -> {
+                    _state.update {
+                        it.copy(isReportSheetVisible = !it.isReportSheetVisible)
+                    }
+                }
+                is DetailPhotographerIntent.SwitchReview -> {
+                    _state.update { it.copy(currentReviewIndex = intent.reviewIndex) }
+                }
             }
         }
 

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/FullScreenPhotoView.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/FullScreenPhotoView.kt
@@ -1,0 +1,56 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+@Composable
+fun FullScreenPhotoView(
+    imageUri: String,
+    onDismiss: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .systemBarsPadding(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(model = imageUri),
+            contentDescription = stringResource(PhotographerR.string.full_screen_photo),
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Fit,
+        )
+
+        Icon(
+            painter = painterResource(id = R.drawable.triangle_left),
+            contentDescription = stringResource(PhotographerR.string.back),
+            tint = Color.White,
+            modifier =
+                Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
+                    .size(24.dp)
+                    .clickable { onDismiss() },
+        )
+    }
+}

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotoCarousel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotoCarousel.kt
@@ -1,0 +1,143 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+@Composable
+fun PhotoCarousel(
+    photos: List<String>,
+    pagerState: PagerState,
+    onPhotoClick: (String) -> Unit,
+) {
+    Column {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth(),
+        ) { page ->
+            Image(
+                painter = rememberAsyncImagePainter(model = photos[page]),
+                contentDescription = stringResource(PhotographerR.string.review_photo),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f)
+                        .clickable { onPhotoClick(photos[page]) },
+                contentScale = ContentScale.Crop,
+            )
+        }
+
+        // dots 영역 고정 높이 — 1장이어도 레이아웃 시프트 방지
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(DOT_AREA_HEIGHT),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (photos.size > 1) {
+                PageIndicatorDots(
+                    totalCount = photos.size,
+                    currentPage = pagerState.currentPage,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 인스타그램 스타일 슬라이딩 dots indicator.
+ * - 최대 5개 표시, 선택된 dot은 가운데 유지
+ * - 가운데서 멀수록 작아짐: 6 → 4 → 2
+ * - 처음/마지막 2개에서는 edge에 고정
+ */
+@Composable
+fun PageIndicatorDots(
+    totalCount: Int,
+    currentPage: Int,
+) {
+    if (totalCount <= 0) return
+
+    val visibleCount = minOf(totalCount, MAX_VISIBLE_DOTS)
+    // 슬라이딩 윈도우 시작 인덱스
+    val windowStart =
+        when {
+            totalCount <= MAX_VISIBLE_DOTS -> 0
+            currentPage <= CENTER_INDEX -> 0
+            currentPage >= totalCount - CENTER_INDEX - 1 -> totalCount - MAX_VISIBLE_DOTS
+            else -> currentPage - CENTER_INDEX
+        }
+    // 윈도우 안에서 선택된 dot의 위치
+    val selectedPosInWindow =
+        when {
+            totalCount <= MAX_VISIBLE_DOTS -> currentPage
+            currentPage <= CENTER_INDEX -> currentPage
+            currentPage >= totalCount - CENTER_INDEX - 1 ->
+                MAX_VISIBLE_DOTS - (totalCount - currentPage)
+            else -> CENTER_INDEX
+        }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        for (i in 0 until visibleCount) {
+            val pageIndex = windowStart + i
+            val distFromSelected =
+                kotlin.math.abs(i - selectedPosInWindow)
+            val dotSize =
+                when (distFromSelected) {
+                    0 -> DOT_LARGE
+                    1 -> DOT_MEDIUM
+                    else -> DOT_SMALL
+                }
+            val dotColor =
+                if (pageIndex == currentPage) {
+                    MainThemeColor.Black
+                } else {
+                    MainThemeColor.Black.copy(alpha = 0.2f)
+                }
+
+            if (i > 0) Spacer(modifier = Modifier.width(4.dp))
+
+            Box(
+                modifier =
+                    Modifier
+                        .size(dotSize)
+                        .clip(CircleShape)
+                        .background(dotColor),
+            )
+        }
+    }
+}
+
+private val DOT_AREA_HEIGHT = 18.dp
+private const val MAX_VISIBLE_DOTS = 5
+private const val CENTER_INDEX = 2
+private val DOT_LARGE = 6.dp
+private val DOT_MEDIUM = 4.dp
+private val DOT_SMALL = 2.dp

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotoThumbnailBar.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotoThumbnailBar.kt
@@ -1,0 +1,141 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+/**
+ * 하단 고정 썸네일 바.
+ * 모든 리뷰의 대표 사진을 나열하고, 선택된 리뷰가 가운데에 위치.
+ */
+@Composable
+fun ReviewThumbnailBar(
+    thumbnails: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+    onCenterChanged: (Int) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
+    val centerPadding = (screenWidthDp - THUMBNAIL_SIZE) / 2
+    var isUserDragging by remember { mutableStateOf(false) }
+
+    LaunchedEffect(listState.interactionSource) {
+        listState.interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is DragInteraction.Start -> {
+                    isUserDragging = true
+                }
+                is DragInteraction.Stop,
+                is DragInteraction.Cancel,
+                -> {
+                    isUserDragging = false
+                    val centerIndex = listState.findCenterItemIndex()
+                    if (centerIndex != -1 && centerIndex != selectedIndex) {
+                        onCenterChanged(centerIndex)
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(selectedIndex) {
+        if (!isUserDragging) {
+            listState.centerItem(selectedIndex)
+        }
+    }
+
+    LazyRow(
+        state = listState,
+        horizontalArrangement = Arrangement.spacedBy(1.dp),
+        contentPadding = PaddingValues(horizontal = centerPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 8.dp),
+    ) {
+        itemsIndexed(thumbnails) { index, uri ->
+            val isSelected = index == selectedIndex
+            Image(
+                painter = rememberAsyncImagePainter(model = uri),
+                contentDescription = stringResource(PhotographerR.string.review_photo),
+                modifier =
+                    Modifier
+                        .size(
+                            if (isSelected) {
+                                THUMBNAIL_SELECTED_SIZE
+                            } else {
+                                THUMBNAIL_SIZE
+                            },
+                        )
+                        .clickable { onSelect(index) },
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}
+
+private suspend fun androidx.compose.foundation.lazy.LazyListState.centerItem(index: Int) {
+    val layoutInfo = layoutInfo
+    val target = layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+
+    if (target != null) {
+        val containerSize =
+            layoutInfo.viewportSize.width -
+                layoutInfo.beforeContentPadding -
+                layoutInfo.afterContentPadding
+        val targetCenter = target.offset + target.size / 2f
+        val viewportCenter = containerSize / 2f
+        animateScrollBy(targetCenter - viewportCenter)
+    } else {
+        scrollToItem(index)
+        val retarget =
+            layoutInfo.visibleItemsInfo.firstOrNull { it.index == index }
+        if (retarget != null) {
+            val containerSize =
+                layoutInfo.viewportSize.width -
+                    layoutInfo.beforeContentPadding -
+                    layoutInfo.afterContentPadding
+            val targetCenter = retarget.offset + retarget.size / 2f
+            val viewportCenter = containerSize / 2f
+            animateScrollBy(targetCenter - viewportCenter)
+        }
+    }
+}
+
+internal fun androidx.compose.foundation.lazy.LazyListState.findCenterItemIndex(): Int {
+    val layoutInfo = layoutInfo
+    val containerSize =
+        layoutInfo.viewportSize.width -
+            layoutInfo.beforeContentPadding -
+            layoutInfo.afterContentPadding
+    val viewportCenter = containerSize / 2f
+
+    return layoutInfo.visibleItemsInfo.minByOrNull { item ->
+        val itemCenter = item.offset + item.size / 2f
+        kotlin.math.abs(itemCenter - viewportCenter)
+    }?.index ?: -1
+}
+
+private val THUMBNAIL_SIZE = 40.dp
+private val THUMBNAIL_SELECTED_SIZE = 50.dp

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotographerInfoSection.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/PhotographerInfoSection.kt
@@ -1,0 +1,141 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.data.model.PhotographerReview
+import com.hm.picplz.navigation.model.DetailPhotographer
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+@Composable
+fun PhotographerInfoSection(
+    modifier: Modifier,
+    profileImageUri: String,
+    photographerName: String,
+    photographerId: Int,
+    review: PhotographerReview,
+    navController: NavController,
+) {
+    Column(
+        modifier = modifier.padding(vertical = 20.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        navController.navigate(DetailPhotographer(photographerId))
+                    },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                painter = rememberAsyncImagePainter(model = profileImageUri),
+                contentDescription =
+                    stringResource(
+                        PhotographerR.string.photographer_profile,
+                    ),
+                modifier =
+                    Modifier
+                        .size(24.dp)
+                        .clip(CircleShape),
+                contentScale = ContentScale.Crop,
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text =
+                    stringResource(
+                        PhotographerR.string.photographer_link_format,
+                        photographerName,
+                    ),
+                style = MainThemeFont.ButtonDefault,
+                color = MainThemeColor.Gray5,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Image(
+                painter = painterResource(id = R.drawable.depth_arrow),
+                contentDescription = stringResource(PhotographerR.string.more),
+                modifier = Modifier.size(12.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row {
+            Text(
+                text = stringResource(PhotographerR.string.option_label),
+                style = MainThemeFont.InnerTag,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = review.option,
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(PhotographerR.string.shooting_location),
+                style = MainThemeFont.InnerTag,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = review.location,
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Image(
+                painter =
+                    painterResource(
+                        id =
+                            if (review.isRecommended) {
+                                R.drawable.like_active
+                            } else {
+                                R.drawable.like_inactive
+                            },
+                    ),
+                contentDescription = stringResource(PhotographerR.string.like),
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .clickable { },
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = review.recommendationCount.toString(),
+                style = RecommendCountStyle,
+                color = MainThemeColor.Gray6,
+            )
+        }
+    }
+}

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReportBottomSheet.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReportBottomSheet.kt
@@ -1,0 +1,88 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.screen.common.CommonModalBottomSheet
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+private const val ITEM_HEIGHT = 57
+private const val SHEET_PADDING = 80
+
+private val reportOptions: List<Int> =
+    listOf(
+        PhotographerR.string.report_harmful_content,
+        PhotographerR.string.report_plagiarism,
+        PhotographerR.string.report_privacy_risk,
+        PhotographerR.string.report_not_customer,
+        PhotographerR.string.report_other,
+    )
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReportBottomSheet(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit,
+) {
+    CommonModalBottomSheet(
+        visible = visible,
+        visibleCloseButton = false,
+        onDismissRequest = onDismiss,
+        dragHandle = null,
+        sheetMaxHeight = (ITEM_HEIGHT * reportOptions.size + SHEET_PADDING).dp,
+    ) {
+        Spacer(modifier = Modifier.height(20.dp))
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 15.dp)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
+        ) {
+            reportOptions.forEachIndexed { index, resId ->
+                val label = stringResource(resId)
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(57.dp)
+                            .clickable {
+                                onSelect(label)
+                                onDismiss()
+                            },
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = label,
+                        style = MainThemeFont.Body,
+                        color = MainThemeColor.Black,
+                    )
+                }
+                if (index != reportOptions.lastIndex) {
+                    HorizontalDivider(
+                        color = MainThemeColor.Gray2,
+                        thickness = 0.96.dp,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewHeader.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewHeader.kt
@@ -1,0 +1,120 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hm.picplz.data.model.PhotographerReview
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.util.ReviewUtil
+import com.hm.picplz.ui.util.StarType
+import com.hm.picplz.feature.photographer.R as PhotographerR
+
+@Composable
+fun ReviewHeader(
+    modifier: Modifier,
+    review: PhotographerReview,
+    onReport: () -> Unit,
+) {
+    val starList = ReviewUtil.calculateStarRating(review.rating, StarType.SUB)
+
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(model = review.profileImageUri),
+            contentDescription =
+                stringResource(
+                    PhotographerR.string.user_profile,
+                ),
+            modifier =
+                Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .border(1.dp, MainThemeColor.Gray2, CircleShape),
+        )
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        Column {
+            Text(
+                text = review.nickname,
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Black,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                starList.forEach { star ->
+                    Image(
+                        painter = painterResource(id = star),
+                        contentDescription =
+                            stringResource(
+                                PhotographerR.string.star_rating_desc,
+                            ),
+                        modifier = Modifier.size(15.dp),
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Box(
+            modifier =
+                Modifier
+                    .height(17.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(MainThemeColor.Gray1)
+                    .clickable { onReport() }
+                    .padding(horizontal = 4.dp, vertical = 1.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(PhotographerR.string.review_report_title),
+                style = ReportButtonTextStyle,
+                color = MainThemeColor.Gray3,
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Text(
+            text = review.createdAt,
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = stringResource(PhotographerR.string.written),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewTextStyles.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/review/ReviewTextStyles.kt
@@ -1,0 +1,22 @@
+package com.hm.picplz.ui.screen.detail_photographer.review
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.hm.picplz.ui.theme.Pretendard
+
+/** 추천 수 텍스트 — Pretendard Normal 14sp */
+val RecommendCountStyle =
+    TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+    )
+
+/** 신고 버튼 텍스트 — Pretendard Normal 10sp */
+val ReportButtonTextStyle =
+    TextStyle(
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 10.sp,
+    )

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -38,4 +38,33 @@
     <string name="shooting_satisfaction">촬영 만족도</string>
     <string name="star_rating">별점</string>
     <string name="review_photo">리뷰 사진</string>
+
+    <!-- 사진 리뷰 그리드 -->
+    <string name="photo_review_title">사진 리뷰</string>
+    <string name="photo_review_empty">등록된 사진 리뷰가 없습니다</string>
+    <string name="photo_review_empty_icon">빈 상태 아이콘</string>
+
+    <!-- 리뷰 상세 -->
+    <string name="review_photo_counter">%1$d/%2$d</string>
+    <string name="photographer_link_format">%s 작가</string>
+    <string name="written">작성</string>
+    <string name="review_report_title">신고</string>
+    <string name="star_rating_desc">별점</string>
+    <string name="option_label">옵션</string>
+    <string name="shooting_location">촬영지</string>
+    <string name="like">좋아요</string>
+
+    <!-- 신고 바텀시트 -->
+    <string name="report_harmful_content">유해한 콘텐츠</string>
+    <string name="report_plagiarism">타인이 작성한 글, 사진 도용</string>
+    <string name="report_privacy_risk">개인정보 누출 위험</string>
+    <string name="report_not_customer">고객이 아닌 작가의 리뷰</string>
+    <string name="report_other">기타</string>
+
+    <!-- 풀스크린 사진 -->
+    <string name="full_screen_photo">전체 화면 사진</string>
+    <string name="back">뒤로가기</string>
+    <string name="photographer_profile">작가 프로필</string>
+    <string name="user_profile">유저 프로필</string>
+    <string name="more">더보기</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
closes #130

## 변경 사항

### 사진 리뷰 그리드 (DetailPhotographerPhotoReviewsScreen)
- 사진 간 간격 4dp → 2dp
- 좌우 패딩 16dp
- mockdata 직접 참조 → ViewModel State 경유
- 하드코딩 문자열 → strings.xml
- `pretendardTypography` → `MainThemeFont`
- `ImageRequest.Builder` → `rememberAsyncImagePainter` 통일
- contentDescription 복붙 버그 수정 ('포트폴리오 이미지' → '리뷰 사진')

### 리뷰 상세 (DetailPhotographerSingleReviewScreen) — 전면 재작성
기존 PhotoScroller 방식에서 피그마 디자인으로 완전 교체:

**신규 컴포넌트 (review/ 하위 분리):**
- `ReviewHeader`: 프로필 36dp, 별 15dp, 신고 버튼 (높이17/Gray1/Pretendard10sp)
- `PhotoCarousel`: HorizontalPager + 인스타 스타일 슬라이딩 dots (5개 윈도우, 6→4→2dp)
- `PhotoThumbnailBar`: 모든 리뷰 대표 사진 하단 고정, 센터 스크롤 + 드래그 전환
- `PhotographerInfoSection`: 작가 프로필 링크(24dp, ButtonDefault Gray5) + 옵션/촬영지
- `FullScreenPhotoView`: 다크 배경 전체화면 + systemBarsPadding
- `ReportBottomSheet`: 신고 사유 5개 옵션 + navigationBars 패딩
- `ReviewTextStyles`: `RecommendCountStyle`, `ReportButtonTextStyle` 상수

### MVI
- `State`: `currentReviewIndex`, `fullScreenImageUri`, `isReportSheetVisible` 추가
- `Intent`: `SwitchReview`, `ShowFullScreenPhoto`, `DismissFullScreenPhoto`, `ToggleReportSheet` 추가

### 버그 수정
- 리뷰 전환 시 `pagerState` key 재생성 (IndexOutOfBoundsException 방지)
- dots 영역 고정 높이 (1장↔여러장 레이아웃 시프트 방지)

## 머지 후 자동 반영 예정
- 별 아이콘 테두리 제거 — #120 머지 시
- SingleReview 카드 스타일 — #120 머지 시
- 정렬 실제 동작 — #123 API 연동 시

## 스크린샷

![KakaoTalk_Video_2026-03-24-19-13-41](https://github.com/user-attachments/assets/862c8b8f-3d03-4508-b9e9-74920ec15210)