### PR TITLE
✨ 내 리뷰 화면 추가 (#152)

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -14,6 +14,7 @@ import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
+import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
@@ -27,6 +28,7 @@ import com.hm.picplz.ui.screen.feed.FeedScreen
 import com.hm.picplz.ui.screen.main.MainScreen
 import com.hm.picplz.ui.screen.main.MainSearchScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
+import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
@@ -65,6 +67,10 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MyPageModifyProfile> {
         MyPageModifyProfileScreen(navController = navController)
+    }
+
+    composable<MyPageMyReviews> {
+        MyReviewScreen(navController = navController)
     }
 
     composable<MyPageShootingHistory> { backStackEntry ->

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -28,10 +28,10 @@ import com.hm.picplz.ui.screen.feed.FeedScreen
 import com.hm.picplz.ui.screen.main.MainScreen
 import com.hm.picplz.ui.screen.main.MainSearchScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
-import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
+import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -71,6 +71,8 @@ data class SignUpAddDevice(val category: String = "phone") : NavigationRoute
 
 @Serializable object MyPageModifyProfile : NavigationRoute
 
+@Serializable object MyPageMyReviews : NavigationRoute
+
 @Serializable
 data class MyPageShootingHistory(
     val forceEmpty: Boolean = false,

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonDestructiveConfirmDialog.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonDestructiveConfirmDialog.kt
@@ -1,0 +1,162 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+private object CommonDestructiveConfirmDialogDefaults {
+    val Width = 304.dp
+    val Radius = RoundedCornerShape(5.dp)
+    val ContentHorizontalPadding = 36.dp
+    val ContentTopPadding = 18.dp
+    val ContentBottomPadding = 18.dp
+    val TitleBodyGap = 10.dp
+    val ButtonHeight = 46.dp
+    val ScrimColor = Color(0x66000000)
+}
+
+@Composable
+fun CommonDestructiveConfirmDialog(
+    title: String,
+    description: String,
+    cancelText: String,
+    confirmText: String,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(CommonDestructiveConfirmDialogDefaults.ScrimColor)
+                    .clickable(onClick = onDismissRequest),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier =
+                    modifier
+                        .width(CommonDestructiveConfirmDialogDefaults.Width)
+                        .clickable(enabled = false, onClick = {}),
+                shape = CommonDestructiveConfirmDialogDefaults.Radius,
+                color = MainThemeColor.White,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    start = CommonDestructiveConfirmDialogDefaults.ContentHorizontalPadding,
+                                    end = CommonDestructiveConfirmDialogDefaults.ContentHorizontalPadding,
+                                    top = CommonDestructiveConfirmDialogDefaults.ContentTopPadding,
+                                    bottom = CommonDestructiveConfirmDialogDefaults.ContentBottomPadding,
+                                ),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = title,
+                            style = MainThemeFont.TitleSmall,
+                            color = MainThemeColor.Black,
+                            textAlign = TextAlign.Center,
+                        )
+                        Box(modifier = Modifier.height(CommonDestructiveConfirmDialogDefaults.TitleBodyGap))
+                        Text(
+                            text = description,
+                            style = MainThemeFont.Body,
+                            color = MainThemeColor.Gray5,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(CommonDestructiveConfirmDialogDefaults.ButtonHeight),
+                    ) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .weight(1f)
+                                    .fillMaxSize()
+                                    .background(MainThemeColor.White)
+                                    .clickable(onClick = onDismissRequest),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.TopCenter)
+                                        .fillMaxWidth()
+                                        .height(1.dp)
+                                        .background(MainThemeColor.Gray2),
+                            )
+                            Text(
+                                text = cancelText,
+                                style = MainThemeFont.ButtonDefault,
+                                color = MainThemeColor.Black,
+                            )
+                        }
+                        Box(
+                            modifier =
+                                Modifier
+                                    .weight(1f)
+                                    .fillMaxSize()
+                                    .background(Color.Black)
+                                    .clickable(onClick = onConfirm),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = confirmText,
+                                style = MainThemeFont.ButtonDefault,
+                                color = MainThemeColor.White,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CommonDestructiveConfirmDialogPreview() {
+    PicplzTheme {
+        CommonDestructiveConfirmDialog(
+            title = "리뷰를 삭제하시겠습니까?",
+            description = "삭제된 리뷰는\n되돌릴 수 없습니다.",
+            cancelText = "취소",
+            confirmText = "삭제",
+            onDismissRequest = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -51,6 +51,7 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.hm.picplz.feature.mypage.R
 import com.hm.picplz.navigation.model.MyPageModifyProfile
+import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.ui.navigation.BottomNavigationBar
 import com.hm.picplz.ui.screen.my_page.toggleSwitch.ToggleSwitch
@@ -73,6 +74,9 @@ fun MyPageScreen(
             when (effect) {
                 is MyPageSideEffect.NavigateToModifyProfile -> {
                     navController.navigate(MyPageModifyProfile)
+                }
+                is MyPageSideEffect.NavigateToMyReviews -> {
+                    navController.navigate(MyPageMyReviews)
                 }
                 is MyPageSideEffect.NavigateToShootingHistory -> {
                     navController.navigate(MyPageShootingHistory)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
@@ -3,6 +3,8 @@ package com.hm.picplz.ui.screen.my_page
 sealed interface MyPageSideEffect {
     data object NavigateToModifyProfile : MyPageSideEffect
 
+    data object NavigateToMyReviews : MyPageSideEffect
+
     data object NavigateToShootingHistory : MyPageSideEffect
 
     data object NavigateToSettings : MyPageSideEffect

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -38,9 +38,7 @@ class MyPageViewModel
                     )
                 }
                 is MyPageIntent.NavigateToMyReviews -> {
-                    sendSideEffect(
-                        MyPageSideEffect.ShowToast("내 리뷰 기능은 준비 중입니다."),
-                    )
+                    sendSideEffect(MyPageSideEffect.NavigateToMyReviews)
                 }
                 is MyPageIntent.NavigateToTerms -> {
                     sendSideEffect(

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewIntent.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyReviewIntent {
+    data object NavigateBack : MyReviewIntent
+
+    data class ToggleReviewExpansion(val reviewId: Int) : MyReviewIntent
+
+    data class RequestDelete(val reviewId: Int) : MyReviewIntent
+
+    data object DismissDeleteDialog : MyReviewIntent
+
+    data object ConfirmDelete : MyReviewIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
@@ -426,13 +426,7 @@ private fun buildCollapsedReviewText(
         val safeEnd = (visibleTextEnd - suffix.length).coerceAtLeast(0)
         append(text.take(safeEnd).trimEnd())
         append("...")
-        withLink(
-            LinkAnnotation.Clickable(
-                tag = "toggle_more",
-                styles = TextLinkStyles(style = MoreTextStyle),
-                linkInteractionListener = {},
-            ),
-        ) {
+        withStyle(style = MoreTextStyle) {
             append(moreText)
         }
     }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
@@ -369,7 +369,6 @@ private fun ExpandableReviewText(
     onToggleExpanded: () -> Unit,
 ) {
     var isOverflowing by remember(text) { mutableStateOf(false) }
-    var canExpand by remember(text) { mutableStateOf(false) }
     val moreText = stringResource(R.string.my_review_more)
     val lessText = stringResource(R.string.my_review_less)
     var collapsedAnnotatedText by remember(text, moreText) {
@@ -399,24 +398,20 @@ private fun ExpandableReviewText(
             style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
         )
     } else {
-        Box(
-            modifier = Modifier.clickable(onClick = { if (canExpand) onToggleExpanded() }),
-        ) {
-            Text(
-                text = collapsedAnnotatedText,
-                style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                onTextLayout = { layoutResult ->
-                    if (layoutResult.hasVisualOverflow) {
-                        isOverflowing = true
-                        canExpand = true
-                        val visibleTextEnd = layoutResult.getLineEnd(1, visibleEnd = true)
-                        collapsedAnnotatedText = buildCollapsedReviewText(text, visibleTextEnd, moreText)
-                    }
-                },
-            )
-        }
+        Text(
+            text = collapsedAnnotatedText,
+            style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
+            modifier = Modifier.clickable(enabled = isOverflowing, onClick = onToggleExpanded),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { layoutResult ->
+                if (layoutResult.hasVisualOverflow) {
+                    isOverflowing = true
+                    val visibleTextEnd = layoutResult.getLineEnd(1, visibleEnd = true)
+                    collapsedAnnotatedText = buildCollapsedReviewText(text, visibleTextEnd, moreText)
+                }
+            },
+        )
     }
 }
 

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
@@ -42,17 +42,16 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withLink
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.hm.picplz.feature.mypage.R
 import com.hm.picplz.ui.screen.common.CommonDestructiveConfirmDialog
@@ -370,6 +369,7 @@ private fun ExpandableReviewText(
     onToggleExpanded: () -> Unit,
 ) {
     var isOverflowing by remember(text) { mutableStateOf(false) }
+    var canExpand by remember(text) { mutableStateOf(false) }
     val moreText = stringResource(R.string.my_review_more)
     val lessText = stringResource(R.string.my_review_less)
     var collapsedAnnotatedText by remember(text, moreText) {
@@ -399,20 +399,24 @@ private fun ExpandableReviewText(
             style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
         )
     } else {
-        Text(
-            text = collapsedAnnotatedText,
-            style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
-            modifier = Modifier.clickable(enabled = isOverflowing, onClick = onToggleExpanded),
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            onTextLayout = { layoutResult ->
-                if (layoutResult.hasVisualOverflow) {
-                    isOverflowing = true
-                    val visibleTextEnd = layoutResult.getLineEnd(1, visibleEnd = true)
-                    collapsedAnnotatedText = buildCollapsedReviewText(text, visibleTextEnd, moreText)
-                }
-            },
-        )
+        Box(
+            modifier = Modifier.clickable(onClick = { if (canExpand) onToggleExpanded() }),
+        ) {
+            Text(
+                text = collapsedAnnotatedText,
+                style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                onTextLayout = { layoutResult ->
+                    if (layoutResult.hasVisualOverflow) {
+                        isOverflowing = true
+                        canExpand = true
+                        val visibleTextEnd = layoutResult.getLineEnd(1, visibleEnd = true)
+                        collapsedAnnotatedText = buildCollapsedReviewText(text, visibleTextEnd, moreText)
+                    }
+                },
+            )
+        }
     }
 }
 
@@ -420,7 +424,7 @@ private fun buildCollapsedReviewText(
     text: String,
     visibleTextEnd: Int,
     moreText: String,
-) =
+): androidx.compose.ui.text.AnnotatedString =
     buildAnnotatedString {
         val suffix = "...$moreText"
         val safeEnd = (visibleTextEnd - suffix.length).coerceAtLeast(0)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
@@ -1,0 +1,491 @@
+package com.hm.picplz.ui.screen.my_page
+
+import CommonDialog
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.screen.common.CommonFixedTopBar
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.ui.util.ReviewUtil
+import com.hm.picplz.ui.util.StarType
+import com.hm.picplz.core.ui.R as CoreUiR
+
+@Composable
+fun MyReviewScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    viewModel: MyReviewViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is MyReviewSideEffect.NavigateBack -> {
+                    navController.popBackStack()
+                }
+            }
+        }
+    }
+
+    MyReviewScreenContent(
+        state = state,
+        onIntent = viewModel::handleIntent,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun MyReviewScreenContent(
+    state: MyReviewState,
+    onIntent: (MyReviewIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pendingDeleteReview = state.reviews.find { it.id == state.pendingDeleteReviewId }
+
+    Scaffold(
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonFixedTopBar(
+                title = stringResource(R.string.my_page_my_reviews),
+                onClickBack = {
+                    onIntent(MyReviewIntent.NavigateBack)
+                },
+            )
+        },
+        modifier =
+            modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+    ) { innerPadding ->
+        if (state.reviews.isEmpty()) {
+            MyReviewEmptyState(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding.toCenteredEmptyStatePadding()),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.padding(innerPadding),
+                contentPadding = PaddingValues(horizontal = 15.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(
+                    items = state.reviews,
+                    key = { review -> review.id },
+                ) { review ->
+                    MyReviewCard(
+                        review = review,
+                        isExpanded = review.id in state.expandedReviewIds,
+                        onToggleExpanded = {
+                            onIntent(MyReviewIntent.ToggleReviewExpansion(review.id))
+                        },
+                        onDeleteClick = {
+                            onIntent(MyReviewIntent.RequestDelete(review.id))
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    if (pendingDeleteReview != null) {
+        MyReviewDeleteDialog(
+            photographerName = pendingDeleteReview.photographerName,
+            onDismiss = {
+                onIntent(MyReviewIntent.DismissDeleteDialog)
+            },
+            onConfirm = {
+                onIntent(MyReviewIntent.ConfirmDelete)
+            },
+        )
+    }
+}
+
+private fun PaddingValues.toCenteredEmptyStatePadding(): PaddingValues =
+    PaddingValues(
+        top = calculateTopPadding() / 2,
+        bottom = calculateBottomPadding(),
+    )
+
+@Composable
+private fun MyReviewCard(
+    review: MyReviewItem,
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    onDeleteClick: () -> Unit,
+) {
+    val starIcons = ReviewUtil.calculateStarRating(review.rating, StarType.SUB)
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(5.dp))
+                .border(1.dp, MainThemeColor.Gray2, RoundedCornerShape(5.dp))
+                .background(MainThemeColor.White)
+                .padding(horizontal = 18.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top,
+        ) {
+            ReviewProfileImage(
+                imageUri = review.photographerImageUri,
+                contentDescription = review.photographerName,
+            )
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = review.photographerName,
+                    style = MainThemeFont.BodyBold,
+                    color = MainThemeColor.Black,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                    starIcons.forEach { iconRes ->
+                        Image(
+                            painter = painterResource(iconRes),
+                            contentDescription = stringResource(CoreUiR.string.star_rating),
+                            modifier = Modifier.size(11.dp),
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.my_review_delete),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.White,
+                    modifier =
+                        Modifier
+                            .clip(RoundedCornerShape(5.dp))
+                            .background(MainThemeColor.Red)
+                            .clickable(onClick = onDeleteClick)
+                            .padding(horizontal = 6.dp, vertical = 3.dp),
+                )
+                Text(
+                    text = review.createdAt,
+                    style = MainThemeFont.Body,
+                    color = MainThemeColor.Gray5,
+                )
+            }
+        }
+
+        if (review.imageUris.isNotEmpty()) {
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                items(
+                    items = review.imageUris,
+                    key = { imageUri -> imageUri },
+                ) { imageUri ->
+                    AsyncImage(
+                        model = imageUri,
+                        contentDescription = stringResource(CoreUiR.string.review_photo),
+                        contentScale = ContentScale.Crop,
+                        modifier =
+                            Modifier
+                                .size(114.dp)
+                                .clip(RoundedCornerShape(5.dp)),
+                    )
+                }
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            ReviewMetaRow(
+                label = stringResource(CoreUiR.string.option_label),
+                value = review.option,
+            )
+            ReviewMetaRow(
+                label = stringResource(CoreUiR.string.shooting_location),
+                value = review.location,
+            )
+        }
+
+        ExpandableReviewText(
+            text = review.reviewText,
+            isExpanded = isExpanded,
+            onToggleExpanded = onToggleExpanded,
+        )
+
+        Row(
+            modifier = Modifier.align(Alignment.End),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                painter = painterResource(CoreUiR.drawable.like_inactive),
+                contentDescription = stringResource(CoreUiR.string.like),
+            )
+            Text(
+                text = review.likeCount.toString(),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewProfileImage(
+    imageUri: String,
+    contentDescription: String,
+) {
+    if (imageUri.isNotBlank()) {
+        AsyncImage(
+            model = imageUri,
+            contentDescription = stringResource(CoreUiR.string.user_profile),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .size(37.dp)
+                    .clip(CircleShape)
+                    .border(1.dp, MainThemeColor.Gray3, CircleShape),
+        )
+    } else {
+        Image(
+            painter = painterResource(CoreUiR.drawable.default_profile),
+            contentDescription = contentDescription,
+            modifier =
+                Modifier
+                    .size(37.dp)
+                    .clip(CircleShape)
+                    .border(1.dp, MainThemeColor.Gray3, CircleShape),
+        )
+    }
+}
+
+@Composable
+private fun ReviewMetaRow(
+    label: String,
+    value: String,
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            text = label,
+            style = MainThemeFont.InnerTag,
+            color = MainThemeColor.Gray4,
+        )
+        Text(
+            text = value,
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Composable
+private fun ExpandableReviewText(
+    text: String,
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
+) {
+    var isOverflowing by remember(text) { mutableStateOf(false) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = text,
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Black,
+            maxLines = if (isExpanded) Int.MAX_VALUE else 2,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { layoutResult ->
+                if (!isExpanded) {
+                    isOverflowing = layoutResult.hasVisualOverflow
+                }
+            },
+        )
+
+        if (isExpanded || isOverflowing) {
+            Text(
+                text = stringResource(if (isExpanded) R.string.my_review_less else R.string.my_review_more),
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+                modifier = Modifier.clickable(onClick = onToggleExpanded),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MyReviewDeleteDialog(
+    photographerName: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    CommonDialog(
+        onDismissRequest = onDismiss,
+        hasQuit = false,
+    ) {
+        Column {
+            Text(
+                text = stringResource(R.string.my_review_delete_dialog_title),
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Black,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                text = stringResource(R.string.my_review_delete_dialog_description, photographerName),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray5,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(5.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.my_review_delete_dialog_cancel),
+                        style = MainThemeFont.Body,
+                        color = MainThemeColor.Gray5,
+                    )
+                }
+
+                Button(
+                    onClick = onConfirm,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(5.dp),
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MainThemeColor.Red,
+                            contentColor = MainThemeColor.White,
+                        ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.my_review_delete_dialog_confirm),
+                        style = MainThemeFont.Body,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MyReviewEmptyState(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.my_review_empty_title),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Image(
+                modifier = Modifier.size(64.dp),
+                painter = painterResource(id = R.drawable.ic_shooting_history_empty),
+                contentDescription = stringResource(R.string.my_review_empty_title),
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.my_review_empty_description),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray5,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyReviewScreenPreview() {
+    PicplzTheme {
+        MyReviewScreenContent(
+            state = MyReviewState.idle(),
+            onIntent = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyReviewEmptyStatePreview() {
+    PicplzTheme {
+        MyReviewScreenContent(
+            state = MyReviewState(reviews = emptyList()),
+            onIntent = {},
+            modifier = Modifier,
+        )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewScreen.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.my_page
 
-import CommonDialog
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,9 +22,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -37,19 +34,28 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.screen.common.CommonDestructiveConfirmDialog
 import com.hm.picplz.ui.screen.common.CommonFixedTopBar
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
@@ -57,6 +63,16 @@ import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.util.ReviewUtil
 import com.hm.picplz.ui.util.StarType
 import com.hm.picplz.core.ui.R as CoreUiR
+
+private val DeletePillColor = Color(0xFFE83737)
+private val MoreTextStyle =
+    SpanStyle(
+        color = MainThemeColor.Gray6,
+        fontFamily = MainThemeFont.BodyBold.fontFamily,
+        fontWeight = MainThemeFont.BodyBold.fontWeight,
+        fontSize = MainThemeFont.BodyBold.fontSize,
+        letterSpacing = MainThemeFont.BodyBold.letterSpacing,
+    )
 
 @Composable
 fun MyReviewScreen(
@@ -116,8 +132,7 @@ internal fun MyReviewScreenContent(
         } else {
             LazyColumn(
                 modifier = Modifier.padding(innerPadding),
-                contentPadding = PaddingValues(horizontal = 15.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 10.dp),
             ) {
                 items(
                     items = state.reviews,
@@ -133,6 +148,13 @@ internal fun MyReviewScreenContent(
                             onIntent(MyReviewIntent.RequestDelete(review.id))
                         },
                     )
+
+                    if (review != state.reviews.last()) {
+                        HorizontalDivider(
+                            color = MainThemeColor.Gray2,
+                            thickness = 1.dp,
+                        )
+                    }
                 }
             }
         }
@@ -140,7 +162,6 @@ internal fun MyReviewScreenContent(
 
     if (pendingDeleteReview != null) {
         MyReviewDeleteDialog(
-            photographerName = pendingDeleteReview.photographerName,
             onDismiss = {
                 onIntent(MyReviewIntent.DismissDeleteDialog)
             },
@@ -171,10 +192,8 @@ private fun MyReviewCard(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(5.dp))
-                .border(1.dp, MainThemeColor.Gray2, RoundedCornerShape(5.dp))
                 .background(MainThemeColor.White)
-                .padding(horizontal = 18.dp, vertical = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
+                .padding(vertical = 20.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -185,7 +204,7 @@ private fun MyReviewCard(
                 contentDescription = review.photographerName,
             )
 
-            Spacer(modifier = Modifier.width(10.dp))
+            Spacer(modifier = Modifier.width(8.dp))
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -193,42 +212,49 @@ private fun MyReviewCard(
                     style = MainThemeFont.BodyBold,
                     color = MainThemeColor.Black,
                 )
-                Spacer(modifier = Modifier.height(2.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                Spacer(modifier = Modifier.height(1.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(1.dp)) {
                     starIcons.forEach { iconRes ->
                         Image(
                             painter = painterResource(iconRes),
                             contentDescription = stringResource(CoreUiR.string.star_rating),
-                            modifier = Modifier.size(11.dp),
+                            modifier = Modifier.size(15.dp),
                         )
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(4.dp))
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = stringResource(R.string.my_review_delete),
-                    style = MainThemeFont.Caption,
-                    color = MainThemeColor.White,
+                Box(
                     modifier =
                         Modifier
+                            .height(17.dp)
                             .clip(RoundedCornerShape(5.dp))
-                            .background(MainThemeColor.Red)
+                            .background(DeletePillColor)
                             .clickable(onClick = onDeleteClick)
-                            .padding(horizontal = 6.dp, vertical = 3.dp),
-                )
+                            .padding(horizontal = 4.dp, vertical = 1.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.my_review_delete),
+                        style = MainThemeFont.Caption.copy(fontSize = 10.sp, lineHeight = 14.sp),
+                        color = MainThemeColor.White,
+                    )
+                }
                 Text(
                     text = review.createdAt,
-                    style = MainThemeFont.Body,
+                    style = MainThemeFont.Caption,
                     color = MainThemeColor.Gray5,
                 )
             }
         }
+
+        Spacer(modifier = Modifier.height(14.dp))
 
         if (review.imageUris.isNotEmpty()) {
             LazyRow(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -242,11 +268,12 @@ private fun MyReviewCard(
                         contentScale = ContentScale.Crop,
                         modifier =
                             Modifier
-                                .size(114.dp)
-                                .clip(RoundedCornerShape(5.dp)),
+                                .size(113.dp),
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(14.dp))
         }
 
         Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
@@ -260,11 +287,15 @@ private fun MyReviewCard(
             )
         }
 
+        Spacer(modifier = Modifier.height(12.dp))
+
         ExpandableReviewText(
             text = review.reviewText,
             isExpanded = isExpanded,
             onToggleExpanded = onToggleExpanded,
         )
+
+        Spacer(modifier = Modifier.height(14.dp))
 
         Row(
             modifier = Modifier.align(Alignment.End),
@@ -296,7 +327,7 @@ private fun ReviewProfileImage(
             contentScale = ContentScale.Crop,
             modifier =
                 Modifier
-                    .size(37.dp)
+                    .size(36.dp)
                     .clip(CircleShape)
                     .border(1.dp, MainThemeColor.Gray3, CircleShape),
         )
@@ -306,7 +337,7 @@ private fun ReviewProfileImage(
             contentDescription = contentDescription,
             modifier =
                 Modifier
-                    .size(37.dp)
+                    .size(36.dp)
                     .clip(CircleShape)
                     .border(1.dp, MainThemeColor.Gray3, CircleShape),
         )
@@ -339,93 +370,86 @@ private fun ExpandableReviewText(
     onToggleExpanded: () -> Unit,
 ) {
     var isOverflowing by remember(text) { mutableStateOf(false) }
+    val moreText = stringResource(R.string.my_review_more)
+    val lessText = stringResource(R.string.my_review_less)
+    var collapsedAnnotatedText by remember(text, moreText) {
+        mutableStateOf(
+            buildAnnotatedString {
+                append(text)
+            },
+        )
+    }
 
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    if (isExpanded) {
         Text(
-            text = text,
-            style = MainThemeFont.Body,
-            color = MainThemeColor.Black,
-            maxLines = if (isExpanded) Int.MAX_VALUE else 2,
+            text =
+                buildAnnotatedString {
+                    append(text)
+                    append(" ")
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = "toggle_less",
+                            styles = TextLinkStyles(style = MoreTextStyle),
+                            linkInteractionListener = { onToggleExpanded() },
+                        ),
+                    ) {
+                        append(lessText)
+                    }
+                },
+            style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
+        )
+    } else {
+        Text(
+            text = collapsedAnnotatedText,
+            style = MainThemeFont.Body.copy(color = MainThemeColor.Gray6),
+            modifier = Modifier.clickable(enabled = isOverflowing, onClick = onToggleExpanded),
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             onTextLayout = { layoutResult ->
-                if (!isExpanded) {
-                    isOverflowing = layoutResult.hasVisualOverflow
+                if (layoutResult.hasVisualOverflow) {
+                    isOverflowing = true
+                    val visibleTextEnd = layoutResult.getLineEnd(1, visibleEnd = true)
+                    collapsedAnnotatedText = buildCollapsedReviewText(text, visibleTextEnd, moreText)
                 }
             },
         )
-
-        if (isExpanded || isOverflowing) {
-            Text(
-                text = stringResource(if (isExpanded) R.string.my_review_less else R.string.my_review_more),
-                style = MainThemeFont.Caption,
-                color = MainThemeColor.Gray4,
-                modifier = Modifier.clickable(onClick = onToggleExpanded),
-            )
-        }
     }
 }
 
+private fun buildCollapsedReviewText(
+    text: String,
+    visibleTextEnd: Int,
+    moreText: String,
+) =
+    buildAnnotatedString {
+        val suffix = "...$moreText"
+        val safeEnd = (visibleTextEnd - suffix.length).coerceAtLeast(0)
+        append(text.take(safeEnd).trimEnd())
+        append("...")
+        withLink(
+            LinkAnnotation.Clickable(
+                tag = "toggle_more",
+                styles = TextLinkStyles(style = MoreTextStyle),
+                linkInteractionListener = {},
+            ),
+        ) {
+            append(moreText)
+        }
+    }
+
 @Composable
 private fun MyReviewDeleteDialog(
-    photographerName: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    CommonDialog(
+    CommonDestructiveConfirmDialog(
+        title = stringResource(R.string.my_review_delete_dialog_title),
+        description = stringResource(R.string.my_review_delete_dialog_description),
+        cancelText = stringResource(R.string.my_review_delete_dialog_cancel),
+        confirmText = stringResource(R.string.my_review_delete_dialog_confirm),
         onDismissRequest = onDismiss,
-        hasQuit = false,
-    ) {
-        Column {
-            Text(
-                text = stringResource(R.string.my_review_delete_dialog_title),
-                style = MainThemeFont.BodyBold,
-                color = MainThemeColor.Black,
-            )
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            Text(
-                text = stringResource(R.string.my_review_delete_dialog_description, photographerName),
-                style = MainThemeFont.Body,
-                color = MainThemeColor.Gray5,
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedButton(
-                    onClick = onDismiss,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(5.dp),
-                ) {
-                    Text(
-                        text = stringResource(R.string.my_review_delete_dialog_cancel),
-                        style = MainThemeFont.Body,
-                        color = MainThemeColor.Gray5,
-                    )
-                }
-
-                Button(
-                    onClick = onConfirm,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(5.dp),
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = MainThemeColor.Red,
-                            contentColor = MainThemeColor.White,
-                        ),
-                ) {
-                    Text(
-                        text = stringResource(R.string.my_review_delete_dialog_confirm),
-                        style = MainThemeFont.Body,
-                    )
-                }
-            }
-        }
-    }
+        onConfirm = onConfirm,
+    )
 }
 
 @Composable

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyReviewSideEffect {
+    data object NavigateBack : MyReviewSideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewState.kt
@@ -1,0 +1,81 @@
+package com.hm.picplz.ui.screen.my_page
+
+data class MyReviewState(
+    val reviews: List<MyReviewItem> = emptyList(),
+    val expandedReviewIds: Set<Int> = emptySet(),
+    val pendingDeleteReviewId: Int? = null,
+) {
+    companion object {
+        fun idle() = MyReviewState(reviews = MOCK_REVIEWS)
+
+        private val MOCK_REVIEWS =
+            listOf(
+                MyReviewItem(
+                    id = 1,
+                    photographerName = "합정동 불주먹",
+                    photographerImageUri = "",
+                    rating = 1f,
+                    createdAt = "2024.12.03",
+                    imageUris =
+                        listOf(
+                            "https://picsum.photos/seed/my-review-1-1/360/360",
+                            "https://picsum.photos/seed/my-review-1-2/360/360",
+                        ),
+                    option = "남친생기는 프사",
+                    location = "서울시 마포구 무대륙",
+                    reviewText = "아 개별로에요 다시는 이사람한테 안찍음 ㅡㅡ",
+                    likeCount = 4,
+                ),
+                MyReviewItem(
+                    id = 2,
+                    photographerName = "합정동 불주먹",
+                    photographerImageUri = "",
+                    rating = 4f,
+                    createdAt = "2024.12.03",
+                    imageUris =
+                        listOf(
+                            "https://picsum.photos/seed/my-review-2-1/360/360",
+                            "https://picsum.photos/seed/my-review-2-2/360/360",
+                            "https://picsum.photos/seed/my-review-2-3/360/360",
+                            "https://picsum.photos/seed/my-review-2-4/360/360",
+                        ),
+                    option = "남친생기는 프사",
+                    location = "서울시 마포구 무대륙",
+                    reviewText =
+                        "하나하나 신경써서 해주시고 잘 알려주세요 사진 처음찍거나 잘 못찍으시는 분들 하시면 후회 안하십니다. " +
+                            "하나하나 디테일까지 봐주시고 포즈도 편하게 잡아주셔서 결과물이 훨씬 만족스러웠어요.",
+                    likeCount = 4,
+                ),
+                MyReviewItem(
+                    id = 3,
+                    photographerName = "성수동 감성작가",
+                    photographerImageUri = "https://picsum.photos/seed/my-review-profile-3/120/120",
+                    rating = 3f,
+                    createdAt = "2024.11.28",
+                    imageUris =
+                        listOf(
+                            "https://picsum.photos/seed/my-review-3-1/360/360",
+                            "https://picsum.photos/seed/my-review-3-2/360/360",
+                        ),
+                    option = "인스타 피드 촬영",
+                    location = "서울시 성동구 서울숲길 17",
+                    reviewText =
+                        "보정은 깔끔한데 현장에서 설명이 조금 빠른 편이었어요. 원하는 무드가 분명하면 더 잘 맞을 것 같습니다.",
+                    likeCount = 2,
+                ),
+            )
+    }
+}
+
+data class MyReviewItem(
+    val id: Int,
+    val photographerName: String,
+    val photographerImageUri: String,
+    val rating: Float,
+    val createdAt: String,
+    val imageUris: List<String>,
+    val option: String,
+    val location: String,
+    val reviewText: String,
+    val likeCount: Int,
+)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyReviewViewModel.kt
@@ -1,0 +1,66 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyReviewViewModel
+    @Inject
+    constructor() : ViewModel() {
+        private val _state = MutableStateFlow(MyReviewState.idle())
+        val state: StateFlow<MyReviewState> = _state
+
+        private val _sideEffect = Channel<MyReviewSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        fun handleIntent(intent: MyReviewIntent) {
+            when (intent) {
+                is MyReviewIntent.NavigateBack -> {
+                    sendSideEffect(MyReviewSideEffect.NavigateBack)
+                }
+
+                is MyReviewIntent.ToggleReviewExpansion -> {
+                    _state.update { currentState ->
+                        val expandedReviewIds = currentState.expandedReviewIds.toMutableSet()
+                        if (!expandedReviewIds.add(intent.reviewId)) {
+                            expandedReviewIds.remove(intent.reviewId)
+                        }
+                        currentState.copy(expandedReviewIds = expandedReviewIds)
+                    }
+                }
+
+                is MyReviewIntent.RequestDelete -> {
+                    _state.update { it.copy(pendingDeleteReviewId = intent.reviewId) }
+                }
+
+                is MyReviewIntent.DismissDeleteDialog -> {
+                    _state.update { it.copy(pendingDeleteReviewId = null) }
+                }
+
+                is MyReviewIntent.ConfirmDelete -> {
+                    _state.update { currentState ->
+                        val reviewId = currentState.pendingDeleteReviewId ?: return@update currentState
+                        currentState.copy(
+                            reviews = currentState.reviews.filterNot { review -> review.id == reviewId },
+                            expandedReviewIds = currentState.expandedReviewIds - reviewId,
+                            pendingDeleteReviewId = null,
+                        )
+                    }
+                }
+            }
+        }
+
+        private fun sendSideEffect(effect: MyReviewSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.send(effect)
+            }
+        }
+    }

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -12,6 +12,15 @@
     <string name="my_page_no_ongoing_shooting_sub">촬영지를 검색하고 작가들을 둘러보세요</string>
     <string name="my_page_follow_photographer">팔로우 작가</string>
     <string name="my_page_my_reviews">내 리뷰</string>
+    <string name="my_review_delete">삭제</string>
+    <string name="my_review_more">더보기</string>
+    <string name="my_review_less">접기</string>
+    <string name="my_review_delete_dialog_title">리뷰를 삭제할까요?</string>
+    <string name="my_review_delete_dialog_description">%1$s 리뷰를 삭제하면 다시 복구할 수 없어요.</string>
+    <string name="my_review_delete_dialog_cancel">취소</string>
+    <string name="my_review_delete_dialog_confirm">삭제</string>
+    <string name="my_review_empty_title">아직 작성한 리뷰가 없어요</string>
+    <string name="my_review_empty_description">촬영 후 남긴 리뷰가 이곳에 모여 보여요</string>
     <string name="my_page_terms">이용 약관</string>
     <string name="my_page_ad">광고</string>
     <string name="my_page_shooting_date">촬영 일시</string>

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -15,8 +15,8 @@
     <string name="my_review_delete">삭제</string>
     <string name="my_review_more">더보기</string>
     <string name="my_review_less">접기</string>
-    <string name="my_review_delete_dialog_title">리뷰를 삭제할까요?</string>
-    <string name="my_review_delete_dialog_description">%1$s 리뷰를 삭제하면 다시 복구할 수 없어요.</string>
+    <string name="my_review_delete_dialog_title">리뷰를 삭제하시겠습니까?</string>
+    <string name="my_review_delete_dialog_description">삭제된 리뷰는\n되돌릴 수 없습니다.</string>
     <string name="my_review_delete_dialog_cancel">취소</string>
     <string name="my_review_delete_dialog_confirm">삭제</string>
     <string name="my_review_empty_title">아직 작성한 리뷰가 없어요</string>


### PR DESCRIPTION
## Summary
- MyPage의 `내 리뷰` 메뉴를 실제 화면으로 연결하고 전용 route/nav flow를 추가했습니다.
- `feature/mypage`에 내 리뷰 화면 MVI 구조와 mock 기반 리뷰 목록 UI를 구현했습니다.
- 리뷰 카드 UI 디테일과 삭제 확인 모달을 피그마 기준으로 조정하고, expandable text는 deprecated `ClickableText` 없이 동작하도록 정리했습니다.

## Changes

### navigation
- `RouteModels.kt`
  - `MyPageMyReviews` route 추가
- `MainNavGraph.kt`
  - 내 리뷰 화면 destination 연결
- `MyPageScreen.kt` / `MyPageViewModel.kt` / `MyPageSideEffect.kt`
  - 기존 placeholder toast 분기를 실제 화면 이동으로 교체

### feature/mypage
- `MyReviewScreen.kt`
  - 내 리뷰 목록, 카드, 빈 상태, 삭제 확인 모달 연동
  - 카드 spacing / typography / star / delete pill / divider UI 디테일 조정
  - `...더보기 / 접기` inline 처리 및 최신 Compose 텍스트 API로 정리
- `MyReviewViewModel.kt`
  - mock 데이터 기반 삭제/확장 상태 관리
- `MyReviewState.kt` / `MyReviewIntent.kt` / `MyReviewSideEffect.kt`
  - 내 리뷰 화면 MVI 구조 추가
- `strings.xml`
  - 내 리뷰 및 삭제 모달 문자열 추가/수정

### core/ui
- `CommonDestructiveConfirmDialog.kt`
  - 삭제 확인 전용 공통 다이얼로그 variant 추가

## 구현
<img width="400" height="867" alt="KakaoTalk_Video_2026-04-17-00-24-12" src="https://github.com/user-attachments/assets/0d11371d-77ce-4cd2-938e-e7b0e844e9d3" />

## Verification
- `./gradlew :feature:mypage:compileDebugKotlin`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:installDebug`

Closes #152

