### PR TITLE
✨ 지난 촬영 내역 화면 피그마 디자인 반영 + MVI (#143)

### DIFF
--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -46,4 +46,16 @@
     <string name="review_photo">리뷰 사진</string>
     <string name="review_image">리뷰 이미지</string>
     <string name="like">좋아요</string>
+
+    <!-- ShootingHistoryCard -->
+    <string name="shooting_history_title">지난 촬영 내역</string>
+    <string name="shooting_history_payment_date">%s 결제</string>
+    <string name="shooting_history_price_won">%s원</string>
+    <string name="shooting_history_date_label">촬영 일시</string>
+    <string name="shooting_history_location_label">촬영 장소</string>
+    <string name="shooting_history_view_order_detail">주문 상세보기 ></string>
+    <string name="shooting_history_go_chat">채팅 가기</string>
+    <string name="shooting_history_write_review">리뷰 쓰기</string>
+    <string name="shooting_history_delete">내역 삭제</string>
+    <string name="shooting_history_no_chat_room">채팅방이 없습니다.</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
     <string name="shooting_history_price_won">%s원</string>
     <string name="shooting_history_date_label">촬영 일시</string>
     <string name="shooting_history_location_label">촬영 장소</string>
-    <string name="shooting_history_view_order_detail">주문 상세보기 ></string>
+    <string name="shooting_history_view_order_detail">주문 상세보기</string>
     <string name="shooting_history_go_chat">채팅 가기</string>
     <string name="shooting_history_write_review">리뷰 쓰기</string>
     <string name="shooting_history_delete">내역 삭제</string>

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageShootingHistoryScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageShootingHistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.my_page
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,16 +10,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
-import com.hm.picplz.ui.screen.my_page.shootingHistoryCard.ShootingStatus
 import com.hm.picplz.ui.screen.my_page.shootingHistoryCard.SwipeableShootingHistoryCard
 import com.hm.picplz.ui.theme.MainThemeColor
 
@@ -26,12 +33,34 @@ import com.hm.picplz.ui.theme.MainThemeColor
 fun MyPageShootingHistoryScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController,
+    viewModel: ShootingHistoryViewModel = hiltViewModel(),
 ) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is ShootingHistorySideEffect.NavigateBack -> {
+                    navController.popBackStack()
+                }
+                is ShootingHistorySideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                }
+                is ShootingHistorySideEffect.NavigateToOrderDetail -> {
+                    navController.navigate(MyPageOrderSheet)
+                }
+            }
+        }
+    }
+
     Scaffold(
         containerColor = MainThemeColor.White,
         topBar = {
-            CommonFixedTopBar(title = "내 촬영 내역") {
-                navController.popBackStack()
+            CommonFixedTopBar(
+                title = stringResource(R.string.shooting_history_title),
+            ) {
+                viewModel.handleIntent(ShootingHistoryIntent.NavigateBack)
             }
         },
         modifier =
@@ -52,50 +81,40 @@ fun MyPageShootingHistoryScreen(
                 modifier = Modifier.padding(horizontal = 15.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                item {
+                items(
+                    items = state.shootingHistories,
+                    key = { it.id },
+                ) { item ->
                     SwipeableShootingHistoryCard(
-                        userName = "합정동 불주먹@@",
-                        userProfile = R.drawable.edit_grey4,
-                        status = ShootingStatus.COMPLEETED,
-                        date = "5월 26일 오전 9시 30분",
-                        location = "종로구 효자로 33",
-                        onClickOrderSheet = { navController.navigate(MyPageOrderSheet) },
-                    )
-                }
-                item {
-                    SwipeableShootingHistoryCard(
-                        userName = "합정동 불주먹",
-                        userProfile = R.drawable.edit_grey4,
-                        status = ShootingStatus.CANCLED,
-                        date = "5월 26일 오전 9시 30분",
-                        location = "종로구 효자로 33",
-                    )
-                }
-                item {
-                    SwipeableShootingHistoryCard(
-                        userName = "합정동 불주먹",
-                        userProfile = R.drawable.edit_grey4,
-                        status = ShootingStatus.CANCLED,
-                        date = "5월 26일 오전 9시 30분",
-                        location = "종로구 효자로 33",
-                    )
-                }
-                item {
-                    SwipeableShootingHistoryCard(
-                        userName = "합정동 불주먹",
-                        userProfile = R.drawable.edit_grey4,
-                        status = ShootingStatus.CANCLED,
-                        date = "5월 26일 오전 9시 30분",
-                        location = "종로구 효자로 33",
-                    )
-                }
-                item {
-                    SwipeableShootingHistoryCard(
-                        userName = "합정동 불주먹",
-                        userProfile = R.drawable.edit_grey4,
-                        status = ShootingStatus.CANCLED,
-                        date = "5월 26일 오전 9시 30분",
-                        location = "종로구 효자로 33",
+                        photographerName = item.photographerName,
+                        photographerImageUri = item.photographerImageUri,
+                        productName = item.productName,
+                        price = item.price,
+                        status = item.status,
+                        paymentDate = item.paymentDate,
+                        shootingDate = item.shootingDate,
+                        shootingLocation = item.shootingLocation,
+                        hasChatRoom = item.hasChatRoom,
+                        onDismiss = {
+                            viewModel.handleIntent(
+                                ShootingHistoryIntent.DeleteHistory(item.id),
+                            )
+                        },
+                        onClickChat = {
+                            viewModel.handleIntent(
+                                ShootingHistoryIntent.NavigateToChat(item.id),
+                            )
+                        },
+                        onClickReview = {
+                            viewModel.handleIntent(
+                                ShootingHistoryIntent.WriteReview(item.id),
+                            )
+                        },
+                        onClickOrderDetail = {
+                            viewModel.handleIntent(
+                                ShootingHistoryIntent.ViewOrderDetail(item.id),
+                            )
+                        },
                     )
                 }
             }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryIntent.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface ShootingHistoryIntent {
+    data object NavigateBack : ShootingHistoryIntent
+
+    data class NavigateToChat(val historyId: String) : ShootingHistoryIntent
+
+    data class WriteReview(val historyId: String) : ShootingHistoryIntent
+
+    data class ViewOrderDetail(val historyId: String) : ShootingHistoryIntent
+
+    data class DeleteHistory(val historyId: String) : ShootingHistoryIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistorySideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistorySideEffect.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface ShootingHistorySideEffect {
+    data object NavigateBack : ShootingHistorySideEffect
+
+    data class ShowToast(val message: String) : ShootingHistorySideEffect
+
+    data class NavigateToOrderDetail(val historyId: String) : ShootingHistorySideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryState.kt
@@ -1,0 +1,25 @@
+package com.hm.picplz.ui.screen.my_page
+
+import com.hm.picplz.ui.screen.my_page.shootingHistoryCard.ShootingStatus
+
+data class ShootingHistoryState(
+    val shootingHistories: List<ShootingHistoryItem> = emptyList(),
+    val isLoading: Boolean = false,
+) {
+    companion object {
+        fun idle() = ShootingHistoryState()
+    }
+}
+
+data class ShootingHistoryItem(
+    val id: String,
+    val photographerName: String,
+    val photographerImageUri: String,
+    val productName: String,
+    val price: Int,
+    val status: ShootingStatus,
+    val paymentDate: String,
+    val shootingDate: String,
+    val shootingLocation: String,
+    val hasChatRoom: Boolean,
+)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/ShootingHistoryViewModel.kt
@@ -1,0 +1,116 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.ui.screen.my_page.shootingHistoryCard.ShootingStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ShootingHistoryViewModel
+    @Inject
+    constructor() : ViewModel() {
+        private val _state = MutableStateFlow(DEV_MOCK_STATE)
+        val state: StateFlow<ShootingHistoryState> get() = _state
+
+        private val _sideEffect = Channel<ShootingHistorySideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        fun handleIntent(intent: ShootingHistoryIntent) {
+            when (intent) {
+                is ShootingHistoryIntent.NavigateBack -> {
+                    sendSideEffect(ShootingHistorySideEffect.NavigateBack)
+                }
+                is ShootingHistoryIntent.NavigateToChat -> {
+                    val item = findItem(intent.historyId)
+                    if (item?.hasChatRoom == true) {
+                        sendSideEffect(
+                            ShootingHistorySideEffect.ShowToast("채팅 기능은 준비 중입니다."),
+                        )
+                    } else {
+                        sendSideEffect(
+                            ShootingHistorySideEffect.ShowToast("채팅방이 없습니다."),
+                        )
+                    }
+                }
+                is ShootingHistoryIntent.WriteReview -> {
+                    sendSideEffect(
+                        ShootingHistorySideEffect.ShowToast("리뷰 기능은 준비 중입니다."),
+                    )
+                }
+                is ShootingHistoryIntent.ViewOrderDetail -> {
+                    sendSideEffect(
+                        ShootingHistorySideEffect.NavigateToOrderDetail(intent.historyId),
+                    )
+                }
+                is ShootingHistoryIntent.DeleteHistory -> {
+                    _state.update { current ->
+                        current.copy(
+                            shootingHistories =
+                                current.shootingHistories.filter { it.id != intent.historyId },
+                        )
+                    }
+                }
+            }
+        }
+
+        private fun findItem(historyId: String): ShootingHistoryItem? =
+            _state.value.shootingHistories.find { it.id == historyId }
+
+        private fun sendSideEffect(effect: ShootingHistorySideEffect) {
+            viewModelScope.launch {
+                _sideEffect.send(effect)
+            }
+        }
+
+        companion object {
+            private val DEV_MOCK_STATE =
+                ShootingHistoryState(
+                    shootingHistories =
+                        listOf(
+                            ShootingHistoryItem(
+                                id = "1",
+                                photographerName = "합정동작가",
+                                photographerImageUri = "",
+                                productName = "남친생기는 프사",
+                                price = 12000,
+                                status = ShootingStatus.CANCELLED,
+                                paymentDate = "2025.03.01",
+                                shootingDate = "25.03.24 | 오후2:30",
+                                shootingLocation = "종로구 효자로 33 어디어디빌딩",
+                                hasChatRoom = true,
+                            ),
+                            ShootingHistoryItem(
+                                id = "2",
+                                photographerName = "유가영사진",
+                                photographerImageUri = "",
+                                productName = "인스타 피드꾸미기",
+                                price = 12000,
+                                status = ShootingStatus.COMPLETED,
+                                paymentDate = "2025.03.01",
+                                shootingDate = "25.03.24 | 오후2:30",
+                                shootingLocation = "종로구 효자로 33 어디어디 어디",
+                                hasChatRoom = true,
+                            ),
+                            ShootingHistoryItem(
+                                id = "3",
+                                photographerName = "유가영사진",
+                                photographerImageUri = "",
+                                productName = "인스타 피드꾸미기",
+                                price = 12000,
+                                status = ShootingStatus.COMPLETED,
+                                paymentDate = "2025.03.01",
+                                shootingDate = "25.03.24 | 오후2:30",
+                                shootingLocation = "종로구 효자로 33",
+                                hasChatRoom = false,
+                            ),
+                        ),
+                )
+        }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
@@ -23,18 +23,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.screen.common.BadgeTheme
 import com.hm.picplz.ui.screen.common.CommonBadge
-import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
+import java.text.NumberFormat
+import java.util.Locale
 
 enum class PackageType(val label: String) {
     PROFILE("프로필 패키지"),
@@ -43,197 +46,294 @@ enum class PackageType(val label: String) {
 }
 
 enum class ReservationStatus(val label: String) {
-    PENDING("예약 대기"), // 예약대기
-    CONFIRMED("거래 확정"), // 거래확정
-    INPROGRESS("촬영 진행"), // 촬영진행
+    PENDING("예약 대기"),
+    CONFIRMED("거래 확정"),
+    INPROGRESS("촬영 진행"),
 }
 
 enum class ShootingStatus(val label: String) {
-    COMPLEETED("촬영 완료"),
-    CANCLED("취소 완료"),
+    COMPLETED("촬영 완료"),
+    CANCELLED("촬영 취소"),
 }
 
 enum class ReservationType(val label: String) {
-    ASAP("바로 촬영"), // ASAP
-    NORMAL("일반 예약"), // 일반예약
+    ASAP("바로 촬영"),
+    NORMAL("일반 예약"),
+}
+
+private object ShootingHistoryCardDefaults {
+    val CardCornerRadius = 5.dp
+    val CardHorizontalPadding = 18.dp
+    val CardVerticalPadding = 20.dp
+    val ProfileImageSize = 40.dp
 }
 
 @Composable
 fun ShootingHistoryCard(
     modifier: Modifier = Modifier,
-    horizontalPadding: Dp = 18.dp,
-    verticalPadding: Dp = 23.5.dp,
-    borderRadius: Dp = 5.dp,
-    userName: String = "",
-    userProfile: Int = R.drawable.default_profile,
-    status: ShootingStatus = ShootingStatus.CANCLED,
-    packageType: PackageType = PackageType.PROFILE,
-    paymentDate: String = "2025.03.01",
-    date: String = "",
-    location: String = "",
-    onClickOrderSheet: () -> Unit = {},
+    photographerName: String,
+    photographerImageUri: String,
+    productName: String,
+    price: Int,
+    status: ShootingStatus,
+    paymentDate: String,
+    shootingDate: String,
+    shootingLocation: String,
+    hasChatRoom: Boolean = true,
+    onClickChat: () -> Unit = {},
+    onClickReview: () -> Unit = {},
+    onClickOrderDetail: () -> Unit = {},
 ) {
+    val formattedPrice = NumberFormat.getNumberInstance(Locale.KOREA).format(price)
+
     Box(
         modifier =
             modifier
                 .wrapContentSize()
-                .clip(RoundedCornerShape(borderRadius))
-                .border(1.dp, MainThemeColor.Gray2, RoundedCornerShape(borderRadius))
+                .clip(RoundedCornerShape(ShootingHistoryCardDefaults.CardCornerRadius))
+                .border(
+                    1.dp,
+                    MainThemeColor.Gray2,
+                    RoundedCornerShape(ShootingHistoryCardDefaults.CardCornerRadius),
+                )
                 .background(MainThemeColor.Gray1),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontalPadding, verticalPadding),
+                    .padding(
+                        horizontal = ShootingHistoryCardDefaults.CardHorizontalPadding,
+                        vertical = ShootingHistoryCardDefaults.CardVerticalPadding,
+                    ),
         ) {
-            Column {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Image(
-                            painter = painterResource(id = userProfile),
-                            contentDescription = "user-profile",
-                            modifier =
-                                Modifier
-                                    .size(40.dp)
-                                    .border(1.dp, MainThemeColor.Gray3, CircleShape)
-                                    .clip(CircleShape),
-                        )
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(2.dp),
-                        ) {
-                            Text(text = userName, style = MainThemeFont.BodyBold)
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(2.5.dp),
-                            ) {
-                                when (status) {
-                                    ShootingStatus.CANCLED ->
-                                        CommonBadge(
-                                            label = status.label,
-                                            theme = BadgeTheme.INACTIVE,
-                                            modifier =
-                                                Modifier.border(
-                                                    1.dp,
-                                                    MainThemeColor.Pink2,
-                                                    RoundedCornerShape(5.dp),
-                                                ),
-                                        )
+            PhotographerHeader(
+                photographerName = photographerName,
+                photographerImageUri = photographerImageUri,
+                paymentDate = paymentDate,
+            )
 
-                                    ShootingStatus.COMPLEETED ->
-                                        CommonBadge(
-                                            label = status.label,
-                                            theme = BadgeTheme.ACTIVE,
-                                            modifier =
-                                                Modifier.border(
-                                                    1.dp,
-                                                    MainThemeColor.Olive,
-                                                    RoundedCornerShape(5.dp),
-                                                ),
-                                        )
-                                }
-                            }
-                        }
-                    }
-                    Text(
-                        text = "$paymentDate 결제",
-                        style = MainThemeFont.Caption,
-                        color = MainThemeColor.Gray4,
-                    )
-                }
-                Spacer(modifier = Modifier.height(13.5.dp))
-                Text(text = packageType.label, style = MainThemeFont.Title)
-                HorizontalDivider(
-                    thickness = 1.dp,
-                    color = MainThemeColor.Gray2,
-                    modifier = Modifier.padding(vertical = 8.dp),
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(text = productName, style = MainThemeFont.Body)
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            PriceBadgeRow(
+                formattedPrice = formattedPrice,
+                status = status,
+            )
+
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = MainThemeColor.Gray2,
+                modifier = Modifier.padding(vertical = 12.dp),
+            )
+
+            ShootingInfoSection(
+                shootingDate = shootingDate,
+                shootingLocation = shootingLocation,
+                onClickOrderDetail = onClickOrderDetail,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ActionButtons(
+                status = status,
+                hasChatRoom = hasChatRoom,
+                onClickChat = onClickChat,
+                onClickReview = onClickReview,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerHeader(
+    photographerName: String,
+    photographerImageUri: String,
+    paymentDate: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (photographerImageUri.isNotEmpty()) {
+                AsyncImage(
+                    model = photographerImageUri,
+                    contentDescription = stringResource(R.string.user_profile),
+                    modifier =
+                        Modifier
+                            .size(ShootingHistoryCardDefaults.ProfileImageSize)
+                            .border(1.dp, MainThemeColor.Gray3, CircleShape)
+                            .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
                 )
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Image(
-                            painter = painterResource(id = R.drawable.clock_green),
-                            contentDescription = "clock",
-                            modifier = Modifier.size(13.dp),
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "촬영 일시",
-                            style = MainThemeFont.Body,
-                            color = MainThemeColor.Gray4,
-                        )
-                        Spacer(modifier = Modifier.width(14.dp))
-                        Text(text = date, style = MainThemeFont.BodyBold)
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Row {
-                            Image(
-                                painter = painterResource(id = R.drawable.location_green),
-                                contentDescription = "clock",
-                                modifier = Modifier.size(13.dp),
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "촬영 장소",
-                                style = MainThemeFont.Body,
-                                color = MainThemeColor.Gray4,
-                            )
-                            Spacer(modifier = Modifier.width(14.dp))
-                            Text(text = location, style = MainThemeFont.BodyBold)
-                        }
-                        Text(
-                            text = "주문 상세",
-                            style = MainThemeFont.Caption,
-                            color = MainThemeColor.Gray4,
-                            textDecoration = TextDecoration.Underline,
-                            modifier = Modifier.clickable { onClickOrderSheet() },
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(23.dp))
-                    CommonBottomButton(
-                        text = if (status === ShootingStatus.COMPLEETED) "리뷰 쓰러가기" else "다시 예약하기",
-                        onClick = { },
-                    )
-                }
+            } else {
+                Image(
+                    painter = painterResource(id = R.drawable.default_profile),
+                    contentDescription = stringResource(R.string.user_profile),
+                    modifier =
+                        Modifier
+                            .size(ShootingHistoryCardDefaults.ProfileImageSize)
+                            .border(1.dp, MainThemeColor.Gray3, CircleShape)
+                            .clip(CircleShape),
+                )
+            }
+            Text(text = photographerName, style = MainThemeFont.BodyBold)
+        }
+        Text(
+            text = stringResource(R.string.shooting_history_payment_date, paymentDate),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Composable
+private fun PriceBadgeRow(
+    formattedPrice: String,
+    status: ShootingStatus,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.shooting_history_price_won, formattedPrice),
+            style = MainThemeFont.Title,
+        )
+        CommonBadge(
+            label = status.label,
+            theme =
+                when (status) {
+                    ShootingStatus.COMPLETED -> BadgeTheme.ACTIVE
+                    ShootingStatus.CANCELLED -> BadgeTheme.INACTIVE
+                },
+        )
+    }
+}
+
+@Composable
+private fun ShootingInfoSection(
+    shootingDate: String,
+    shootingLocation: String,
+    onClickOrderDetail: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row {
+            Text(
+                text = stringResource(R.string.shooting_history_date_label),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(text = shootingDate, style = MainThemeFont.BodyBold)
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.shooting_history_location_label),
+                    style = MainThemeFont.Body,
+                    color = MainThemeColor.Gray4,
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(text = shootingLocation, style = MainThemeFont.BodyBold)
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Text(
+                text = stringResource(R.string.shooting_history_view_order_detail),
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+                modifier = Modifier.clickable { onClickOrderDetail() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionButtons(
+    status: ShootingStatus,
+    hasChatRoom: Boolean,
+    onClickChat: () -> Unit,
+    onClickReview: () -> Unit,
+) {
+    when (status) {
+        ShootingStatus.CANCELLED -> {
+            CommonBottomOutlinedButton(
+                text = stringResource(R.string.shooting_history_go_chat),
+                onClick = onClickChat,
+                enabled = hasChatRoom,
+            )
+        }
+        ShootingStatus.COMPLETED -> {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                CommonBottomOutlinedButton(
+                    text = stringResource(R.string.shooting_history_go_chat),
+                    onClick = onClickChat,
+                    modifier = Modifier.weight(1f),
+                    enabled = hasChatRoom,
+                )
+                CommonBottomOutlinedButton(
+                    text = stringResource(R.string.shooting_history_write_review),
+                    onClick = onClickReview,
+                    modifier = Modifier.weight(1f),
+                )
             }
         }
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-fun ShootingHistoryCardCompletedPreview() {
+private fun ShootingHistoryCardCancelledPreview() {
     PicplzTheme {
         ShootingHistoryCard(
-            userName = "합정동 불주먹",
-            userProfile = R.drawable.edit_grey4,
-            status = ShootingStatus.COMPLEETED,
-            date = "5월 26일 오전 9시 30분",
-            location = "종로구 효자로 33",
+            photographerName = "합정동작가",
+            photographerImageUri = "",
+            productName = "남친생기는 프사",
+            price = 12000,
+            status = ShootingStatus.CANCELLED,
+            paymentDate = "2025.03.01",
+            shootingDate = "25.03.24 | 오후2:30",
+            shootingLocation = "종로구 효자로 33 어디어디빌딩",
         )
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-fun ShootingHistoryCardCancledPreview() {
+private fun ShootingHistoryCardCompletedPreview() {
     PicplzTheme {
         ShootingHistoryCard(
-            userName = "합정동 불주먹",
-            userProfile = R.drawable.edit_grey4,
-            status = ShootingStatus.CANCLED,
-            date = "5월 26일 오전 9시 30분",
-            location = "종로구 효자로 33",
+            photographerName = "유가영사진",
+            photographerImageUri = "",
+            productName = "인스타 피드꾸미기",
+            price = 12000,
+            status = ShootingStatus.COMPLETED,
+            paymentDate = "2025.03.01",
+            shootingDate = "25.03.24 | 오후2:30",
+            shootingLocation = "종로구 효자로 33 어디어디 어디",
         )
     }
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/ShootingHistoryCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,13 +27,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.screen.common.BadgeTheme
 import com.hm.picplz.ui.screen.common.CommonBadge
-import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
@@ -65,7 +66,8 @@ private object ShootingHistoryCardDefaults {
     val CardCornerRadius = 5.dp
     val CardHorizontalPadding = 18.dp
     val CardVerticalPadding = 20.dp
-    val ProfileImageSize = 40.dp
+    val ProfileImageSize = 24.dp
+    val ContentGap = 12.dp
 }
 
 @Composable
@@ -96,7 +98,7 @@ fun ShootingHistoryCard(
                     MainThemeColor.Gray2,
                     RoundedCornerShape(ShootingHistoryCardDefaults.CardCornerRadius),
                 )
-                .background(MainThemeColor.Gray1),
+                .background(MainThemeColor.White),
     ) {
         Column(
             modifier =
@@ -106,37 +108,54 @@ fun ShootingHistoryCard(
                         horizontal = ShootingHistoryCardDefaults.CardHorizontalPadding,
                         vertical = ShootingHistoryCardDefaults.CardVerticalPadding,
                     ),
+            verticalArrangement = Arrangement.spacedBy(ShootingHistoryCardDefaults.ContentGap),
         ) {
-            PhotographerHeader(
-                photographerName = photographerName,
-                photographerImageUri = photographerImageUri,
-                paymentDate = paymentDate,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Text(text = productName, style = MainThemeFont.Body)
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            PriceBadgeRow(
-                formattedPrice = formattedPrice,
-                status = status,
-            )
+            Column {
+                PhotographerHeader(
+                    photographerName = photographerName,
+                    photographerImageUri = photographerImageUri,
+                    paymentDate = paymentDate,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = productName, style = MainThemeFont.Body)
+                Spacer(modifier = Modifier.height(4.dp))
+                PriceBadgeRow(
+                    formattedPrice = formattedPrice,
+                    status = status,
+                )
+            }
 
             HorizontalDivider(
                 thickness = 1.dp,
                 color = MainThemeColor.Gray2,
-                modifier = Modifier.padding(vertical = 12.dp),
             )
 
-            ShootingInfoSection(
+            ShootingDateLocationSection(
                 shootingDate = shootingDate,
                 shootingLocation = shootingLocation,
-                onClickOrderDetail = onClickOrderDetail,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { onClickOrderDetail() },
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.shooting_history_view_order_detail),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Gray3,
+                )
+                Spacer(modifier = Modifier.width(2.dp))
+                Icon(
+                    painter = painterResource(id = R.drawable.depth_arrow),
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = MainThemeColor.Gray3,
+                )
+            }
 
             ActionButtons(
                 status = status,
@@ -190,7 +209,7 @@ private fun PhotographerHeader(
         Text(
             text = stringResource(R.string.shooting_history_payment_date, paymentDate),
             style = MainThemeFont.Caption,
-            color = MainThemeColor.Gray4,
+            color = MainThemeColor.Gray3,
         )
     }
 }
@@ -206,7 +225,9 @@ private fun PriceBadgeRow(
     ) {
         Text(
             text = stringResource(R.string.shooting_history_price_won, formattedPrice),
-            style = MainThemeFont.Title,
+            style = MainThemeFont.BodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = MainThemeColor.Gray6,
         )
         CommonBadge(
             label = status.label,
@@ -215,18 +236,26 @@ private fun PriceBadgeRow(
                     ShootingStatus.COMPLETED -> BadgeTheme.ACTIVE
                     ShootingStatus.CANCELLED -> BadgeTheme.INACTIVE
                 },
+            modifier =
+                Modifier.border(
+                    1.dp,
+                    when (status) {
+                        ShootingStatus.COMPLETED -> MainThemeColor.Green100
+                        ShootingStatus.CANCELLED -> MainThemeColor.Pink2
+                    },
+                    RoundedCornerShape(5.dp),
+                ),
         )
     }
 }
 
 @Composable
-private fun ShootingInfoSection(
+private fun ShootingDateLocationSection(
     shootingDate: String,
     shootingLocation: String,
-    onClickOrderDetail: () -> Unit,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         Row {
             Text(
@@ -235,33 +264,32 @@ private fun ShootingInfoSection(
                 color = MainThemeColor.Gray4,
             )
             Spacer(modifier = Modifier.width(12.dp))
-            Text(text = shootingDate, style = MainThemeFont.BodyBold)
+            ShootingDateText(shootingDate)
         }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.Top,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.shooting_history_location_label),
-                    style = MainThemeFont.Body,
-                    color = MainThemeColor.Gray4,
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(text = shootingLocation, style = MainThemeFont.BodyBold)
-            }
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-        ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
             Text(
-                text = stringResource(R.string.shooting_history_view_order_detail),
-                style = MainThemeFont.Caption,
+                text = stringResource(R.string.shooting_history_location_label),
+                style = MainThemeFont.Body,
                 color = MainThemeColor.Gray4,
-                modifier = Modifier.clickable { onClickOrderDetail() },
             )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = shootingLocation,
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Gray5,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShootingDateText(shootingDate: String) {
+    val parts = shootingDate.split("|").map { it.trim() }
+    Row {
+        Text(text = parts[0], style = MainThemeFont.BodyBold, color = MainThemeColor.Gray5)
+        if (parts.size > 1) {
+            Text(text = " | ", style = MainThemeFont.BodyBold, color = MainThemeColor.Gray3)
+            Text(text = parts[1], style = MainThemeFont.BodyBold, color = MainThemeColor.Gray5)
         }
     }
 }
@@ -275,10 +303,11 @@ private fun ActionButtons(
 ) {
     when (status) {
         ShootingStatus.CANCELLED -> {
-            CommonBottomOutlinedButton(
+            ShootingHistoryButton(
                 text = stringResource(R.string.shooting_history_go_chat),
                 onClick = onClickChat,
                 enabled = hasChatRoom,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
         ShootingStatus.COMPLETED -> {
@@ -286,19 +315,53 @@ private fun ActionButtons(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                CommonBottomOutlinedButton(
+                ShootingHistoryButton(
                     text = stringResource(R.string.shooting_history_go_chat),
                     onClick = onClickChat,
-                    modifier = Modifier.weight(1f),
                     enabled = hasChatRoom,
+                    modifier = Modifier.weight(1f),
                 )
-                CommonBottomOutlinedButton(
+                ShootingHistoryButton(
                     text = stringResource(R.string.shooting_history_write_review),
                     onClick = onClickReview,
                     modifier = Modifier.weight(1f),
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ShootingHistoryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val backgroundColor = if (enabled) MainThemeColor.White else MainThemeColor.Gray2
+    val textColor = if (enabled) MainThemeColor.Gray6 else MainThemeColor.Gray3
+    val borderModifier =
+        if (enabled) {
+            Modifier.border(1.dp, MainThemeColor.Gray3, RoundedCornerShape(5.dp))
+        } else {
+            Modifier
+        }
+
+    Box(
+        modifier =
+            modifier
+                .height(40.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .then(borderModifier)
+                .background(backgroundColor)
+                .clickable(enabled = enabled) { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MainThemeFont.Body,
+            color = textColor,
+        )
     }
 }
 

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/SwipeableShootingHistoryCard.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/shootingHistoryCard/SwipeableShootingHistoryCard.kt
@@ -29,26 +29,38 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.theme.MainThemeFont
 import kotlin.math.abs
 
+private object SwipeableDefaults {
+    val MaxSwipeWidth = 140.dp
+    val DeleteAreaHeight = 253.dp
+    val DeleteIconSize = 20.dp
+    val CardCornerRadius = 5.dp
+}
+
 @Composable
 fun SwipeableShootingHistoryCard(
     modifier: Modifier = Modifier,
-    userName: String = "",
-    userProfile: Int = R.drawable.default_profile,
-    status: ShootingStatus = ShootingStatus.CANCLED,
-    packageType: PackageType = PackageType.PROFILE,
-    paymentDate: String = "2025.03.01",
-    date: String = "",
-    location: String = "",
+    photographerName: String,
+    photographerImageUri: String,
+    productName: String,
+    price: Int,
+    status: ShootingStatus,
+    paymentDate: String,
+    shootingDate: String,
+    shootingLocation: String,
+    hasChatRoom: Boolean = true,
     onDismiss: () -> Unit = {},
-    onClickOrderSheet: () -> Unit = {},
+    onClickChat: () -> Unit = {},
+    onClickReview: () -> Unit = {},
+    onClickOrderDetail: () -> Unit = {},
 ) {
     var offsetX by remember { mutableFloatStateOf(0f) }
-    val maxSwipeDistance = with(LocalDensity.current) { 140.dp.toPx() } // 최대 140px까지만 스와이프
+    val maxSwipeDistance = with(LocalDensity.current) { SwipeableDefaults.MaxSwipeWidth.toPx() }
 
     val animatedOffsetX by animateFloatAsState(
         targetValue = offsetX,
@@ -70,14 +82,13 @@ fun SwipeableShootingHistoryCard(
                 Modifier
                     .fillMaxWidth()
                     .height(IntrinsicSize.Min)
-                    .clip(RoundedCornerShape(5.dp)),
+                    .clip(RoundedCornerShape(SwipeableDefaults.CardCornerRadius)),
         ) {
-            // 삭제 영역 (오른쪽에 고정)
             Box(
                 modifier =
                     Modifier
-                        .height(253.dp)
-                        .width(140.dp)
+                        .height(SwipeableDefaults.DeleteAreaHeight)
+                        .width(SwipeableDefaults.MaxSwipeWidth)
                         .align(Alignment.CenterEnd)
                         .background(
                             Color(0xFFEF4747).copy(alpha = deleteBackgroundAlpha),
@@ -96,13 +107,13 @@ fun SwipeableShootingHistoryCard(
                     ) {
                         Icon(
                             painter = painterResource(id = R.drawable.bin),
-                            contentDescription = "Delete",
+                            contentDescription = stringResource(R.string.shooting_history_delete),
                             tint = Color.White,
-                            modifier = Modifier.size(20.dp),
+                            modifier = Modifier.size(SwipeableDefaults.DeleteIconSize),
                         )
                         Spacer(modifier = Modifier.height(6.dp))
                         Text(
-                            text = "내역 삭제️",
+                            text = stringResource(R.string.shooting_history_delete),
                             color = Color.White,
                             style = MainThemeFont.Caption,
                         )
@@ -111,7 +122,6 @@ fun SwipeableShootingHistoryCard(
             }
         }
 
-        // 메인 컨텐츠 (스와이프되는 부분)
         Box(
             modifier =
                 Modifier
@@ -119,35 +129,37 @@ fun SwipeableShootingHistoryCard(
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures(
                             onDragEnd = {
-                                // 드래그 종료 시 위치 결정
                                 offsetX =
                                     when {
-                                        offsetX < -maxSwipeDistance / 2 -> -maxSwipeDistance // 절반 이상 스와이프하면 완전히 열기
-                                        offsetX > maxSwipeDistance / 2 -> maxSwipeDistance // 오른쪽으로 스와이프한 경우
-                                        else -> 0f // 원래 위치로 복귀
+                                        offsetX < -maxSwipeDistance / 2 -> -maxSwipeDistance
+                                        offsetX > maxSwipeDistance / 2 -> maxSwipeDistance
+                                        else -> 0f
                                     }
                             },
                         ) { _, dragAmount ->
-                            // 왼쪽으로만 스와이프 가능하도록 제한
                             val newOffset = offsetX + dragAmount
                             offsetX =
                                 when {
-                                    newOffset > 0 -> 0f // 오른쪽으로는 스와이프 불가
-                                    newOffset < -maxSwipeDistance -> -maxSwipeDistance // 최대 거리 제한
+                                    newOffset > 0 -> 0f
+                                    newOffset < -maxSwipeDistance -> -maxSwipeDistance
                                     else -> newOffset
                                 }
                         }
                     },
         ) {
             ShootingHistoryCard(
-                userName = userName,
-                userProfile = userProfile,
+                photographerName = photographerName,
+                photographerImageUri = photographerImageUri,
+                productName = productName,
+                price = price,
                 status = status,
-                packageType = packageType,
                 paymentDate = paymentDate,
-                date = date,
-                location = location,
-                onClickOrderSheet = onClickOrderSheet,
+                shootingDate = shootingDate,
+                shootingLocation = shootingLocation,
+                hasChatRoom = hasChatRoom,
+                onClickChat = onClickChat,
+                onClickReview = onClickReview,
+                onClickOrderDetail = onClickOrderDetail,
             )
         }
     }


### PR DESCRIPTION
## Summary
- 지난 촬영 내역 화면(`MyPageShootingHistoryScreen`) 피그마 디자인 반영 및 MVI 구조 도입

## Changes

### MVI 구조 신규
- `ShootingHistoryState` / `Intent` / `SideEffect` / `ViewModel`
- DEV mock 데이터 3건 (취소 1, 완료 2 — 채팅방 유/무)

### ShootingHistoryCard 피그마 반영
- 가격 표시 (`BodyLarge Bold, Gray6`) + 상품명 자유 텍스트
- 뱃지: 취소(`Pink2` border) / 완료(`Green100` border)
- 촬영일시/장소 값 `Gray5`, `|` 구분자 `Gray3`
- 주문 상세보기 `Gray3` + `depth_arrow` 꺽쇠 아이콘
- 전용 버튼: 활성화(White/Gray3 border/Gray6) / 비활성화(Gray2/no border/Gray3)
- 카드 배경 White + 테두리 Gray2, 프로필 24×24

### Enum 수정
- `COMPLEETED` → `COMPLETED`, `CANCLED` → `CANCELLED`
- "취소 완료" → "촬영 취소"

### Screen
- `MyPageShootingHistoryScreen` ViewModel 주입 + sideEffect 연동
- `SwipeableShootingHistoryCard` 유지 (새 props 전달)

## 구현화면

![KakaoTalk_Video_2026-04-07-17-09-58](https://github.com/user-attachments/assets/dcc4e3d3-a7ef-470f-9ce6-eeb34499c721)


### 리소스
- `strings.xml` 촬영 내역 관련 10개 추가

## Closes #143
