### PR TITLE
✨ : 결제 후 예약 취소 - 취소 사유 선택 및 입력 페이지 구현

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.CancelReservation
 import com.hm.picplz.navigation.model.CancelReservationConfirm
 import com.hm.picplz.navigation.model.Chat
 import com.hm.picplz.navigation.model.ChatRoom
@@ -18,6 +19,7 @@ import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.Reservation
+import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationScreen
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
 import com.hm.picplz.ui.screen.chat.ChatScreen
 import com.hm.picplz.ui.screen.chat_room.ChatRoomScreen
@@ -80,11 +82,11 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateBack = {
                 navController.popBackStack()
             },
-            onNavigateCancelReservation = {
+            onNavigateCancelReservationConfirm = {
                 navController.navigate(CancelReservationConfirm)
             },
-            onNavigateToOrderDetail = {
-                navController.navigate(OrderDetail)
+            onNavigateToOrderDetail = { orderId ->
+                navController.navigate(OrderDetail(orderId = orderId))
             },
         )
     }
@@ -102,12 +104,26 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         )
     }
 
-    composable<OrderDetail> {
+    composable<OrderDetail> { backStackEntry ->
+        val args = backStackEntry.toRoute<OrderDetail>()
         OrderDetailScreen(
             onNavigateBack = {
                 navController.popBackStack()
             },
-            onNavigateNextStep = { },
+            onNavigateNextStep = {
+                navController.navigate(CancelReservation(orderId = args.orderId))
+            },
+        )
+    }
+
+    composable<CancelReservation> {
+        CancelReservationScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            onNavigateToCancelConfirm = {
+                navController.navigate(CancelReservationConfirm)
+            },
         )
     }
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -113,4 +113,7 @@ data object DetailReservation : NavigationRoute
 data object CancelReservationConfirm : NavigationRoute
 
 @Serializable
-data object OrderDetail : NavigationRoute
+data class OrderDetail(val orderId: String) : NavigationRoute
+
+@Serializable
+data class CancelReservation(val orderId: String) : NavigationRoute

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -44,6 +44,7 @@ import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPageShootingHistory
+import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerEquipmentSetting
 import com.hm.picplz.navigation.model.PhotographerMain
 import com.hm.picplz.navigation.model.QuickShoot
@@ -179,6 +180,7 @@ fun DevScreen(navController: NavHostController) {
             // === Reservation ===
             SectionTitle("Reservation")
             DevButton("DetailReservation(예약 상세)") { navController.navigate(DetailReservation) }
+            DevButton("OrderDetail(결제 후 취소 주문 상세)") { navController.navigate(OrderDetail("order123")) }
 
             Spacer(modifier = Modifier.height(32.dp))
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReason.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReason.kt
@@ -1,0 +1,15 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+import com.hm.picplz.feature.reservation.R
+
+enum class CancelReason(
+    val stringRes: Int,
+) {
+    SCHEDULE(R.string.cancel_reason_option_schedule),
+    PRODUCT(R.string.cancel_reason_option_product),
+    PHOTOGRAPHER_LATE(R.string.cancel_reason_option_photographer_late),
+    LOCATION(R.string.cancel_reason_option_location),
+    OTHER(R.string.cancel_reason_option_other),
+    MIND(R.string.cancel_reason_option_mind),
+    DIRECT_INPUT(R.string.cancel_reason_option_direct_input),
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -1,3 +1,15 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
-sealed interface CancelReservationIntent
+sealed interface CancelReservationIntent {
+    data class Initialize(val orderId: String) : CancelReservationIntent
+
+    data class ToggleReason(val reason: CancelReason) : CancelReservationIntent
+
+    data class UpdateDirectInput(val text: String) : CancelReservationIntent
+
+    data class UpdatePagerPage(val page: CancelReservationPagerPage) : CancelReservationIntent
+
+    data object OnBackClick : CancelReservationIntent
+
+    data object OnNextClick : CancelReservationIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -1,8 +1,6 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
 sealed interface CancelReservationIntent {
-    data class Initialize(val orderId: String) : CancelReservationIntent
-
     data class ToggleReason(val reason: CancelReason) : CancelReservationIntent
 
     data class UpdateDirectInput(val text: String) : CancelReservationIntent

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+sealed interface CancelReservationIntent

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationPagerPage.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationPagerPage.kt
@@ -1,0 +1,19 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+/**
+ * 취소 예약 플로우의 페이지.
+ *
+ * 주의: 선언 순서 = 페이지 순서입니다.
+ * 순서를 변경하면 HorizontalPager의 페이지 순서도 바뀝니다.
+ */
+enum class CancelReservationPagerPage {
+    REASON_INPUT,
+    REFUND_GUIDE,
+    ;
+
+    companion object {
+        val size: Int get() = entries.size
+
+        fun fromIndex(index: Int): CancelReservationPagerPage = entries.getOrNull(index) ?: REASON_INPUT
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -1,13 +1,184 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReasonInputContent
+import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationStepIndicator
+import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationTopBar
+import com.hm.picplz.ui.screen.common.CommonBottomButton
 
 @Composable
-fun CancelReservationScreen() {}
+fun CancelReservationScreen(
+    orderId: String,
+    onNavigateBack: () -> Unit,
+    onNavigateToCancelConfirm: (orderId: String, reasons: Set<CancelReason>, directInput: String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CancelReservationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val pagerState =
+        rememberPagerState(initialPage = state.currentPagerPage.ordinal) {
+            CancelReservationPagerPage.size
+        }
+
+    LaunchedEffect(Unit) {
+        viewModel.handleIntent(CancelReservationIntent.Initialize(orderId))
+    }
+
+    LaunchedEffect(state.currentPagerPage) {
+        pagerState.animateScrollToPage(state.currentPagerPage.ordinal)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is CancelReservationSideEffect.NavigateBack -> {
+                    onNavigateBack()
+                }
+
+                is CancelReservationSideEffect.ShowCancelConfirmModal -> {
+                    onNavigateToCancelConfirm(
+                        state.orderId,
+                        state.selectedReasons,
+                        state.directInputText,
+                    )
+                }
+            }
+        }
+    }
+
+    CancelReservationScreenContent(
+        modifier = modifier,
+        state = state,
+        pagerState = pagerState,
+        onBackClick = {
+            viewModel.handleIntent(CancelReservationIntent.OnBackClick)
+        },
+        onReasonToggle = { reason ->
+            viewModel.handleIntent(CancelReservationIntent.ToggleReason(reason))
+        },
+        onDirectInputChange = { text ->
+            viewModel.handleIntent(CancelReservationIntent.UpdateDirectInput(text))
+        },
+        onPageChange = { pagerPage ->
+            viewModel.handleIntent(CancelReservationIntent.UpdatePagerPage(pagerPage))
+        },
+        onNextClick = {
+            viewModel.handleIntent(CancelReservationIntent.OnNextClick)
+        },
+    )
+}
+
+@Composable
+private fun CancelReservationScreenContent(
+    state: CancelReservationState,
+    pagerState: PagerState,
+    onBackClick: () -> Unit,
+    onReasonToggle: (CancelReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    onPageChange: (CancelReservationPagerPage) -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = Color.White,
+        topBar = {
+            CancelReservationTopBar(
+                onBackClick = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxWidth(),
+        ) {
+            CancelReservationStepIndicator(
+                modifier =
+                    Modifier
+                        .padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 10.dp),
+                currentPage = state.currentPagerPage,
+            )
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+                userScrollEnabled = false,
+            ) { page ->
+                when (CancelReservationPagerPage.fromIndex(page)) {
+                    CancelReservationPagerPage.REASON_INPUT -> {
+                        CancelReasonInputContent(
+                            selectedReasons = state.selectedReasons,
+                            directInputText = state.directInputText,
+                            onReasonToggle = onReasonToggle,
+                            onDirectInputChange = onDirectInputChange,
+                        )
+                    }
+
+                    CancelReservationPagerPage.REFUND_GUIDE -> {
+                        RefundGuideContent(
+                            selectedReasons = state.selectedReasons,
+                            directInputText = state.directInputText,
+                        )
+                    }
+                }
+            }
+
+            CommonBottomButton(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
+                text =
+                    when (state.currentPagerPage) {
+                        CancelReservationPagerPage.REASON_INPUT -> "다음"
+                        CancelReservationPagerPage.REFUND_GUIDE -> "취소 확인"
+                    },
+                onClick = onNextClick,
+                enabled = state.selectedReasons.isNotEmpty(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RefundGuideContent(
+    selectedReasons: Set<CancelReason>,
+    directInputText: String,
+    modifier: Modifier = Modifier,
+) {
+    // TODO: 환불 안내 화면 구현
+}
 
 @Preview
 @Composable
 private fun CancelReservationScreenPreview() {
-    CancelReservationScreen()
+    CancelReservationScreenContent(
+        state =
+            CancelReservationState(
+                orderId = "order123",
+                selectedReasons = setOf(CancelReason.SCHEDULE),
+                directInputText = "",
+                currentPagerPage = CancelReservationPagerPage.REASON_INPUT,
+            ),
+        pagerState = rememberPagerState(initialPage = 0) { CancelReservationPagerPage.size },
+        onBackClick = {},
+        onReasonToggle = {},
+        onDirectInputChange = {},
+        onPageChange = {},
+        onNextClick = {},
+    )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -139,7 +139,7 @@ private fun CancelReservationScreenContent(
                         CancelReservationPagerPage.REFUND_GUIDE -> "취소 확인"
                     },
                 onClick = onNextClick,
-                enabled = state.selectedReasons.isNotEmpty(),
+                enabled = state.isNextButtonEnabled(),
             )
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -23,9 +23,8 @@ import com.hm.picplz.ui.screen.common.CommonBottomButton
 
 @Composable
 fun CancelReservationScreen(
-    orderId: String,
     onNavigateBack: () -> Unit,
-    onNavigateToCancelConfirm: (orderId: String, reasons: Set<CancelReason>, directInput: String) -> Unit,
+    onNavigateToCancelConfirm: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CancelReservationViewModel = hiltViewModel(),
 ) {
@@ -34,10 +33,6 @@ fun CancelReservationScreen(
         rememberPagerState(initialPage = state.currentPagerPage.ordinal) {
             CancelReservationPagerPage.size
         }
-
-    LaunchedEffect(Unit) {
-        viewModel.handleIntent(CancelReservationIntent.Initialize(orderId))
-    }
 
     LaunchedEffect(state.currentPagerPage) {
         pagerState.animateScrollToPage(state.currentPagerPage.ordinal)
@@ -51,11 +46,7 @@ fun CancelReservationScreen(
                 }
 
                 is CancelReservationSideEffect.ShowCancelConfirmModal -> {
-                    onNavigateToCancelConfirm(
-                        state.orderId,
-                        state.selectedReasons,
-                        state.directInputText,
-                    )
+                    onNavigateToCancelConfirm()
                 }
             }
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun CancelReservationScreen() {}
+
+@Preview
+@Composable
+private fun CancelReservationScreenPreview() {
+    CancelReservationScreen()
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+sealed interface CancelReservationSideEffect

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
@@ -1,3 +1,7 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
-sealed interface CancelReservationSideEffect
+sealed interface CancelReservationSideEffect {
+    data object NavigateBack : CancelReservationSideEffect
+
+    data object ShowCancelConfirmModal : CancelReservationSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+class CancelReservationState

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -9,6 +9,6 @@ data class CancelReservationState(
     val errorMessage: String? = null,
 ) {
     companion object {
-        fun idle(): CancelReservationState = CancelReservationState()
+        fun idle(orderId: String): CancelReservationState = CancelReservationState(orderId = orderId)
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,3 +1,14 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
-class CancelReservationState
+data class CancelReservationState(
+    val orderId: String = "",
+    val selectedReasons: Set<CancelReason> = emptySet(),
+    val directInputText: String = "",
+    val currentPagerPage: CancelReservationPagerPage = CancelReservationPagerPage.REASON_INPUT,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    companion object {
+        fun idle(): CancelReservationState = CancelReservationState()
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -8,6 +8,10 @@ data class CancelReservationState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 ) {
+    fun isNextButtonEnabled(): Boolean =
+        selectedReasons.isNotEmpty() &&
+            (!selectedReasons.contains(CancelReason.DIRECT_INPUT) || directInputText.isNotBlank())
+
     companion object {
         fun idle(orderId: String): CancelReservationState = CancelReservationState(orderId = orderId)
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -9,8 +9,10 @@ data class CancelReservationState(
     val errorMessage: String? = null,
 ) {
     fun isNextButtonEnabled(): Boolean =
-        selectedReasons.isNotEmpty() &&
-            (!selectedReasons.contains(CancelReason.DIRECT_INPUT) || directInputText.isNotBlank())
+        selectedReasons.isNotEmpty() && (
+            selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 이유가 있거나
+                directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
+        )
 
     companion object {
         fun idle(orderId: String): CancelReservationState = CancelReservationState(orderId = orderId)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.cancel_reservation
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.hm.picplz.navigation.model.CancelReservation
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -70,6 +72,8 @@ class CancelReservationViewModel @Inject constructor(
     }
 
     private fun emitSideEffect(sideEffect: CancelReservationSideEffect) {
-        _sideEffect.tryEmit(sideEffect)
+        viewModelScope.launch {
+            _sideEffect.emit(sideEffect)
+        }
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -1,0 +1,8 @@
+package com.hm.picplz.ui.screen.cancel_reservation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CancelReservationViewModel @Inject constructor() : ViewModel()

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -2,7 +2,71 @@ package com.hm.picplz.ui.screen.cancel_reservation
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class CancelReservationViewModel @Inject constructor() : ViewModel()
+class CancelReservationViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow(CancelReservationState.idle())
+    val state: StateFlow<CancelReservationState> = _state.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<CancelReservationSideEffect>()
+    val sideEffect: SharedFlow<CancelReservationSideEffect> = _sideEffect.asSharedFlow()
+
+    fun handleIntent(intent: CancelReservationIntent) {
+        when (intent) {
+            is CancelReservationIntent.Initialize -> {
+                _state.update { it.copy(orderId = intent.orderId) }
+            }
+
+            is CancelReservationIntent.ToggleReason -> {
+                _state.update { currentState ->
+                    val newReasons = currentState.selectedReasons.toMutableSet()
+                    if (newReasons.contains(intent.reason)) {
+                        newReasons.remove(intent.reason)
+                    } else {
+                        newReasons.add(intent.reason)
+                    }
+                    currentState.copy(selectedReasons = newReasons)
+                }
+            }
+
+            is CancelReservationIntent.UpdateDirectInput -> {
+                _state.update { it.copy(directInputText = intent.text.take(100)) }
+            }
+
+            is CancelReservationIntent.UpdatePagerPage -> {
+                _state.update { it.copy(currentPagerPage = intent.page) }
+            }
+
+            is CancelReservationIntent.OnBackClick -> {
+                emitSideEffect(CancelReservationSideEffect.NavigateBack)
+            }
+
+            is CancelReservationIntent.OnNextClick -> {
+                // 페이지에 따라 다른 동작
+                val currentPage = _state.value.currentPagerPage
+                when (currentPage) {
+                    CancelReservationPagerPage.REASON_INPUT -> {
+                        // 취소 사유 입력 완료 → 환불 안내로
+                        _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REFUND_GUIDE) }
+                    }
+                    CancelReservationPagerPage.REFUND_GUIDE -> {
+                        // 환불 안내 완료 → 취소 확인 모달
+                        emitSideEffect(CancelReservationSideEffect.ShowCancelConfirmModal)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun emitSideEffect(sideEffect: CancelReservationSideEffect) {
+        _sideEffect.tryEmit(sideEffect)
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -1,6 +1,9 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.CancelReservation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,8 +15,12 @@ import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class CancelReservationViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow(CancelReservationState.idle())
+class CancelReservationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val orderId: String = savedStateHandle.toRoute<CancelReservation>().orderId
+
+    private val _state = MutableStateFlow(CancelReservationState.idle(orderId))
     val state: StateFlow<CancelReservationState> = _state.asStateFlow()
 
     private val _sideEffect = MutableSharedFlow<CancelReservationSideEffect>()
@@ -21,10 +28,6 @@ class CancelReservationViewModel @Inject constructor() : ViewModel() {
 
     fun handleIntent(intent: CancelReservationIntent) {
         when (intent) {
-            is CancelReservationIntent.Initialize -> {
-                _state.update { it.copy(orderId = intent.orderId) }
-            }
-
             is CancelReservationIntent.ToggleReason -> {
                 _state.update { currentState ->
                     val newReasons = currentState.selectedReasons.toMutableSet()

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonCheckbox.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonCheckbox.kt
@@ -1,0 +1,99 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.screen.common.CommonCheckbox
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun CancelReasonCheckbox(
+    text: String,
+    isSelected: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CommonCheckbox(
+            checked = isSelected,
+            onCheckedChange = { onToggle() },
+        )
+
+        Text(
+            text = text,
+            style = if (isSelected) MainThemeFont.BodyBold else MainThemeFont.Body,
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(start = 10.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonCheckboxPreviewUnchecked() {
+    PicplzTheme {
+        CancelReasonCheckbox(
+            text = "촬영 스케줄 다른 일정이 생겼어요",
+            isSelected = false,
+            onToggle = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonCheckboxPreviewChecked() {
+    PicplzTheme {
+        CancelReasonCheckbox(
+            text = "촬영 스케줄 다른 일정이 생겼어요",
+            isSelected = true,
+            onToggle = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonCheckboxPreviewMultiple() {
+    PicplzTheme {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            CancelReasonCheckbox(
+                text = "촬영 스케줄 다른 일정이 생겼어요",
+                isSelected = true,
+                onToggle = {},
+                modifier = Modifier.padding(vertical = 12.dp),
+            )
+
+            CancelReasonCheckbox(
+                text = "원금 상품을 변경하고 싶어요",
+                isSelected = false,
+                onToggle = {},
+                modifier = Modifier.padding(vertical = 12.dp),
+            )
+
+            CancelReasonCheckbox(
+                text = "그냥 마음이 바뀌었어요",
+                isSelected = true,
+                onToggle = {},
+                modifier = Modifier.padding(vertical = 12.dp),
+            )
+        }
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonInputContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonInputContent.kt
@@ -1,0 +1,142 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.CancelReason
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun CancelReasonInputContent(
+    selectedReasons: Set<CancelReason>,
+    directInputText: String,
+    onReasonToggle: (CancelReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Text(
+            text = stringResource(R.string.cancel_reason_input_title),
+            style = MainThemeFont.Title,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = 22.dp),
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.cancel_reason_input_subtitle),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Green120,
+                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
+                )
+            }
+
+            items(CancelReason.entries) { reason ->
+                CancelReasonCheckbox(
+                    text = stringResource(reason.stringRes),
+                    isSelected = selectedReasons.contains(reason),
+                    onToggle = { onReasonToggle(reason) },
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 20.dp),
+                )
+            }
+
+            if (selectedReasons.contains(CancelReason.DIRECT_INPUT)) {
+                item {
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = expandVertically(),
+                        exit = shrinkVertically(),
+                    ) {
+                        DirectInputTextField(
+                            value = directInputText,
+                            onValueChange = onDirectInputChange,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonInputContentPreviewEmpty() {
+    PicplzTheme {
+        CancelReasonInputContent(
+            selectedReasons = emptySet(),
+            directInputText = "",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonInputContentPreviewWithSelection() {
+    PicplzTheme {
+        CancelReasonInputContent(
+            selectedReasons =
+                setOf(
+                    CancelReason.SCHEDULE,
+                    CancelReason.MIND,
+                ),
+            directInputText = "",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonInputContentPreviewWithDirectInput() {
+    PicplzTheme {
+        CancelReasonInputContent(
+            selectedReasons = setOf(CancelReason.DIRECT_INPUT),
+            directInputText = "촬영 위치가 너무 멀어서 취소합니다.",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReasonInputContentPreviewFull() {
+    PicplzTheme {
+        CancelReasonInputContent(
+            selectedReasons =
+                setOf(
+                    CancelReason.SCHEDULE,
+                    CancelReason.PRODUCT,
+                    CancelReason.DIRECT_INPUT,
+                ),
+            directInputText = "개인적인 사유로 취소하게 되었습니다.",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReservationStepIndicator.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReservationStepIndicator.kt
@@ -1,0 +1,83 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationPagerPage
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun CancelReservationStepIndicator(
+    currentPage: CancelReservationPagerPage,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        CancelReservationPagerPage.entries.forEach { page ->
+            StepBadge(
+                stepNumber = page.ordinal + 1,
+                isActive = currentPage == page,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepBadge(
+    stepNumber: Int,
+    isActive: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(22.dp)
+                .background(
+                    color = if (isActive) MainThemeColor.Green120 else MainThemeColor.Gray1,
+                    shape = CircleShape,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stepNumber.toString(),
+            style = MainThemeFont.BodySmallButton2,
+            color = if (isActive) MainThemeColor.White else MainThemeColor.Gray5,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReservationStepIndicatorPreviewStep1() {
+    PicplzTheme {
+        CancelReservationStepIndicator(
+            currentPage = CancelReservationPagerPage.REASON_INPUT,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReservationStepIndicatorPreviewStep2() {
+    PicplzTheme {
+        CancelReservationStepIndicator(
+            currentPage = CancelReservationPagerPage.REFUND_GUIDE,
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReservationTopBar.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReservationTopBar.kt
@@ -1,0 +1,31 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun CancelReservationTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonTopBar(
+        modifier = modifier,
+        text = stringResource(R.string.cancel_reservation_top_bar_title),
+        onClickBack = onBackClick,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CancelReservationTopBarPreview() {
+    PicplzTheme {
+        CancelReservationTopBar(
+            onBackClick = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/DirectInputTextField.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/DirectInputTextField.kt
@@ -1,0 +1,113 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+private const val CANCEL_REASON_INPUT_MAX_LENGTH = 100
+
+@Composable
+fun DirectInputTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    maxLength: Int = CANCEL_REASON_INPUT_MAX_LENGTH,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        BasicTextField(
+            value = value,
+            onValueChange = { newText ->
+                if (newText.length <= maxLength) {
+                    onValueChange(newText)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = MainThemeFont.Body,
+            interactionSource = interactionSource,
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = MainThemeColor.Gray2,
+                                shape = RoundedCornerShape(5.dp),
+                            )
+                            .background(
+                                color = MainThemeColor.Gray1,
+                                shape = RoundedCornerShape(5.dp),
+                            )
+                            .height(136.dp)
+                            .padding(12.dp),
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.cancel_reason_input_placeholder, maxLength),
+                            style = MainThemeFont.Body,
+                            color = MainThemeColor.Gray3,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DirectInputTextFieldPreviewEmpty() {
+    PicplzTheme {
+        DirectInputTextField(
+            value = "",
+            onValueChange = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DirectInputTextFieldPreviewWithText() {
+    PicplzTheme {
+        DirectInputTextField(
+            value = "촬영 날짜를 변경하고 싶은데, 사진작가님이 다른 일정이 있다고 하셔서 취소하게 되었습니다.",
+            onValueChange = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DirectInputTextFieldPreviewNearMaxLength() {
+    PicplzTheme {
+        val longText = "a".repeat(90)
+        DirectInputTextField(
+            value = longText,
+            onValueChange = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -28,8 +28,8 @@ import com.hm.picplz.ui.theme.MainThemeColor
 @Composable
 fun DetailReservationScreen(
     onNavigateBack: () -> Unit,
-    onNavigateCancelReservation: () -> Unit,
-    onNavigateToOrderDetail: () -> Unit,
+    onNavigateCancelReservationConfirm: () -> Unit,
+    onNavigateToOrderDetail: (orderId: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
@@ -39,8 +39,12 @@ fun DetailReservationScreen(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is DetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
-                is DetailReservationSideEffect.NavigateToCancelReservation -> onNavigateCancelReservation()
-                is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail()
+
+                is DetailReservationSideEffect.NavigateToCancelReservationConfirm -> {
+                    onNavigateCancelReservationConfirm()
+                }
+
+                is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail(state.orderId)
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
@@ -3,7 +3,7 @@ package com.hm.picplz.ui.screen.detail_reservation
 sealed interface DetailReservationSideEffect {
     data object NavigateToPrev : DetailReservationSideEffect
 
-    data object NavigateToCancelReservation : DetailReservationSideEffect
+    data object NavigateToCancelReservationConfirm : DetailReservationSideEffect
 
     data object NavigateToOrderDetail : DetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -5,6 +5,7 @@ import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import java.time.LocalDateTime
 
 data class DetailReservationState(
+    val orderId: String = "",
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
     val showCancelDialog: Boolean = false,
     val shootingDateTime: LocalDateTime = LocalDateTime.now(),

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -75,7 +75,7 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                         ReservationStatus.WAITING_APPROVAL,
                         ReservationStatus.WAITING_PAYMENT,
                         -> {
-                            _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservation)
+                            _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservationConfirm)
                         }
 
                         ReservationStatus.RESERVED,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
@@ -1,7 +1,10 @@
 package com.hm.picplz.ui.screen.order_detail
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.OrderDetail
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,7 +14,11 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class OrderDetailViewModel @Inject constructor() : ViewModel() {
+class OrderDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val orderId: String = savedStateHandle.toRoute<OrderDetail>().orderId
+
     private val _state = MutableStateFlow(OrderDetailState.idle())
     val state: StateFlow<OrderDetailState> = _state
 
@@ -19,7 +26,7 @@ class OrderDetailViewModel @Inject constructor() : ViewModel() {
     val sideEffect: SharedFlow<OrderDetailSideEffect> = _sideEffect
 
     init {
-        loadOrderDetail("")
+        loadOrderDetail(orderId)
     }
 
     fun handleIntent(intent: OrderDetailIntent) {

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -60,4 +60,19 @@
     <string name="order_detail_section_shooting_schedule">촬영 희망 시각</string>
     <string name="order_detail_button_next">다음</string>
     <string name="price_format">%,d₩</string>
+
+    <!-- 취소 사유 입력 화면 -->
+    <string name="cancel_reason_input_title">취소 사유를 알려주세요</string>
+    <string name="cancel_reason_input_subtitle">* 중복 선택 가능</string>
+    <string name="cancel_reason_input_placeholder">취소 사유를 입력해주세요. (%1$d자 이내)</string>
+    <string name="cancel_reason_option_schedule">촬영 스케줄 다른 일정이 생겼어요</string>
+    <string name="cancel_reason_option_product">원금 상품을 변경하고 싶어요</string>
+    <string name="cancel_reason_option_photographer_late">자기의 단벌 늦거나 놀랐싶었어요</string>
+    <string name="cancel_reason_option_location">촬영 위치 문제가 생겼어요</string>
+    <string name="cancel_reason_option_other">자기가 추기 결체를 유도해요</string>
+    <string name="cancel_reason_option_mind">그냥 마음이 바뀌었어요</string>
+    <string name="cancel_reason_option_direct_input">직접 입력</string>
+
+    <!-- 예약 취소 화면 -->
+    <string name="cancel_reservation_top_bar_title">예약 취소</string>
 </resources>


### PR DESCRIPTION
## 개요
예약 취소 플로우를 구현합니다. 취소 사유 다중 선택, 직접 입력, 진행도 표시를 포함한 2단계 취소 사유 입력 화면과 네비게이션 연결을 완료했습니다.

## 변경 사항
- **취소 예약 화면 구현**: State, Intent, SideEffect, ViewModel, Screen 구현
- **취소 사유 입력 UI**:
  - CancelReason enum으로 타입 안전성 확보
  - 다중 선택 체크박스 (CommonCheckbox 재사용)
  - 직접 입력 필드 (BasicTextField, 100자 제한)
  - Step Indicator로 진행 상황 표시 (1단계: 사유 입력, 2단계: 환불 안내)
  - 선택 여부에 따른 폰트 스타일 변경
- **네비게이션 플로우**: DetailReservation → OrderDetail(orderId) → CancelReservation(orderId)
  - SavedStateHandle로 ViewModel에서 직접 orderId 수신
  - OrderDetail, CancelReservation 라우트에 orderId 파라미터 추가
- **버튼 활성화 검증**:
  - 다른 이유가 선택되어 있으면 직접 입력 텍스트 무관하게 활성화
  - 직접 입력만 선택된 경우에만 공백 아닌 텍스트 필수
- **문자열 리소스화**: strings.xml에 취소 사유, 입력 필드 플레이스홀더 등 추가
- **테스트**: DevScreen에 OrderDetail 테스트 버튼 추가
- **개선**: SideEffect 발행을 비동기로 변경 (tryEmit → emit)

[Screen_recording_20260412_130757.webm](https://github.com/user-attachments/assets/b56c8784-e6e0-455a-ba5b-86aab25cc373)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #133
