### PR TITLE
✨ : 결제 후 예약 취소 - 취소할 주문 정보 확인 페이지 구현

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -16,6 +16,7 @@ import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPageShootingHistory
+import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
 import com.hm.picplz.ui.screen.chat.ChatScreen
@@ -29,6 +30,7 @@ import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
+import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
@@ -81,6 +83,9 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateCancelReservation = {
                 navController.navigate(CancelReservationConfirm)
             },
+            onNavigateToOrderDetail = {
+                navController.navigate(OrderDetail)
+            },
         )
     }
 
@@ -94,6 +99,15 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                     popUpTo<Dev> { inclusive = false }
                 }
             },
+        )
+    }
+
+    composable<OrderDetail> {
+        OrderDetailScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            onNavigateNextStep = { },
         )
     }
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -111,3 +111,6 @@ data object DetailReservation : NavigationRoute
 
 @Serializable
 data object CancelReservationConfirm : NavigationRoute
+
+@Serializable
+data object OrderDetail : NavigationRoute

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -28,6 +28,7 @@ import com.hm.picplz.ui.theme.MainThemeColor
 fun DetailReservationScreen(
     onNavigateBack: () -> Unit,
     onNavigateCancelReservation: () -> Unit,
+    onNavigateToOrderDetail: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
@@ -38,6 +39,7 @@ fun DetailReservationScreen(
             when (sideEffect) {
                 is DetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
                 is DetailReservationSideEffect.NavigateToCancelReservation -> onNavigateCancelReservation()
+                is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail()
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
@@ -4,4 +4,6 @@ sealed interface DetailReservationSideEffect {
     data object NavigateToPrev : DetailReservationSideEffect
 
     data object NavigateToCancelReservation : DetailReservationSideEffect
+
+    data object NavigateToOrderDetail : DetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -71,7 +71,19 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                 _state.update { it.copy(showCancelDialog = false) }
 
                 viewModelScope.launch {
-                    _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservation)
+                    when (state.value.reservationStatus) {
+                        ReservationStatus.WAITING_APPROVAL,
+                        ReservationStatus.WAITING_PAYMENT,
+                        -> {
+                            _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservation)
+                        }
+
+                        ReservationStatus.RESERVED,
+                        ReservationStatus.COMPLETED,
+                        -> {
+                            _sideEffect.emit(DetailReservationSideEffect.NavigateToOrderDetail)
+                        }
+                    }
                 }
             }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailIntent.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.order_detail
+
+sealed interface OrderDetailIntent

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailIntent.kt
@@ -1,3 +1,7 @@
 package com.hm.picplz.ui.screen.order_detail
 
-sealed interface OrderDetailIntent
+sealed interface OrderDetailIntent {
+    data object OnBackClick : OrderDetailIntent
+
+    data object OnNextClick : OrderDetailIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailScreen.kt
@@ -1,13 +1,160 @@
 package com.hm.picplz.ui.screen.order_detail
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.order_detail.composable.CustomerInfoSection
+import com.hm.picplz.ui.screen.order_detail.composable.OrderDetailTopBar
+import com.hm.picplz.ui.screen.order_detail.composable.OrderNumberSection
+import com.hm.picplz.ui.screen.order_detail.composable.PhotographerSection
+import com.hm.picplz.ui.screen.order_detail.composable.ProductInfoSection
+import com.hm.picplz.ui.screen.order_detail.composable.ScheduleSection
+import com.hm.picplz.ui.theme.MainThemeColor.Gray2
 
 @Composable
-fun OrderDetailScreen() {}
+fun OrderDetailScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateNextStep: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: OrderDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is OrderDetailSideEffect.NavigateBack -> onNavigateBack()
+                is OrderDetailSideEffect.NavigateToNextStep -> onNavigateNextStep()
+            }
+        }
+    }
+
+    OrderDetailScreenContent(
+        modifier = modifier,
+        state = state,
+        onBackClick = {
+            viewModel.handleIntent(OrderDetailIntent.OnBackClick)
+        },
+        onNextClick = {
+            viewModel.handleIntent(OrderDetailIntent.OnNextClick)
+        },
+    )
+}
+
+@Composable
+private fun OrderDetailScreenContent(
+    state: OrderDetailState,
+    onBackClick: () -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = Color.White,
+        topBar = {
+            OrderDetailTopBar(
+                onBackClick = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(modifier = Modifier.padding(innerPadding)) {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+            ) {
+                item {
+                    OrderNumberSection(
+                        orderNumber = state.orderNumber,
+                        orderTime = state.orderTime,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+
+                item {
+                    CustomerInfoSection(
+                        customerName = state.customerName,
+                        phoneNumber = state.phoneNumber,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+
+                item {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = Gray2,
+                    )
+                }
+
+                item {
+                    PhotographerSection(
+                        photographerName = state.photographerName,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+
+                item {
+                    ProductInfoSection(
+                        photographerImageUrl = state.productImageUrl,
+                        photographerName = state.productName,
+                        price = state.price,
+                        description = state.productDescription,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+
+                item {
+                    ScheduleSection(
+                        shootingTime = state.shootingTime,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+            }
+
+            CommonBottomButton(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
+                text = stringResource(R.string.order_detail_button_next),
+                onClick = onNextClick,
+            )
+        }
+    }
+}
 
 @Preview
 @Composable
 private fun OrderDetailScreenPreview() {
-    OrderDetailScreen()
+    OrderDetailScreenContent(
+        state =
+            OrderDetailState(
+                orderNumber = "nnnnmmdd123456",
+                orderTime = "2025-03-09 19:09:14",
+                customerName = "주은강",
+                phoneNumber = "01023293185",
+                photographerName = "주문고",
+                productName = "남친생기는 프사❤️",
+                productImageUrl = "https://picsum.photos/id/222/300/300",
+                price = 12000,
+                productDescription = "작가가 해놓은 한줄소개 기렁지면 이렇게 처리 작가가 해놓은 한줄소개 기렁지면 이렇게 처리",
+                shootingTime = "25.01.09 - 오후 02:00",
+                isLoading = false,
+            ),
+        onBackClick = {},
+        onNextClick = {},
+    )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailScreen.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.ui.screen.order_detail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun OrderDetailScreen() {}
+
+@Preview
+@Composable
+private fun OrderDetailScreenPreview() {
+    OrderDetailScreen()
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailSideEffect.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.order_detail
+
+sealed interface OrderDetailSideEffect

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailSideEffect.kt
@@ -1,3 +1,7 @@
 package com.hm.picplz.ui.screen.order_detail
 
-sealed interface OrderDetailSideEffect
+sealed interface OrderDetailSideEffect {
+    data object NavigateBack : OrderDetailSideEffect
+
+    data object NavigateToNextStep : OrderDetailSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailState.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.order_detail
+
+class OrderDetailState

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailState.kt
@@ -1,3 +1,20 @@
 package com.hm.picplz.ui.screen.order_detail
 
-class OrderDetailState
+data class OrderDetailState(
+    val orderNumber: String = "",
+    val orderTime: String = "",
+    val customerName: String = "",
+    val phoneNumber: String = "",
+    val photographerName: String = "",
+    val productName: String = "",
+    val productImageUrl: String? = null,
+    val price: Int = 0,
+    val productDescription: String = "",
+    val shootingTime: String = "",
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    companion object {
+        fun idle(): OrderDetailState = OrderDetailState()
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
@@ -1,8 +1,63 @@
 package com.hm.picplz.ui.screen.order_detail
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class OrderDetailViewModel @Inject constructor() : ViewModel()
+class OrderDetailViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow(OrderDetailState.idle())
+    val state: StateFlow<OrderDetailState> = _state
+
+    private val _sideEffect = MutableSharedFlow<OrderDetailSideEffect>()
+    val sideEffect: SharedFlow<OrderDetailSideEffect> = _sideEffect
+
+    fun handleIntent(intent: OrderDetailIntent) {
+        when (intent) {
+            is OrderDetailIntent.OnBackClick -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(OrderDetailSideEffect.NavigateBack)
+                }
+            }
+            is OrderDetailIntent.OnNextClick -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(OrderDetailSideEffect.NavigateToNextStep)
+                }
+            }
+        }
+    }
+
+    fun loadOrderDetail(bookingId: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true)
+            try {
+                _state.value =
+                    OrderDetailState(
+                        orderNumber = "nnnnmmdd123456",
+                        orderTime = "2025-03-09 19:09:14",
+                        customerName = "가나다",
+                        phoneNumber = "01023293185",
+                        photographerName = "주로그",
+                        productName = "남친생기는 프사❤️",
+                        productImageUrl = "https://picsum.photos/id/222/300/300",
+                        price = 12000,
+                        productDescription = "작가가 해놓은 한줄소개 기렁지면 이렇게 처리 작가가 해놓은 한줄소개 기렁지면 이렇게 처리",
+                        shootingTime = "25.01.09 - 오후 02:00",
+                        isLoading = false,
+                    )
+            } catch (e: Exception) {
+                _state.value =
+                    _state.value.copy(
+                        isLoading = false,
+                        errorMessage = e.message ?: "주문 정보 조회 실패",
+                    )
+            }
+        }
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
@@ -1,0 +1,8 @@
+package com.hm.picplz.ui.screen.order_detail
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderDetailViewModel @Inject constructor() : ViewModel()

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
@@ -18,6 +18,10 @@ class OrderDetailViewModel @Inject constructor() : ViewModel() {
     private val _sideEffect = MutableSharedFlow<OrderDetailSideEffect>()
     val sideEffect: SharedFlow<OrderDetailSideEffect> = _sideEffect
 
+    init {
+        loadOrderDetail("")
+    }
+
     fun handleIntent(intent: OrderDetailIntent) {
         when (intent) {
             is OrderDetailIntent.OnBackClick -> {

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/CustomerInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/CustomerInfoSection.kt
@@ -1,0 +1,71 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainFontFamily
+import com.hm.picplz.ui.theme.MainThemeColor.Black
+import com.hm.picplz.ui.theme.MainThemeColor.Gray4
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@Composable
+fun CustomerInfoSection(
+    customerName: String,
+    phoneNumber: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.order_detail_section_customer_info),
+            style = MainThemeFont.ButtonDefault,
+            color = Black,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            modifier = Modifier.padding(bottom = 4.dp),
+            text = stringResource(R.string.order_detail_label_customer_name),
+            style = MainFontFamily.insideTag,
+            color = Gray4,
+        )
+
+        Text(
+            text = customerName,
+            style = MainThemeFont.Body,
+            color = Black,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            modifier = Modifier.padding(bottom = 4.dp),
+            text = stringResource(R.string.order_detail_label_phone_number),
+            style = MainFontFamily.insideTag,
+            color = Gray4,
+        )
+
+        Text(
+            text = phoneNumber,
+            style = MainThemeFont.Body,
+            color = Black,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CustomerInfoSectionPreview() {
+    CustomerInfoSection(
+        customerName = "주은강",
+        phoneNumber = "01012345678",
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/OrderDetailTopBar.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/OrderDetailTopBar.kt
@@ -1,0 +1,17 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.hm.picplz.ui.screen.common.CommonTopBar
+
+@Composable
+fun OrderDetailTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonTopBar(
+        modifier = modifier,
+        text = "주문 상세",
+        onClickBack = onBackClick,
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/OrderNumberSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/OrderNumberSection.kt
@@ -1,0 +1,52 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor.Black
+import com.hm.picplz.ui.theme.MainThemeColor.Gray4
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@Composable
+fun OrderNumberSection(
+    orderNumber: String,
+    orderTime: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            modifier = Modifier.padding(bottom = 4.dp),
+            text = stringResource(R.string.order_detail_section_order_number),
+            style = MainThemeFont.ButtonDefault,
+            color = Black,
+        )
+
+        Text(
+            text = orderNumber,
+            style = MainThemeFont.BodyBold,
+            color = Color(0XFFEF4747),
+        )
+
+        Text(
+            text = orderTime,
+            style = MainThemeFont.BodyBold,
+            color = Gray4,
+        )
+    }
+}
+
+@Preview(widthDp = 340)
+@Composable
+private fun OrderNumberSectionPreview() {
+    OrderNumberSection(
+        orderNumber = "nnnnmmdd123456",
+        orderTime = "2025-03-09 19:09:14",
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/PhotographerSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/PhotographerSection.kt
@@ -1,0 +1,35 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor.Black
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@Composable
+fun PhotographerSection(
+    photographerName: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.order_detail_section_photographer_type),
+            style = MainThemeFont.ButtonDefault,
+            color = Black,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = photographerName,
+            style = MainThemeFont.Body,
+            color = Black,
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/ProductInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/ProductInfoSection.kt
@@ -1,0 +1,111 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor.Black
+import com.hm.picplz.ui.theme.MainThemeColor.Gray4
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@Composable
+fun ProductInfoSection(
+    photographerImageUrl: String?,
+    photographerName: String,
+    price: Int,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(R.string.order_detail_section_product_info),
+            style = MainThemeFont.ButtonDefault,
+            color = Black,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(102.dp)
+                    .border(
+                        width = 1.dp,
+                        color = Black,
+                        shape = RoundedCornerShape(5.dp),
+                    ).padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            AsyncImage(
+                model = photographerImageUrl,
+                contentDescription = "주문 상품 사진",
+                modifier =
+                    Modifier
+                        .size(70.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+            )
+
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .align(Alignment.Top),
+            ) {
+                Text(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    text = photographerName,
+                    style = MainThemeFont.TitleSmall,
+                    color = Black,
+                )
+
+                Text(
+                    text = stringResource(R.string.price_format, price),
+                    style = MainThemeFont.Body,
+                    color = Black,
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Text(
+                    modifier = Modifier.padding(bottom = 2.dp),
+                    text = description,
+                    style = MainThemeFont.Caption,
+                    color = Gray4,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProductInfoSectionPreview() {
+    ProductInfoSection(
+        photographerImageUrl = "",
+        photographerName = "주문고",
+        price = 12000,
+        description = "작가가 해놓은 한줄소개 기렁지면 이렇게 처리 작가가 해놓은 한줄소개 기렁지면 이렇게 처리",
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/ScheduleSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/composable/ScheduleSection.kt
@@ -1,0 +1,45 @@
+package com.hm.picplz.ui.screen.order_detail.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor.Black
+import com.hm.picplz.ui.theme.MainThemeColor.Gray5
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@Composable
+fun ScheduleSection(
+    shootingTime: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.order_detail_section_shooting_schedule),
+            style = MainThemeFont.ButtonDefault,
+            color = Black,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = shootingTime,
+            style = MainThemeFont.Body,
+            color = Gray5,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ScheduleSectionPreview() {
+    ScheduleSection(
+        shootingTime = "25.01.09 - 오후 02:00",
+    )
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -49,4 +49,15 @@
     <string name="cancel_reservation_notice_suffix">추기 인내해야할 사항들~</string>
     <string name="cancel_reservation_button_history">취소내역 확인</string>
     <string name="cancel_reservation_button_home">홈으로</string>
+
+    <!-- 주문 상세 화면 -->
+    <string name="order_detail_section_order_number">주문번호</string>
+    <string name="order_detail_section_customer_info">주문 고객 정보</string>
+    <string name="order_detail_label_customer_name">이름</string>
+    <string name="order_detail_label_phone_number">전화번호</string>
+    <string name="order_detail_section_photographer_type">작가명</string>
+    <string name="order_detail_section_product_info">주문 상품 정보</string>
+    <string name="order_detail_section_shooting_schedule">촬영 희망 시각</string>
+    <string name="order_detail_button_next">다음</string>
+    <string name="price_format">%,d₩</string>
 </resources>


### PR DESCRIPTION
## 개요
주문(예약) 상세 페이지 구현. 고객의 주문 정보, 사진가 정보, 촬영 상품 정보, 촬영 일정 등을 표시하고 채팅 이동, 내역 보기, 거래 확정 등의 액션을 제공합니다.

## 변경 사항
- **네비게이션**: 주문 상세 페이지(`order-detail/{orderId}`) 라우트 추가 및 DetailReservationScreen에서 네비게이션 연결
- **MVI 구조**: OrderDetailState, OrderDetailIntent, OrderDetailSideEffect, OrderDetailViewModel 구현
- **화면 구성**:
  - OrderDetailScreen: 전체 레이아웃 및 상단 바
  - OrderNumberSection: 주문번호 섹션
  - CustomerInfoSection: 고객 정보 (이름, 전화번호)
  - PhotographerSection: 사진가 정보 섹션
  - ProductInfoSection: 주문 상품 정보 섹션
  - ScheduleSection: 촬영 일정 섹션
- **리소스**: 주문 상세 페이지 관련 문자열 추가 (12개 항목)

[Screen_recording_20260330_162026.webm](https://github.com/user-attachments/assets/3eb82563-83ba-419a-a355-aad55b159470)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #132
