### PR TITLE
✨ 팔로우 작가 목록 화면 구현 (#150)

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -13,6 +13,7 @@ import com.hm.picplz.navigation.model.Feed
 import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.navigation.model.MyPage
+import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPageShootingHistory
@@ -28,6 +29,7 @@ import com.hm.picplz.ui.screen.main.MainScreen
 import com.hm.picplz.ui.screen.main.MainSearchScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
+import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
@@ -61,6 +63,10 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MyPage> {
         MyPageScreen(navController = navController)
+    }
+
+    composable<MyPageFollowedPhotographers> {
+        FollowedPhotographersScreen(navController = navController)
     }
 
     composable<MyPageModifyProfile> {

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -27,9 +27,9 @@ import com.hm.picplz.ui.screen.dev.DevScreen
 import com.hm.picplz.ui.screen.feed.FeedScreen
 import com.hm.picplz.ui.screen.main.MainScreen
 import com.hm.picplz.ui.screen.main.MainSearchScreen
+import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
-import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -69,6 +69,8 @@ data class SignUpAddDevice(val category: String = "phone") : NavigationRoute
 
 @Serializable object MyPage : NavigationRoute
 
+@Serializable object MyPageFollowedPhotographers : NavigationRoute
+
 @Serializable object MyPageModifyProfile : NavigationRoute
 
 @Serializable

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -23,6 +23,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
     composeOptions {
@@ -59,5 +60,14 @@ dependencies {
     // KakaoMap
     implementation(libs.kakao.maps)
 
+    testImplementation(libs.junit)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+
     debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/feature/mypage/src/androidTest/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreenTest.kt
+++ b/feature/mypage/src/androidTest/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreenTest.kt
@@ -1,0 +1,60 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.hm.picplz.ui.theme.PicplzTheme
+import org.junit.Rule
+import org.junit.Test
+
+class FollowedPhotographersScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun loading_state_exposes_accessible_description() {
+        composeTestRule.setContent {
+            PicplzTheme {
+                FollowedPhotographersScreenContent(
+                    state = FollowedPhotographersState(isLoading = true),
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("팔로우 작가를 불러오는 중이에요")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun unavailable_state_shows_honest_unavailable_copy() {
+        composeTestRule.setContent {
+            PicplzTheme {
+                FollowedPhotographersScreenContent(
+                    state = FollowedPhotographersState(isLoading = false, isUnavailable = true),
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("아직 준비 중인 기능이에요").assertIsDisplayed()
+        composeTestRule.onNodeWithText("정식 지원 전까지는 팔로우한 작가를 여기서 확인할 수 없어요").assertIsDisplayed()
+    }
+
+    @Test
+    fun empty_state_keeps_real_no_followed_photographers_message() {
+        composeTestRule.setContent {
+            PicplzTheme {
+                FollowedPhotographersScreenContent(
+                    state = FollowedPhotographersState(isLoading = false),
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("아직 팔로우한 작가가 없어요").assertIsDisplayed()
+        composeTestRule.onNodeWithText("마음에 드는 작가를 팔로우하면 이곳에서 모아볼 수 있어요").assertIsDisplayed()
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersIntent.kt
@@ -1,0 +1,7 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface FollowedPhotographersIntent {
+    data object NavigateBack : FollowedPhotographersIntent
+
+    data class SelectPhotographer(val photographerId: Int) : FollowedPhotographersIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreen.kt
@@ -1,0 +1,458 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.navigation.model.DetailPhotographer
+import com.hm.picplz.ui.screen.common.CommonFixedTopBar
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun FollowedPhotographersScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    viewModel: FollowedPhotographersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is FollowedPhotographersSideEffect.NavigateBack -> {
+                    navController.popBackStack()
+                }
+
+                is FollowedPhotographersSideEffect.NavigateToPhotographerDetail -> {
+                    navController.navigate(DetailPhotographer(sideEffect.photographerId))
+                }
+            }
+        }
+    }
+
+    FollowedPhotographersScreenContent(
+        state = state,
+        onIntent = viewModel::handleIntent,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun FollowedPhotographersScreenContent(
+    state: FollowedPhotographersState,
+    onIntent: (FollowedPhotographersIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonFixedTopBar(
+                title = stringResource(R.string.my_page_follow_photographer),
+                onClickBack = {
+                    onIntent(FollowedPhotographersIntent.NavigateBack)
+                },
+            )
+        },
+        modifier =
+            modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+    ) { innerPadding ->
+        when {
+            state.isLoading -> {
+                FollowedPhotographersLoading(
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            state.isUnavailable -> {
+                FollowedPhotographersUnavailable(
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            state.photographers.isEmpty() -> {
+                FollowedPhotographersEmpty(
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.padding(innerPadding),
+                ) {
+                    items(
+                    items = state.photographers,
+                        key = { photographer -> photographer.id },
+                    ) { photographer ->
+                        FollowedPhotographerCard(
+                            photographer = photographer,
+                            onClick = {
+                                onIntent(
+                                    FollowedPhotographersIntent.SelectPhotographer(photographer.id),
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FollowedPhotographerCard(
+    photographer: FollowedPhotographerItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            FollowedPhotographerThumbnail(
+                imageUri = photographer.profileImageUri,
+                contentDescription = photographer.name,
+            )
+
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .heightIn(min = 88.dp),
+                verticalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(0.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            modifier = Modifier.weight(1f),
+                            text = photographer.name,
+                            style = MainThemeFont.BodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                            color = MainThemeColor.Black,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+
+                        if (photographer.isBookable) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .size(10.dp)
+                                            .clip(RoundedCornerShape(999.dp))
+                                            .background(MainThemeColor.Green120),
+                                )
+                                Text(
+                                    text = stringResource(R.string.followed_photographers_available_now),
+                                    style = MainThemeFont.Body,
+                                    color = MainThemeColor.Green120,
+                                    maxLines = 1,
+                                )
+                            }
+                        }
+                    }
+
+                    Text(
+                        text = formatWorkingAreas(photographer.workingAreas),
+                        style = MainThemeFont.Body,
+                        color = MainThemeColor.Gray4,
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    photographer.keywords.forEach { keyword ->
+                        KeywordChip(text = keyword)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider(thickness = 1.dp, color = MainThemeColor.Gray2)
+    }
+}
+
+@Composable
+private fun FollowedPhotographerThumbnail(
+    imageUri: String,
+    contentDescription: String,
+) {
+    if (imageUri.isNotBlank()) {
+        AsyncImage(
+            model = imageUri,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .size(88.dp)
+                    .clip(RoundedCornerShape(5.dp)),
+        )
+    } else {
+        Box(
+            modifier =
+                Modifier
+                    .size(88.dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .semantics {
+                        this.contentDescription = contentDescription
+                    }
+                    .background(MainThemeColor.Gray2),
+        )
+    }
+}
+
+@Composable
+private fun KeywordChip(text: String) {
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .background(MainThemeColor.Gray1)
+                .height(30.dp)
+                .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun FollowedPhotographersLoading(modifier: Modifier = Modifier) {
+    val loadingDescription = stringResource(R.string.followed_photographers_loading)
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clearAndSetSemantics {
+                    contentDescription = loadingDescription
+                },
+    ) {
+        repeat(5) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 20.dp),
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(88.dp)
+                                .clip(RoundedCornerShape(5.dp))
+                                .background(MainThemeColor.Gray1),
+                    )
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        LoadingLine(width = 132.dp)
+                        LoadingLine(width = 150.dp)
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            LoadingChip()
+                            LoadingChip()
+                            LoadingChip()
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+                HorizontalDivider(thickness = 1.dp, color = MainThemeColor.Gray2)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingLine(width: androidx.compose.ui.unit.Dp) {
+    Box(
+        modifier =
+            Modifier
+                .width(width)
+                .height(18.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MainThemeColor.Gray1),
+    )
+}
+
+@Composable
+private fun LoadingChip() {
+    Box(
+        modifier =
+            Modifier
+                .width(82.dp)
+                .height(30.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MainThemeColor.Gray1),
+    )
+}
+
+@Composable
+private fun FollowedPhotographersUnavailable(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .border(1.dp, MainThemeColor.Gray2, RoundedCornerShape(24.dp))
+                    .background(MainThemeColor.Gray1),
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(
+            text = stringResource(R.string.followed_photographers_unavailable_title),
+            style = MainThemeFont.Title,
+            color = MainThemeColor.Black,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.followed_photographers_unavailable_description),
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Composable
+private fun FollowedPhotographersEmpty(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .border(1.dp, MainThemeColor.Gray2, RoundedCornerShape(24.dp))
+                    .background(MainThemeColor.Gray1),
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(
+            text = stringResource(R.string.followed_photographers_empty_title),
+            style = MainThemeFont.Title,
+            color = MainThemeColor.Black,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.followed_photographers_empty_description),
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Composable
+private fun formatWorkingAreas(workingAreas: List<String>): String {
+    return when {
+        workingAreas.isEmpty() -> ""
+        workingAreas.size <= 3 -> workingAreas.joinToString(separator = ", ")
+        else -> {
+            val visibleAreas = workingAreas.take(3).joinToString(separator = ", ")
+            val remainingCount = workingAreas.size - 3
+            val overflowLabel = stringResource(R.string.followed_photographers_area_overflow, remainingCount)
+            "$visibleAreas $overflowLabel"
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FollowedPhotographersScreenPreview() {
+    PicplzTheme {
+        FollowedPhotographersScreenContent(
+            state =
+                FollowedPhotographersState(
+                    isLoading = false,
+                    photographers =
+                        listOf(
+                            FollowedPhotographerItem(
+                                id = 1,
+                                name = "유가영 작가",
+                                profileImageUri = "",
+                                workingAreas = listOf("강남구", "강북구", "동대문구", "송파구"),
+                                keywords = listOf("#을지로 감성", "#MZ 감성", "#필름톤"),
+                                isBookable = true,
+                            ),
+                        ),
+                ),
+            onIntent = {},
+        )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +19,7 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
@@ -124,7 +124,7 @@ internal fun FollowedPhotographersScreenContent(
                     modifier = Modifier.padding(innerPadding),
                 ) {
                     items(
-                    items = state.photographers,
+                        items = state.photographers,
                         key = { photographer -> photographer.id },
                     ) { photographer ->
                         FollowedPhotographerCard(

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersSideEffect.kt
@@ -1,0 +1,7 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface FollowedPhotographersSideEffect {
+    data object NavigateBack : FollowedPhotographersSideEffect
+
+    data class NavigateToPhotographerDetail(val photographerId: Int) : FollowedPhotographersSideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersState.kt
@@ -1,0 +1,20 @@
+package com.hm.picplz.ui.screen.my_page
+
+data class FollowedPhotographersState(
+    val isLoading: Boolean = true,
+    val isUnavailable: Boolean = false,
+    val photographers: List<FollowedPhotographerItem> = emptyList(),
+) {
+    companion object {
+        fun idle() = FollowedPhotographersState()
+    }
+}
+
+data class FollowedPhotographerItem(
+    val id: Int,
+    val name: String,
+    val profileImageUri: String,
+    val workingAreas: List<String>,
+    val keywords: List<String>,
+    val isBookable: Boolean,
+)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModel.kt
@@ -1,0 +1,126 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.feature.mypage.BuildConfig
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FollowedPhotographersViewModel
+    @Inject
+    constructor() : ViewModel() {
+        private val _state = MutableStateFlow(FollowedPhotographersState.idle())
+        val state: StateFlow<FollowedPhotographersState> = _state
+
+        private val _sideEffect = Channel<FollowedPhotographersSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        init {
+            loadFollowedPhotographers()
+        }
+
+        fun handleIntent(intent: FollowedPhotographersIntent) {
+            when (intent) {
+                is FollowedPhotographersIntent.NavigateBack -> {
+                    sendSideEffect(FollowedPhotographersSideEffect.NavigateBack)
+                }
+
+                is FollowedPhotographersIntent.SelectPhotographer -> {
+                    sendSideEffect(
+                        FollowedPhotographersSideEffect.NavigateToPhotographerDetail(intent.photographerId),
+                    )
+                }
+            }
+        }
+
+        private fun loadFollowedPhotographers() {
+            viewModelScope.launch {
+                delay(350)
+                _state.value = loadedState(isDebugBuild = BuildConfig.DEBUG)
+            }
+        }
+
+        private fun sendSideEffect(effect: FollowedPhotographersSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.send(effect)
+            }
+        }
+
+        companion object {
+            internal fun loadedState(isDebugBuild: Boolean): FollowedPhotographersState {
+                return if (isDebugBuild) {
+                    FollowedPhotographersState(
+                        isLoading = false,
+                        photographers = FOLLOWED_PHOTOGRAPHERS,
+                    )
+                } else {
+                    FollowedPhotographersState(
+                        isLoading = false,
+                        isUnavailable = true,
+                    )
+                }
+            }
+
+            private val FOLLOWED_PHOTOGRAPHERS =
+                listOf(
+                    FollowedPhotographerItem(
+                        id = 1,
+                        name = "유가영 작가",
+                        profileImageUri = "https://picsum.photos/seed/followed-photographer-1/160/160",
+                        workingAreas = listOf("마포구", "서대문구"),
+                        keywords =
+                            listOf(
+                                "#을지로 감성",
+                                "#MZ 감성",
+                                "#필름톤",
+                                "#스냅촬영",
+                                "#프로필촬영",
+                                "#감성보정",
+                                "#야외촬영",
+                                "#데이트스냅",
+                            ),
+                        isBookable = true,
+                    ),
+                    FollowedPhotographerItem(
+                        id = 2,
+                        name = "유가영 작가",
+                        profileImageUri = "https://picsum.photos/seed/followed-photographer-2/160/160",
+                        workingAreas = listOf("동작구", "영등포구"),
+                        keywords = listOf("#을지로 감성", "#MZ 감성", "#자연광"),
+                        isBookable = false,
+                    ),
+                    FollowedPhotographerItem(
+                        id = 3,
+                        name = "유가영 작가",
+                        profileImageUri = "",
+                        workingAreas = listOf("마포구", "망원구"),
+                        keywords = listOf("#을지로 감성", "#MZ 감성", "#프로필맛집"),
+                        isBookable = false,
+                    ),
+                    FollowedPhotographerItem(
+                        id = 4,
+                        name = "유가영 작가",
+                        profileImageUri = "https://picsum.photos/seed/followed-photographer-4/160/160",
+                        workingAreas = listOf("강남구", "강북구", "동대문구", "송파구", "성동구", "광진구"),
+                        keywords = listOf("#을지로 감성", "#MZ 감성", "#하이틴"),
+                        isBookable = false,
+                    ),
+                    FollowedPhotographerItem(
+                        id = 5,
+                        name = "유가영 작가",
+                        profileImageUri = "https://picsum.photos/seed/followed-photographer-5/160/160",
+                        workingAreas = listOf("강동구"),
+                        keywords = listOf("#을지로 감성", "#MZ 감성", "#데이트스냅"),
+                        isBookable = false,
+                    ),
+                )
+        }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -50,6 +50,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.ui.navigation.BottomNavigationBar
@@ -73,6 +74,9 @@ fun MyPageScreen(
             when (effect) {
                 is MyPageSideEffect.NavigateToModifyProfile -> {
                     navController.navigate(MyPageModifyProfile)
+                }
+                is MyPageSideEffect.NavigateToFollowedPhotographers -> {
+                    navController.navigate(MyPageFollowedPhotographers)
                 }
                 is MyPageSideEffect.NavigateToShootingHistory -> {
                     navController.navigate(MyPageShootingHistory)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
@@ -3,6 +3,8 @@ package com.hm.picplz.ui.screen.my_page
 sealed interface MyPageSideEffect {
     data object NavigateToModifyProfile : MyPageSideEffect
 
+    data object NavigateToFollowedPhotographers : MyPageSideEffect
+
     data object NavigateToShootingHistory : MyPageSideEffect
 
     data object NavigateToSettings : MyPageSideEffect

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -33,9 +33,7 @@ class MyPageViewModel
                     sendSideEffect(MyPageSideEffect.NavigateToSettings)
                 }
                 is MyPageIntent.NavigateToFollowedPhotographers -> {
-                    sendSideEffect(
-                        MyPageSideEffect.ShowToast("팔로우 작가 기능은 준비 중입니다."),
-                    )
+                    sendSideEffect(MyPageSideEffect.NavigateToFollowedPhotographers)
                 }
                 is MyPageIntent.NavigateToMyReviews -> {
                     sendSideEffect(

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -11,6 +11,13 @@
     <string name="my_page_no_ongoing_shooting">진행중인 촬영이 없어요</string>
     <string name="my_page_no_ongoing_shooting_sub">촬영지를 검색하고 작가들을 둘러보세요</string>
     <string name="my_page_follow_photographer">팔로우 작가</string>
+    <string name="followed_photographers_available_now">바로촬영</string>
+    <string name="followed_photographers_loading">팔로우 작가를 불러오는 중이에요</string>
+    <string name="followed_photographers_unavailable_title">아직 준비 중인 기능이에요</string>
+    <string name="followed_photographers_unavailable_description">정식 지원 전까지는 팔로우한 작가를 여기서 확인할 수 없어요</string>
+    <string name="followed_photographers_empty_title">아직 팔로우한 작가가 없어요</string>
+    <string name="followed_photographers_empty_description">마음에 드는 작가를 팔로우하면 이곳에서 모아볼 수 있어요</string>
+    <string name="followed_photographers_area_overflow">외 %1$d개</string>
     <string name="my_page_my_reviews">내 리뷰</string>
     <string name="my_page_terms">이용 약관</string>
     <string name="my_page_ad">광고</string>

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/FollowedPhotographersViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.hm.picplz.ui.screen.my_page
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FollowedPhotographersViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `initial load finishes and exposes followed photographers state`() =
+        runTest {
+            val viewModel = FollowedPhotographersViewModel()
+
+            assertTrue(viewModel.state.value.isLoading)
+
+            advanceTimeBy(350)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.state.value.isLoading)
+            assertTrue(viewModel.state.value.photographers.isNotEmpty())
+            assertFalse(viewModel.state.value.isUnavailable)
+        }
+
+    @Test
+    fun `release loaded state is unavailable instead of empty follows state`() {
+        val state = FollowedPhotographersViewModel.loadedState(isDebugBuild = false)
+
+        assertFalse(state.isLoading)
+        assertTrue(state.isUnavailable)
+        assertTrue(state.photographers.isEmpty())
+    }
+
+    @Test
+    fun `select photographer emits detail navigation side effect`() =
+        runTest {
+            val viewModel = FollowedPhotographersViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(FollowedPhotographersIntent.SelectPhotographer(5))
+            advanceUntilIdle()
+
+            assertTrue(
+                sideEffectDeferred.await() is
+                    FollowedPhotographersSideEffect.NavigateToPhotographerDetail,
+            )
+        }
+
+    @Test
+    fun `navigate back emits back side effect`() =
+        runTest {
+            val viewModel = FollowedPhotographersViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(FollowedPhotographersIntent.NavigateBack)
+            advanceUntilIdle()
+
+            assertEquals(FollowedPhotographersSideEffect.NavigateBack, sideEffectDeferred.await())
+        }
+}

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MainDispatcherRule.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.ui.screen.my_page
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
@@ -1,0 +1,31 @@
+package com.hm.picplz.ui.screen.my_page
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyPageViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `navigate to followed photographers emits navigation side effect`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToFollowedPhotographers)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPageSideEffect.NavigateToFollowedPhotographers,
+                sideEffectDeferred.await(),
+            )
+        }
+}


### PR DESCRIPTION
## Summary
- MyPage의 `팔로우 작가` 메뉴를 실제 목록 화면으로 연결하고 전용 route/nav flow를 추가했습니다.
- 팔로우 작가 화면에 loading, unavailable, empty, list 상태와 카드 UI를 구현하고, 상세 화면 이동과 칩 가로 스크롤 동작을 반영했습니다.
- ViewModel 테스트와 Compose UI 테스트를 추가해 주요 상태/네비게이션 동작을 검증했습니다.

## Changes

### navigation
- `RouteModels.kt`
  - `MyPageFollowedPhotographers` route 추가
- `MainNavGraph.kt`
  - 팔로우 작가 목록 화면 destination 연결
- `MyPageScreen.kt` / `MyPageViewModel.kt` / `MyPageSideEffect.kt`
  - 기존 placeholder toast 분기를 실제 화면 이동으로 교체

### feature/mypage
- `FollowedPhotographersScreen.kt`
  - `loading / unavailable / empty / list` 상태 UI 구현
  - 카드 UI, 바로촬영 상태 표시, 지역 요약, 칩 가로 스크롤 반영
  - 카드 탭 시 작가 상세 화면으로 이동
- `FollowedPhotographersViewModel.kt`
  - debug build 기준 mock 데이터 로딩
  - non-debug build unavailable 상태 분기
- `FollowedPhotographersState.kt` / `Intent.kt` / `SideEffect.kt`
  - MVI 구조 추가
- `strings.xml`
  - 팔로우 작가 화면 문자열 추가
- `build.gradle.kts`
  - unit test / androidTest 의존성 및 BuildConfig 사용 설정 추가

### tests
- `MyPageViewModelTest.kt`
  - 팔로우 작가 화면 이동 side effect 검증
- `FollowedPhotographersViewModelTest.kt`
  - 초기 로딩과 상세 이동 side effect 검증
- `FollowedPhotographersScreenTest.kt`
  - loading / unavailable / list UI 상태 검증

## Verification
- `./gradlew :app:ktlintMainSourceSetCheck`
- `./gradlew ktlintCheck`
- `./gradlew :feature:mypage:compileDebugKotlin`
- `./gradlew :feature:mypage:testDebugUnitTest`

## 구현
![KakaoTalk_Video_2026-04-15-13-37-33](https://github.com/user-attachments/assets/56945c5a-5676-46a7-b4d5-afce763a4a4f)

Closes #150


