### PR TITLE
작가 전용 프로필 수정 플로우 추가

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/di/MemberModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/MemberModule.kt
@@ -1,9 +1,11 @@
 package com.hm.picplz.di
 
+import com.hm.picplz.data.repository.MemberRepositoryImpl
 import com.hm.picplz.data.service.MemberService
 import com.hm.picplz.data.service.MemberServiceImpl
 import com.hm.picplz.data.source.MemberSource
 import com.hm.picplz.data.source.MemberSourceImpl
+import com.hm.picplz.domain.repository.MemberRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,6 +15,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class MemberModule {
+    @Binds
+    @Singleton
+    abstract fun bindMemberRepository(memberRepositoryImpl: MemberRepositoryImpl): MemberRepository
+
     @Binds
     @Singleton
     abstract fun bindMemberService(memberServiceImpl: MemberServiceImpl): MemberService

--- a/app/src/main/kotlin/com/hm/picplz/di/S3Module.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/S3Module.kt
@@ -1,9 +1,11 @@
 package com.hm.picplz.di
 
+import com.hm.picplz.data.repository.S3RepositoryImpl
 import com.hm.picplz.data.service.S3Service
 import com.hm.picplz.data.service.S3ServiceImpl
 import com.hm.picplz.data.source.S3Source
 import com.hm.picplz.data.source.S3SourceImpl
+import com.hm.picplz.domain.repository.S3Repository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,6 +15,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class S3Module {
+    @Binds
+    @Singleton
+    abstract fun bindS3Repository(s3RepositoryImpl: S3RepositoryImpl): S3Repository
+
     @Binds
     @Singleton
     abstract fun bindS3Service(s3ServiceImpl: S3ServiceImpl): S3Service

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -19,6 +19,7 @@ import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPagePhotographer
+import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.Reservation
@@ -34,6 +35,7 @@ import com.hm.picplz.ui.screen.main.MainSearchScreen
 import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
+import com.hm.picplz.ui.screen.my_page.MyPagePhotographerModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.my_page.MyReviewScreen
@@ -87,6 +89,10 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MyPageModifyProfile> {
         MyPageModifyProfileScreen(navController = navController)
+    }
+
+    composable<MyPagePhotographerModifyProfile> {
+        MyPagePhotographerModifyProfileScreen(navController = navController)
     }
 
     composable<MyPageMyReviews> {

--- a/core/common/src/main/kotlin/com/hm/picplz/common/model/NicknameFieldError.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/model/NicknameFieldError.kt
@@ -5,15 +5,13 @@ sealed class NicknameFieldError {
 
     data class Required(override val message: String = "닉네임을 작성해주세요") : NicknameFieldError()
 
-    data class InvalidChar(override val message: String = "한글, 영문, 숫자만 입력 가능합니다") : NicknameFieldError()
+    data class InvalidChar(override val message: String = "한글,영문,숫자만 입력해 주세요. (2~15자)") : NicknameFieldError()
 
-    data class Length(override val message: String = "2~15자로 입력해주세요") : NicknameFieldError()
+    data class Length(override val message: String = "닉네임은 2~15자로 입력해 주세요.") : NicknameFieldError()
 
-    data class DuplicateNickname(override val message: String = "이미 사용 중인 닉네임입니다") : NicknameFieldError()
+    data class DuplicateNickname(override val message: String = "중복된 닉네임입니다.") : NicknameFieldError()
 
-    data class InvalidSpecialCharacter(override val message: String = "이모티콘이나 특수문자는 사용할 수 없습니다") : NicknameFieldError()
-
-    data class Whitespace(override val message: String = "닉네임의 처음과 끝에 공백을 사용할 수 없습니다") : NicknameFieldError()
+    data class Whitespace(override val message: String = "닉네임에 공백 사용은 불가능합니다.") : NicknameFieldError()
 
     data class Custom(override val message: String) : NicknameFieldError()
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/common/util/NicknameValidator.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/util/NicknameValidator.kt
@@ -3,20 +3,12 @@ package com.hm.picplz.common.util
 import com.hm.picplz.common.model.NicknameFieldError
 
 object NicknameValidator {
-    fun validate(newNickname: String): List<NicknameFieldError> {
-        val errors = mutableListOf<NicknameFieldError>()
-        if (newNickname.isEmpty()) {
-            errors.add(NicknameFieldError.Required())
-            return errors
+    fun validate(newNickname: String): List<NicknameFieldError> =
+        when {
+            newNickname.isEmpty() -> listOf(NicknameFieldError.Required())
+            newNickname.any { it.isWhitespace() } -> listOf(NicknameFieldError.Whitespace())
+            !newNickname.matches(Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$")) -> listOf(NicknameFieldError.InvalidChar())
+            newNickname.length !in 2..15 -> listOf(NicknameFieldError.Length())
+            else -> emptyList()
         }
-        if (!newNickname.matches(Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]+$"))) {
-            errors.add(NicknameFieldError.InvalidChar())
-            return errors
-        }
-        if (newNickname.length !in 2..15) {
-            errors.add(NicknameFieldError.Length())
-            return errors
-        }
-        return errors
-    }
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -80,6 +80,8 @@ data class MyPagePhotographer(
 
 @Serializable object MyPageModifyProfile : NavigationRoute
 
+@Serializable object MyPagePhotographerModifyProfile : NavigationRoute
+
 @Serializable object MyPageMyReviews : NavigationRoute
 
 @Serializable

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/MemberApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/MemberApi.kt
@@ -1,12 +1,27 @@
 package com.hm.picplz.data.api
 
+import com.hm.picplz.data.model.MemberInfoResponseDto
+import com.hm.picplz.data.model.UpdateMemberInfoRequest
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface MemberApi {
     @GET("api/v1/members/nickname")
     suspend fun checkNickname(
         @Query("nickname") nickname: String,
+    ): Response<Unit>
+
+    @GET("api/v1/members/{memberId}/info")
+    suspend fun getMemberInfo(
+        @Path("memberId") memberId: Long,
+    ): Response<MemberInfoResponseDto>
+
+    @PATCH("api/v1/members/info")
+    suspend fun updateMemberInfo(
+        @Body request: UpdateMemberInfoRequest,
     ): Response<Unit>
 }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/MemberModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/MemberModel.kt
@@ -1,0 +1,42 @@
+package com.hm.picplz.data.model
+
+import com.hm.picplz.domain.model.MemberProfile
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
+
+data class UpdateMemberInfoRequest(
+    val id: Long,
+    val nickname: String,
+    val profileImage: String?,
+    val introduction: String?,
+    val instagram: String?,
+)
+
+data class MemberInfoResponseDto(
+    val id: Long,
+    val nickname: String,
+    val role: String,
+    val socialEmail: String?,
+    val profileImage: String?,
+    val socialProvider: String?,
+    val socialCode: String?,
+    val introduction: String? = null,
+    val instagram: String? = null,
+)
+
+fun UpdateMemberProfileCommand.toRequest() =
+    UpdateMemberInfoRequest(
+        id = id,
+        nickname = nickname,
+        profileImage = profileImage,
+        introduction = introduction,
+        instagram = instagram,
+    )
+
+fun MemberInfoResponseDto.toDomain() =
+    MemberProfile(
+        id = id,
+        nickname = nickname,
+        profileImage = profileImage,
+        introduction = introduction,
+        instagram = instagram,
+    )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/provider/TokenManager.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/provider/TokenManager.kt
@@ -2,7 +2,9 @@ package com.hm.picplz.data.provider
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Base64
 import dagger.hilt.android.qualifiers.ApplicationContext
+import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -84,6 +86,17 @@ class TokenManager
         fun getSocialEmail(): String? = prefs.getString(KEY_SOCIAL_EMAIL, null)
 
         fun getSocialProvider(): String? = prefs.getString(KEY_SOCIAL_PROVIDER, null)
+
+        fun getMemberId(): Long? {
+            val token = getToken() ?: return null
+            val payload = token.split('.').getOrNull(1) ?: return null
+            val normalizedPayload = payload.padEnd((payload.length + 3) / 4 * 4, '=')
+
+            return runCatching {
+                val decodedPayload = Base64.decode(normalizedPayload, Base64.URL_SAFE or Base64.NO_WRAP)
+                JSONObject(String(decodedPayload)).optString("sub").toLongOrNull()
+            }.getOrNull()
+        }
 
         fun clearSocialInfo() {
             prefs.edit()

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/AuthRepositoryImpl.kt
@@ -47,4 +47,6 @@ class AuthRepositoryImpl
         override fun isKakaoTalkLoginAvailable(context: Context): Boolean {
             return kakaoAuthService.isKakaoTalkLoginAvailable(context)
         }
+
+        override fun getCurrentMemberId(): Long? = tokenManager.getMemberId()
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
@@ -1,6 +1,9 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.data.model.toRequest
 import com.hm.picplz.data.service.MemberService
+import com.hm.picplz.domain.model.MemberProfile
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 import com.hm.picplz.domain.repository.MemberRepository
 import javax.inject.Inject
 
@@ -11,4 +14,10 @@ class MemberRepositoryImpl
     ) : MemberRepository {
         override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> =
             memberService.checkNicknameAvailable(nickname)
+
+        override suspend fun getMemberProfile(memberId: Long): Result<MemberProfile> =
+            memberService.getMemberInfo(memberId)
+
+        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit> =
+            memberService.updateMemberInfo(command.toRequest())
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.hm.picplz.data.repository
+
+import com.hm.picplz.data.service.MemberService
+import com.hm.picplz.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class MemberRepositoryImpl
+    @Inject
+    constructor(
+        private val memberService: MemberService,
+    ) : MemberRepository {
+        override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> =
+            memberService.checkNicknameAvailable(nickname)
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/S3RepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/S3RepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.data.repository
+
+import com.hm.picplz.data.service.S3Service
+import com.hm.picplz.domain.repository.S3Repository
+import javax.inject.Inject
+
+class S3RepositoryImpl
+    @Inject
+    constructor(
+        private val s3Service: S3Service,
+    ) : S3Repository {
+        override suspend fun uploadProfileImage(
+            imageBytes: ByteArray,
+            filename: String,
+        ): Result<String> =
+            s3Service.getUploadUrl("PROFILE", filename)
+                .mapCatching { response ->
+                    s3Service.uploadImage(response.uploadUrl, imageBytes, "image/jpeg").getOrThrow()
+                    response.objectKey
+                }
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
@@ -1,10 +1,18 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.data.model.MemberInfoResponseDto
+import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.model.toDomain
 import com.hm.picplz.data.source.MemberSource
+import com.hm.picplz.domain.model.MemberProfile
 import javax.inject.Inject
 
 interface MemberService {
     suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+
+    suspend fun getMemberInfo(memberId: Long): Result<MemberProfile>
+
+    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit>
 }
 
 class MemberServiceImpl
@@ -14,4 +22,10 @@ class MemberServiceImpl
     ) : MemberService {
         override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> =
             memberSource.checkNickname(nickname)
+
+        override suspend fun getMemberInfo(memberId: Long): Result<MemberProfile> =
+            memberSource.getMemberInfo(memberId).map(MemberInfoResponseDto::toDomain)
+
+        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit> =
+            memberSource.updateMemberInfo(request)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
@@ -1,10 +1,18 @@
 package com.hm.picplz.data.source
 
 import com.hm.picplz.data.api.MemberApi
+import com.hm.picplz.data.model.MemberInfoResponseDto
+import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.util.safeApiCall
+import com.hm.picplz.data.util.safeApiCallUnit
 import javax.inject.Inject
 
 interface MemberSource {
     suspend fun checkNickname(nickname: String): Result<Boolean>
+
+    suspend fun getMemberInfo(memberId: Long): Result<MemberInfoResponseDto>
+
+    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit>
 }
 
 class MemberSourceImpl
@@ -21,4 +29,10 @@ class MemberSourceImpl
                     else -> error("Nickname check failed: ${response.code()} ${response.errorBody()?.string()}")
                 }
             }
+
+        override suspend fun getMemberInfo(memberId: Long): Result<MemberInfoResponseDto> =
+            safeApiCall { memberApi.getMemberInfo(memberId) }
+
+        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit> =
+            safeApiCallUnit { memberApi.updateMemberInfo(request) }
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/MemberProfile.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/MemberProfile.kt
@@ -1,0 +1,17 @@
+package com.hm.picplz.domain.model
+
+data class MemberProfile(
+    val id: Long,
+    val nickname: String,
+    val profileImage: String?,
+    val introduction: String?,
+    val instagram: String?,
+)
+
+data class UpdateMemberProfileCommand(
+    val id: Long,
+    val nickname: String,
+    val profileImage: String?,
+    val introduction: String?,
+    val instagram: String?,
+)

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AuthRepository.kt
@@ -12,4 +12,6 @@ interface AuthRepository {
     suspend fun unlinkKakao(): Result<Unit>
 
     fun isKakaoTalkLoginAvailable(context: Context): Boolean
+
+    fun getCurrentMemberId(): Long?
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.domain.repository
+
+interface MemberRepository {
+    suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
@@ -1,5 +1,12 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.domain.model.MemberProfile
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
+
 interface MemberRepository {
     suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+
+    suspend fun getMemberProfile(memberId: Long): Result<MemberProfile>
+
+    suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/S3Repository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/S3Repository.kt
@@ -1,0 +1,8 @@
+package com.hm.picplz.domain.repository
+
+interface S3Repository {
+    suspend fun uploadProfileImage(
+        imageBytes: ByteArray,
+        filename: String,
+    ): Result<String>
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CheckNicknameAvailabilityUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CheckNicknameAvailabilityUseCase.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class CheckNicknameAvailabilityUseCase
+    @Inject
+    constructor(
+        private val memberRepository: MemberRepository,
+    ) {
+        suspend operator fun invoke(nickname: String): Result<Boolean> =
+            memberRepository.checkNicknameAvailable(nickname)
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetCurrentMemberIdUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetCurrentMemberIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class GetCurrentMemberIdUseCase
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+    ) {
+        operator fun invoke(): Long? = authRepository.getCurrentMemberId()
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetMemberProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetMemberProfileUseCase.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.model.MemberProfile
+import com.hm.picplz.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class GetMemberProfileUseCase
+    @Inject
+    constructor(
+        private val memberRepository: MemberRepository,
+    ) {
+        suspend operator fun invoke(memberId: Long): Result<MemberProfile> = memberRepository.getMemberProfile(memberId)
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberProfileUseCase.kt
@@ -1,0 +1,14 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
+import com.hm.picplz.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class UpdateMemberProfileUseCase
+    @Inject
+    constructor(
+        private val memberRepository: MemberRepository,
+    ) {
+        suspend operator fun invoke(command: UpdateMemberProfileCommand): Result<Unit> =
+            memberRepository.updateMemberProfile(command)
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProfileImageUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProfileImageUseCase.kt
@@ -1,0 +1,15 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.repository.S3Repository
+import javax.inject.Inject
+
+class UploadProfileImageUseCase
+    @Inject
+    constructor(
+        private val s3Repository: S3Repository,
+    ) {
+        suspend operator fun invoke(
+            imageBytes: ByteArray,
+            filename: String,
+        ): Result<String> = s3Repository.uploadProfileImage(imageBytes, filename)
+    }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -43,6 +43,7 @@ import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
+import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPagePhotographer
 import com.hm.picplz.navigation.model.MyPageShootingHistory
@@ -182,6 +183,7 @@ fun DevScreen(navController: NavHostController) {
             SectionTitle("Main Sub")
             DevButton("MainSearch") { navController.navigate(MainSearch) }
             DevButton("MyPageModifyProfile") { navController.navigate(MyPageModifyProfile) }
+            DevButton("MyPagePhotographerModifyProfile") { navController.navigate(MyPagePhotographerModifyProfile) }
             DevButton("MyPageShootingHistory") { navController.navigate(MyPageShootingHistory()) }
             DevButton("MyPageShootingHistory (Empty)") {
                 navController.navigate(MyPageShootingHistory(forceEmpty = true))

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -43,9 +43,9 @@ import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
-import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPagePhotographer
+import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerEquipmentSetting

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageIntent.kt
@@ -3,6 +3,8 @@ package com.hm.picplz.ui.screen.my_page
 sealed interface MyPageIntent {
     data object NavigateToModifyProfile : MyPageIntent
 
+    data object NavigateToPhotographerModifyProfile : MyPageIntent
+
     data object NavigateToShootingHistory : MyPageIntent
 
     data object NavigateToSettings : MyPageIntent

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
@@ -1,0 +1,15 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePhotographerModifyProfileIntent {
+    data class ChangeNickname(val value: String) : MyPagePhotographerModifyProfileIntent
+
+    data class ChangeInstagramId(val value: String) : MyPagePhotographerModifyProfileIntent
+
+    data class ChangeIntroduction(val value: String) : MyPagePhotographerModifyProfileIntent
+
+    data class ChangeProfileImage(val uri: String) : MyPagePhotographerModifyProfileIntent
+
+    data object Save : MyPagePhotographerModifyProfileIntent
+
+    data object NavigateBack : MyPagePhotographerModifyProfileIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
@@ -9,6 +9,19 @@ sealed interface MyPagePhotographerModifyProfileIntent {
 
     data class ChangeProfileImage(val uri: String) : MyPagePhotographerModifyProfileIntent
 
+    data class UploadProfileImage(
+        val imageBytes: ByteArray,
+        val filename: String,
+    ) : MyPagePhotographerModifyProfileIntent {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is UploadProfileImage) return false
+            return filename == other.filename && imageBytes.contentEquals(other.imageBytes)
+        }
+
+        override fun hashCode(): Int = 31 * imageBytes.contentHashCode() + filename.hashCode()
+    }
+
     data object Save : MyPagePhotographerModifyProfileIntent
 
     data object NavigateBack : MyPagePhotographerModifyProfileIntent

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.ui.screen.my_page
 
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -27,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -55,6 +57,7 @@ fun MyPagePhotographerModifyProfileScreen(
     viewModel: MyPagePhotographerModifyProfileViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
 
     val filePickerLauncher =
         rememberLauncherForActivityResult(
@@ -62,6 +65,16 @@ fun MyPagePhotographerModifyProfileScreen(
         ) { uri: Uri? ->
             uri?.toString()?.let {
                 viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeProfileImage(it))
+                val imageBytes = context.contentResolver.openInputStream(uri)?.use { stream -> stream.readBytes() }
+                if (imageBytes != null) {
+                    val filename = uri.lastPathSegment ?: "profile.jpg"
+                    viewModel.handleIntent(
+                        MyPagePhotographerModifyProfileIntent.UploadProfileImage(
+                            imageBytes = imageBytes,
+                            filename = filename,
+                        ),
+                    )
+                }
             }
         }
 
@@ -69,6 +82,9 @@ fun MyPagePhotographerModifyProfileScreen(
         viewModel.sideEffect.collectLatest { sideEffect ->
             when (sideEffect) {
                 MyPagePhotographerModifyProfileSideEffect.NavigateBack -> navController.popBackStack()
+                is MyPagePhotographerModifyProfileSideEffect.ShowToast -> {
+                    Toast.makeText(context, sideEffect.messageResId, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
@@ -85,7 +101,7 @@ fun MyPagePhotographerModifyProfileScreen(
                 CommonBottomButton(
                     text = stringResource(R.string.modify_profile_done),
                     onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
-                    enabled = state.isCompleteEnabled,
+                    enabled = state.isCompleteEnabled && !state.isLoading,
                 )
             }
         },

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -60,11 +60,11 @@ import com.hm.picplz.core.ui.R as CoreR
 private const val INTRODUCTION_MAX_LENGTH = 100
 
 private object MyPagePhotographerModifyProfileLayoutDefaults {
-    val BottomButtonStartPadding = 30.dp
-    val BottomContentSpacing = 120.dp
+    val BottomActionAreaHeight = 120.dp
     val HorizontalPadding = 16.dp
     val SectionVerticalPadding = 12.dp
     val LabelToFieldSpacing = 12.dp
+    val NicknameBlockBottomSpacing = 12.dp
     val ProfileImageSize = 102.dp
     val CameraButtonTouchTarget = 32.dp
     val CameraIconSize = 26.dp
@@ -77,6 +77,7 @@ private object MyPagePhotographerModifyProfileLayoutDefaults {
     val IntroductionFieldBottomPadding = 18.dp
     val CounterHorizontalPadding = 16.dp
     val CounterBottomPadding = 2.dp
+    val IntroductionCounterBottomSpacing = 14.dp
     val FieldHelperTopPadding = 4.dp
 }
 
@@ -128,20 +129,6 @@ fun MyPagePhotographerModifyProfileScreen(
                 viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.NavigateBack)
             }
         },
-        floatingActionButton = {
-            Box(
-                modifier =
-                    Modifier
-                        .padding(start = MyPagePhotographerModifyProfileLayoutDefaults.BottomButtonStartPadding)
-                        .imePadding(),
-            ) {
-                CommonBottomButton(
-                    text = stringResource(R.string.modify_profile_done),
-                    onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
-                    enabled = state.isCompleteEnabled && !state.isLoading,
-                )
-            }
-        },
         modifier =
             modifier
                 .fillMaxSize()
@@ -154,46 +141,69 @@ fun MyPagePhotographerModifyProfileScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .imePadding()
-                    .verticalScroll(scrollState),
+                    .imePadding(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(modifier = Modifier.height(10.dp))
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(scrollState),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(modifier = Modifier.height(10.dp))
 
-            PhotographerProfileImageSection(
-                profileImageUri = state.profileImageUri,
-                onChangeImage = { filePickerLauncher.launch("image/*") },
-            )
+                PhotographerProfileImageSection(
+                    profileImageUri = state.profileImageUri,
+                    onChangeImage = { filePickerLauncher.launch("image/*") },
+                )
 
-            Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.ProfileToFormSpacing))
+                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.ProfileToFormSpacing))
 
-            PhotographerNicknameSection(
-                nickname = state.nickname,
-                isCheckingNickname = state.isCheckingNickname,
-                errorMessage = state.representativeNicknameError?.message,
-                onNicknameChange = {
-                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname(it))
-                },
-            )
+                PhotographerNicknameSection(
+                    nickname = state.nickname,
+                    isCheckingNickname = state.isCheckingNickname,
+                    errorMessage = state.representativeNicknameError?.message,
+                    onNicknameChange = {
+                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname(it))
+                    },
+                )
 
-            PhotographerTextFieldSection(
-                title = stringResource(R.string.modify_profile_instagram_id),
-                value = state.instagramId,
-                placeholder = stringResource(R.string.modify_profile_instagram_placeholder),
-                onValueChange = {
-                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId(it))
-                },
-            )
+                PhotographerTextFieldSection(
+                    title = stringResource(R.string.modify_profile_instagram_id),
+                    value = state.instagramId,
+                    placeholder = stringResource(R.string.modify_profile_instagram_placeholder),
+                    onValueChange = {
+                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId(it))
+                    },
+                )
 
-            PhotographerIntroductionSection(
-                introduction = state.introduction,
-                saveErrorMessage = state.saveErrorMessageResId?.let { stringResource(it) },
-                onIntroductionChange = {
-                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
-                },
-            )
+                PhotographerIntroductionSection(
+                    introduction = state.introduction,
+                    saveErrorMessage = state.saveErrorMessageResId?.let { stringResource(it) },
+                    onIntroductionChange = {
+                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
+                    },
+                )
 
-            Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.BottomContentSpacing))
+                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding))
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(MyPagePhotographerModifyProfileLayoutDefaults.BottomActionAreaHeight)
+                        .padding(horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CommonBottomButton(
+                    text = stringResource(R.string.modify_profile_done),
+                    onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
+                    enabled = state.isCompleteEnabled && !state.isLoading,
+                )
+            }
         }
     }
 }
@@ -290,6 +300,7 @@ private fun PhotographerNicknameSection(
                     .padding(top = MyPagePhotographerModifyProfileLayoutDefaults.FieldHelperTopPadding),
             textAlign = TextAlign.End,
         )
+        Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.NicknameBlockBottomSpacing))
     }
 }
 
@@ -355,9 +366,7 @@ private fun PhotographerIntroductionSection(
             ModifyProfileOutlinedTextField(
                 value = introduction,
                 onValueChange = {
-                    if (it.length <= INTRODUCTION_MAX_LENGTH) {
-                        onIntroductionChange(it)
-                    }
+                    onIntroductionChange(it.take(INTRODUCTION_MAX_LENGTH))
                 },
                 modifier =
                     Modifier
@@ -373,7 +382,7 @@ private fun PhotographerIntroductionSection(
             Text(
                 text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
                 style = IntroductionCounterTextStyle,
-                color = MainThemeColor.Gray4,
+                color = MainThemeColor.Gray3,
                 modifier =
                     Modifier
                         .align(Alignment.BottomEnd)
@@ -383,6 +392,7 @@ private fun PhotographerIntroductionSection(
                         ),
             )
         }
+        Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterBottomSpacing))
         if (saveErrorMessage != null) {
             Text(
                 text = saveErrorMessage,

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -12,11 +12,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -49,6 +52,11 @@ import kotlinx.coroutines.flow.collectLatest
 import com.hm.picplz.core.ui.R as CoreR
 
 private const val INTRODUCTION_MAX_LENGTH = 100
+
+private object MyPagePhotographerModifyProfileLayoutDefaults {
+    val BottomButtonStartPadding = 30.dp
+    val BottomContentSpacing = 120.dp
+}
 
 @Composable
 fun MyPagePhotographerModifyProfileScreen(
@@ -97,7 +105,12 @@ fun MyPagePhotographerModifyProfileScreen(
             }
         },
         floatingActionButton = {
-            Box(modifier = Modifier.padding(start = 30.dp)) {
+            Box(
+                modifier =
+                    Modifier
+                        .padding(start = MyPagePhotographerModifyProfileLayoutDefaults.BottomButtonStartPadding)
+                        .imePadding(),
+            ) {
                 CommonBottomButton(
                     text = stringResource(R.string.modify_profile_done),
                     onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
@@ -110,11 +123,15 @@ fun MyPagePhotographerModifyProfileScreen(
                 .fillMaxSize()
                 .systemBarsPadding(),
     ) { innerPadding ->
+        val scrollState = rememberScrollState()
+
         Column(
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .padding(innerPadding),
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .imePadding()
+                    .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.height(10.dp))
@@ -151,6 +168,8 @@ fun MyPagePhotographerModifyProfileScreen(
                     viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
                 },
             )
+
+            Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.BottomContentSpacing))
         }
     }
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -398,7 +398,12 @@ private fun PhotographerIntroductionSection(
                     modifier =
                         Modifier.padding(bottom = MyPagePhotographerModifyProfileLayoutDefaults.CounterBottomPadding),
                 )
-                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterBottomSpacing))
+                Spacer(
+                    modifier =
+                        Modifier.height(
+                            MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterBottomSpacing,
+                        ),
+                )
             }
         }
         if (saveErrorMessage != null) {

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -78,6 +78,8 @@ private object MyPagePhotographerModifyProfileLayoutDefaults {
     val CounterHorizontalPadding = 16.dp
     val CounterBottomPadding = 2.dp
     val IntroductionCounterBottomSpacing = 14.dp
+    val IntroductionCounterReservedBottomPadding =
+        IntroductionFieldBottomPadding + CounterBottomPadding + IntroductionCounterBottomSpacing
     val FieldHelperTopPadding = 4.dp
 }
 
@@ -362,37 +364,43 @@ private fun PhotographerIntroductionSection(
             style = MainThemeFont.TitleSmall,
         )
         Spacer(Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.LabelToFieldSpacing))
-        Box(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldHeight),
+        ) {
             ModifyProfileOutlinedTextField(
                 value = introduction,
                 onValueChange = {
                     onIntroductionChange(it.take(INTRODUCTION_MAX_LENGTH))
                 },
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldHeight),
+                modifier = Modifier.fillMaxSize(),
                 placeholder = stringResource(R.string.modify_profile_introduction_placeholder),
                 textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
                 singleLine = false,
                 isValid = true,
                 contentTopPadding = MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldTopPadding,
-                contentBottomPadding = MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldBottomPadding,
+                contentBottomPadding =
+                    MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterReservedBottomPadding,
             )
-            Text(
-                text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
-                style = IntroductionCounterTextStyle,
-                color = MainThemeColor.Gray3,
+            Column(
                 modifier =
                     Modifier
                         .align(Alignment.BottomEnd)
-                        .padding(
-                            end = MyPagePhotographerModifyProfileLayoutDefaults.CounterHorizontalPadding,
-                            bottom = MyPagePhotographerModifyProfileLayoutDefaults.CounterBottomPadding,
-                        ),
-            )
+                        .padding(end = MyPagePhotographerModifyProfileLayoutDefaults.CounterHorizontalPadding),
+                horizontalAlignment = Alignment.End,
+            ) {
+                Text(
+                    text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
+                    style = IntroductionCounterTextStyle,
+                    color = MainThemeColor.Gray3,
+                    modifier =
+                        Modifier.padding(bottom = MyPagePhotographerModifyProfileLayoutDefaults.CounterBottomPadding),
+                )
+                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterBottomSpacing))
+            }
         }
-        Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionCounterBottomSpacing))
         if (saveErrorMessage != null) {
             Text(
                 text = saveErrorMessage,

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,14 +20,16 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,9 +37,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -56,7 +62,25 @@ private const val INTRODUCTION_MAX_LENGTH = 100
 private object MyPagePhotographerModifyProfileLayoutDefaults {
     val BottomButtonStartPadding = 30.dp
     val BottomContentSpacing = 120.dp
+    val HorizontalPadding = 16.dp
+    val SectionVerticalPadding = 12.dp
+    val LabelToFieldSpacing = 12.dp
+    val ProfileImageSize = 102.dp
+    val CameraButtonTouchTarget = 32.dp
+    val CameraIconSize = 26.dp
+    val ProfileToFormSpacing = 12.dp
+    val SingleLineFieldHeight = 42.dp
+    val IntroductionFieldHeight = 136.dp
+    val FieldCornerRadius = 5.dp
+    val SingleLineFieldVerticalPadding = 10.dp
+    val IntroductionFieldTopPadding = 8.dp
+    val IntroductionFieldBottomPadding = 18.dp
+    val CounterHorizontalPadding = 16.dp
+    val CounterBottomPadding = 2.dp
+    val FieldHelperTopPadding = 4.dp
 }
+
+private val IntroductionCounterTextStyle = MainThemeFont.Caption.copy(fontSize = 11.sp, lineHeight = 14.sp)
 
 @Composable
 fun MyPagePhotographerModifyProfileScreen(
@@ -141,7 +165,7 @@ fun MyPagePhotographerModifyProfileScreen(
                 onChangeImage = { filePickerLauncher.launch("image/*") },
             )
 
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.ProfileToFormSpacing))
 
             PhotographerNicknameSection(
                 nickname = state.nickname,
@@ -180,7 +204,7 @@ private fun PhotographerProfileImageSection(
     onChangeImage: () -> Unit,
 ) {
     Box(
-        modifier = Modifier.size(102.dp),
+        modifier = Modifier.size(MyPagePhotographerModifyProfileLayoutDefaults.ProfileImageSize),
         contentAlignment = Alignment.BottomEnd,
     ) {
         if (profileImageUri.isNotEmpty()) {
@@ -190,27 +214,27 @@ private fun PhotographerProfileImageSection(
                 contentScale = ContentScale.Crop,
                 modifier =
                     Modifier
-                        .size(102.dp)
+                        .size(MyPagePhotographerModifyProfileLayoutDefaults.ProfileImageSize)
                         .clip(CircleShape),
             )
         } else {
             Box(
                 modifier =
                     Modifier
-                        .size(102.dp)
+                        .size(MyPagePhotographerModifyProfileLayoutDefaults.ProfileImageSize)
                         .clip(CircleShape)
-                        .background(MainThemeColor.Gray2),
+                        .background(MainThemeColor.Gray3),
             )
         }
 
         IconButton(
             onClick = onChangeImage,
-            modifier = Modifier.size(32.dp),
+            modifier = Modifier.size(MyPagePhotographerModifyProfileLayoutDefaults.CameraButtonTouchTarget),
         ) {
             Image(
                 painter = painterResource(id = CoreR.drawable.camera_circle),
                 contentDescription = stringResource(R.string.modify_profile_camera),
-                modifier = Modifier.size(27.dp),
+                modifier = Modifier.size(MyPagePhotographerModifyProfileLayoutDefaults.CameraIconSize),
             )
         }
     }
@@ -227,28 +251,30 @@ private fun PhotographerNicknameSection(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(
+                    horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding,
+                    vertical = MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding,
+                ),
     ) {
-        Column(modifier = Modifier.padding(vertical = 12.dp)) {
-            Text(
-                text = stringResource(R.string.modify_profile_nickname),
-                style = MainThemeFont.TitleSmall,
-            )
-            Spacer(Modifier.height(12.dp))
-            OutlinedTextField(
-                value = nickname,
-                onValueChange = onNicknameChange,
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = {
-                    Text(stringResource(R.string.modify_profile_nickname_placeholder))
-                },
-                singleLine = true,
-                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
-                isError = errorMessage != null,
-                colors = outlinedTextFieldColors(isValid = errorMessage == null),
-                shape = RoundedCornerShape(5.dp),
-            )
-        }
+        Text(
+            text = stringResource(R.string.modify_profile_nickname),
+            style = MainThemeFont.TitleSmall,
+        )
+        Spacer(Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.LabelToFieldSpacing))
+        ModifyProfileOutlinedTextField(
+            value = nickname,
+            onValueChange = onNicknameChange,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldHeight),
+            placeholder = stringResource(R.string.modify_profile_nickname_placeholder),
+            singleLine = true,
+            textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+            isValid = errorMessage == null,
+            contentTopPadding = MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldVerticalPadding,
+            contentBottomPadding = MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldVerticalPadding,
+        )
         Text(
             text =
                 when {
@@ -258,7 +284,10 @@ private fun PhotographerNicknameSection(
                 },
             style = MainThemeFont.Caption,
             color = if (errorMessage == null) MainThemeColor.Green120 else MainThemeColor.Red,
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = MyPagePhotographerModifyProfileLayoutDefaults.FieldHelperTopPadding),
             textAlign = TextAlign.End,
         )
     }
@@ -275,25 +304,30 @@ private fun PhotographerTextFieldSection(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(
+                    horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding,
+                    vertical = MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding,
+                ),
     ) {
-        Column(modifier = Modifier.padding(vertical = 12.dp)) {
-            Text(
-                text = title,
-                style = MainThemeFont.TitleSmall,
-            )
-            Spacer(Modifier.height(12.dp))
-            OutlinedTextField(
-                value = value,
-                onValueChange = onValueChange,
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text(placeholder) },
-                singleLine = true,
-                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
-                colors = outlinedTextFieldColors(isValid = true),
-                shape = RoundedCornerShape(5.dp),
-            )
-        }
+        Text(
+            text = title,
+            style = MainThemeFont.TitleSmall,
+        )
+        Spacer(Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.LabelToFieldSpacing))
+        ModifyProfileOutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldHeight),
+            placeholder = placeholder,
+            singleLine = true,
+            textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+            isValid = true,
+            contentTopPadding = MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldVerticalPadding,
+            contentBottomPadding = MyPagePhotographerModifyProfileLayoutDefaults.SingleLineFieldVerticalPadding,
+        )
     }
 }
 
@@ -307,44 +341,57 @@ private fun PhotographerIntroductionSection(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(
+                    horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding,
+                    vertical = MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding,
+                ),
     ) {
-        Column(modifier = Modifier.padding(vertical = 12.dp)) {
-            Text(
-                text = stringResource(R.string.modify_profile_introduction),
-                style = MainThemeFont.TitleSmall,
-            )
-            Spacer(Modifier.height(12.dp))
-            OutlinedTextField(
+        Text(
+            text = stringResource(R.string.modify_profile_introduction),
+            style = MainThemeFont.TitleSmall,
+        )
+        Spacer(Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.LabelToFieldSpacing))
+        Box(modifier = Modifier.fillMaxWidth()) {
+            ModifyProfileOutlinedTextField(
                 value = introduction,
                 onValueChange = {
                     if (it.length <= INTRODUCTION_MAX_LENGTH) {
                         onIntroductionChange(it)
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text(stringResource(R.string.modify_profile_introduction_placeholder)) },
-                minLines = 5,
-                maxLines = 5,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldHeight),
+                placeholder = stringResource(R.string.modify_profile_introduction_placeholder),
                 textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
-                colors = outlinedTextFieldColors(isValid = true),
-                shape = RoundedCornerShape(5.dp),
+                singleLine = false,
+                isValid = true,
+                contentTopPadding = MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldTopPadding,
+                contentBottomPadding = MyPagePhotographerModifyProfileLayoutDefaults.IntroductionFieldBottomPadding,
+            )
+            Text(
+                text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
+                style = IntroductionCounterTextStyle,
+                color = MainThemeColor.Gray4,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(
+                            end = MyPagePhotographerModifyProfileLayoutDefaults.CounterHorizontalPadding,
+                            bottom = MyPagePhotographerModifyProfileLayoutDefaults.CounterBottomPadding,
+                        ),
             )
         }
-        Text(
-            text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
-            style = MainThemeFont.Caption,
-            color = MainThemeColor.Gray4,
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.End,
-        )
         if (saveErrorMessage != null) {
-            Spacer(Modifier.height(8.dp))
             Text(
                 text = saveErrorMessage,
                 style = MainThemeFont.Caption,
                 color = MainThemeColor.Red,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = MyPagePhotographerModifyProfileLayoutDefaults.FieldHelperTopPadding),
             )
         }
     }
@@ -356,12 +403,77 @@ private fun outlinedTextFieldColors(isValid: Boolean) =
         focusedContainerColor = MainThemeColor.Gray1,
         unfocusedContainerColor = MainThemeColor.Gray1,
         errorContainerColor = MainThemeColor.Gray1,
+        focusedTextColor = MainThemeColor.Black,
+        unfocusedTextColor = MainThemeColor.Black,
+        errorTextColor = MainThemeColor.Black,
         focusedBorderColor = if (isValid) MainThemeColor.Gray3 else MainThemeColor.Red,
         unfocusedBorderColor = if (isValid) MainThemeColor.Gray2 else MainThemeColor.Red,
         errorBorderColor = MainThemeColor.Red,
+        focusedPlaceholderColor = MainThemeColor.Gray3,
+        unfocusedPlaceholderColor = MainThemeColor.Gray3,
+        errorPlaceholderColor = MainThemeColor.Gray3,
         cursorColor = MainThemeColor.Black,
         errorCursorColor = MainThemeColor.Black,
     )
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ModifyProfileOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String,
+    textStyle: TextStyle,
+    singleLine: Boolean,
+    isValid: Boolean,
+    contentTopPadding: androidx.compose.ui.unit.Dp,
+    contentBottomPadding: androidx.compose.ui.unit.Dp,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        textStyle = textStyle,
+        interactionSource = interactionSource,
+        singleLine = singleLine,
+    ) { innerTextField ->
+        OutlinedTextFieldDefaults.DecorationBox(
+            value = value,
+            innerTextField = innerTextField,
+            enabled = true,
+            singleLine = singleLine,
+            visualTransformation = VisualTransformation.None,
+            interactionSource = interactionSource,
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    style = textStyle.copy(color = MainThemeColor.Gray3),
+                )
+            },
+            colors = outlinedTextFieldColors(isValid = isValid),
+            contentPadding =
+                OutlinedTextFieldDefaults.contentPadding(
+                    start = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding,
+                    top = contentTopPadding,
+                    end = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding,
+                    bottom = contentBottomPadding,
+                ),
+            container = {
+                OutlinedTextFieldDefaults.Container(
+                    enabled = true,
+                    isError = !isValid,
+                    interactionSource = interactionSource,
+                    colors = outlinedTextFieldColors(isValid = isValid),
+                    shape = RoundedCornerShape(MyPagePhotographerModifyProfileLayoutDefaults.FieldCornerRadius),
+                    unfocusedBorderThickness = 1.dp,
+                    focusedBorderThickness = 1.dp,
+                )
+            },
+        )
+    }
+}
 
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -1,0 +1,338 @@
+package com.hm.picplz.ui.screen.my_page
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonFixedTopBar
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.core.ui.R as CoreR
+
+private const val INTRODUCTION_MAX_LENGTH = 100
+
+@Composable
+fun MyPagePhotographerModifyProfileScreen(
+    modifier: Modifier = Modifier,
+    navController: NavHostController,
+    viewModel: MyPagePhotographerModifyProfileViewModel = hiltViewModel(),
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle().value
+
+    val filePickerLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.GetContent(),
+        ) { uri: Uri? ->
+            uri?.toString()?.let {
+                viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeProfileImage(it))
+            }
+        }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            when (sideEffect) {
+                MyPagePhotographerModifyProfileSideEffect.NavigateBack -> navController.popBackStack()
+            }
+        }
+    }
+
+    Scaffold(
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonFixedTopBar(title = stringResource(R.string.modify_profile_title)) {
+                viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.NavigateBack)
+            }
+        },
+        floatingActionButton = {
+            Box(modifier = Modifier.padding(start = 30.dp)) {
+                CommonBottomButton(
+                    text = stringResource(R.string.modify_profile_done),
+                    onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
+                    enabled = state.isCompleteEnabled,
+                )
+            }
+        },
+        modifier =
+            modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(innerPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(10.dp))
+
+            PhotographerProfileImageSection(
+                profileImageUri = state.profileImageUri,
+                onChangeImage = { filePickerLauncher.launch("image/*") },
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            PhotographerNicknameSection(
+                nickname = state.nickname,
+                isCheckingNickname = state.isCheckingNickname,
+                errorMessage = state.representativeNicknameError?.message,
+                onNicknameChange = {
+                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname(it))
+                },
+            )
+
+            PhotographerTextFieldSection(
+                title = stringResource(R.string.modify_profile_instagram_id),
+                value = state.instagramId,
+                placeholder = stringResource(R.string.modify_profile_instagram_placeholder),
+                onValueChange = {
+                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId(it))
+                },
+            )
+
+            PhotographerIntroductionSection(
+                introduction = state.introduction,
+                saveErrorMessage = state.saveErrorMessageResId?.let { stringResource(it) },
+                onIntroductionChange = {
+                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerProfileImageSection(
+    profileImageUri: String,
+    onChangeImage: () -> Unit,
+) {
+    Box(
+        modifier = Modifier.size(102.dp),
+        contentAlignment = Alignment.BottomEnd,
+    ) {
+        if (profileImageUri.isNotEmpty()) {
+            AsyncImage(
+                model = profileImageUri,
+                contentDescription = stringResource(R.string.modify_profile_image),
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .size(102.dp)
+                        .clip(CircleShape),
+            )
+        } else {
+            Box(
+                modifier =
+                    Modifier
+                        .size(102.dp)
+                        .clip(CircleShape)
+                        .background(MainThemeColor.Gray2),
+            )
+        }
+
+        IconButton(
+            onClick = onChangeImage,
+            modifier = Modifier.size(32.dp),
+        ) {
+            Image(
+                painter = painterResource(id = CoreR.drawable.camera_circle),
+                contentDescription = stringResource(R.string.modify_profile_camera),
+                modifier = Modifier.size(27.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerNicknameSection(
+    nickname: String,
+    isCheckingNickname: Boolean,
+    errorMessage: String?,
+    onNicknameChange: (String) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 12.dp)) {
+            Text(
+                text = stringResource(R.string.modify_profile_nickname),
+                style = MainThemeFont.TitleSmall,
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = nickname,
+                onValueChange = onNicknameChange,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(stringResource(R.string.modify_profile_nickname_placeholder))
+                },
+                singleLine = true,
+                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+                isError = errorMessage != null,
+                colors = outlinedTextFieldColors(isValid = errorMessage == null),
+                shape = RoundedCornerShape(5.dp),
+            )
+        }
+        Text(
+            text =
+                when {
+                    errorMessage != null -> errorMessage
+                    isCheckingNickname -> stringResource(R.string.modify_profile_nickname_checking)
+                    else -> stringResource(R.string.modify_profile_nickname_hint)
+                },
+            style = MainThemeFont.Caption,
+            color = if (errorMessage == null) MainThemeColor.Green120 else MainThemeColor.Red,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.End,
+        )
+    }
+}
+
+@Composable
+private fun PhotographerTextFieldSection(
+    title: String,
+    value: String,
+    placeholder: String,
+    onValueChange: (String) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 12.dp)) {
+            Text(
+                text = title,
+                style = MainThemeFont.TitleSmall,
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(placeholder) },
+                singleLine = true,
+                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+                colors = outlinedTextFieldColors(isValid = true),
+                shape = RoundedCornerShape(5.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerIntroductionSection(
+    introduction: String,
+    saveErrorMessage: String?,
+    onIntroductionChange: (String) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 12.dp)) {
+            Text(
+                text = stringResource(R.string.modify_profile_introduction),
+                style = MainThemeFont.TitleSmall,
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = introduction,
+                onValueChange = {
+                    if (it.length <= INTRODUCTION_MAX_LENGTH) {
+                        onIntroductionChange(it)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(stringResource(R.string.modify_profile_introduction_placeholder)) },
+                minLines = 5,
+                maxLines = 5,
+                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+                colors = outlinedTextFieldColors(isValid = true),
+                shape = RoundedCornerShape(5.dp),
+            )
+        }
+        Text(
+            text = stringResource(R.string.modify_profile_introduction_counter, introduction.length),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.End,
+        )
+        if (saveErrorMessage != null) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = saveErrorMessage,
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Red,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun outlinedTextFieldColors(isValid: Boolean) =
+    OutlinedTextFieldDefaults.colors(
+        focusedContainerColor = MainThemeColor.Gray1,
+        unfocusedContainerColor = MainThemeColor.Gray1,
+        errorContainerColor = MainThemeColor.Gray1,
+        focusedBorderColor = if (isValid) MainThemeColor.Gray3 else MainThemeColor.Red,
+        unfocusedBorderColor = if (isValid) MainThemeColor.Gray2 else MainThemeColor.Red,
+        errorBorderColor = MainThemeColor.Red,
+        cursorColor = MainThemeColor.Black,
+        errorCursorColor = MainThemeColor.Black,
+    )
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun MyPagePhotographerModifyProfileScreenPreview() {
+    PicplzTheme {
+        MyPagePhotographerModifyProfileScreen(navController = rememberNavController())
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePhotographerModifyProfileSideEffect {
+    data object NavigateBack : MyPagePhotographerModifyProfileSideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
@@ -2,4 +2,6 @@ package com.hm.picplz.ui.screen.my_page
 
 sealed interface MyPagePhotographerModifyProfileSideEffect {
     data object NavigateBack : MyPagePhotographerModifyProfileSideEffect
+
+    data class ShowToast(val messageResId: Int) : MyPagePhotographerModifyProfileSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
@@ -1,0 +1,48 @@
+package com.hm.picplz.ui.screen.my_page
+
+import com.hm.picplz.common.model.NicknameFieldError
+
+data class MyPagePhotographerModifyProfileState(
+    val originalNickname: String,
+    val nickname: String,
+    val originalInstagramId: String,
+    val instagramId: String,
+    val originalIntroduction: String,
+    val introduction: String,
+    val originalProfileImageUri: String,
+    val profileImageUri: String,
+    val nicknameFieldErrors: List<NicknameFieldError> = emptyList(),
+    val isCheckingNickname: Boolean = false,
+    val isSaving: Boolean = false,
+    val saveErrorMessageResId: Int? = null,
+) {
+    val representativeNicknameError: NicknameFieldError?
+        get() = nicknameFieldErrors.firstOrNull()
+
+    val hasChanges: Boolean
+        get() =
+            nickname != originalNickname ||
+                instagramId != originalInstagramId ||
+                introduction != originalIntroduction ||
+                profileImageUri != originalProfileImageUri
+
+    val isFormValid: Boolean
+        get() = nickname.isNotBlank() && nicknameFieldErrors.isEmpty() && !isCheckingNickname && !isSaving
+
+    val isCompleteEnabled: Boolean
+        get() = hasChanges && isFormValid
+
+    companion object {
+        fun idle() =
+            MyPagePhotographerModifyProfileState(
+                originalNickname = "유가영",
+                nickname = "유가영",
+                originalInstagramId = "imdooring",
+                instagramId = "imdooring",
+                originalIntroduction = "안녕하세요, 임두현 사진작가입니다.",
+                introduction = "안녕하세요, 임두현 사진작가입니다.",
+                originalProfileImageUri = "",
+                profileImageUri = "",
+            )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
@@ -3,17 +3,22 @@ package com.hm.picplz.ui.screen.my_page
 import com.hm.picplz.common.model.NicknameFieldError
 
 data class MyPagePhotographerModifyProfileState(
+    val memberId: Long?,
     val originalNickname: String,
     val nickname: String,
     val originalInstagramId: String,
     val instagramId: String,
     val originalIntroduction: String,
     val introduction: String,
+    val originalProfileImageObjectKey: String?,
+    val profileImageObjectKey: String?,
     val originalProfileImageUri: String,
     val profileImageUri: String,
     val nicknameFieldErrors: List<NicknameFieldError> = emptyList(),
     val isCheckingNickname: Boolean = false,
+    val isUploadingImage: Boolean = false,
     val isSaving: Boolean = false,
+    val isLoading: Boolean = false,
     val saveErrorMessageResId: Int? = null,
 ) {
     val representativeNicknameError: NicknameFieldError?
@@ -24,10 +29,17 @@ data class MyPagePhotographerModifyProfileState(
             nickname != originalNickname ||
                 instagramId != originalInstagramId ||
                 introduction != originalIntroduction ||
+                profileImageObjectKey != originalProfileImageObjectKey ||
                 profileImageUri != originalProfileImageUri
 
     val isFormValid: Boolean
-        get() = nickname.isNotBlank() && nicknameFieldErrors.isEmpty() && !isCheckingNickname && !isSaving
+        get() =
+            memberId != null &&
+                nickname.isNotBlank() &&
+                nicknameFieldErrors.isEmpty() &&
+                !isCheckingNickname &&
+                !isUploadingImage &&
+                !isSaving
 
     val isCompleteEnabled: Boolean
         get() = hasChanges && isFormValid
@@ -35,12 +47,15 @@ data class MyPagePhotographerModifyProfileState(
     companion object {
         fun idle() =
             MyPagePhotographerModifyProfileState(
+                memberId = null,
                 originalNickname = "유가영",
                 nickname = "유가영",
                 originalInstagramId = "imdooring",
                 instagramId = "imdooring",
                 originalIntroduction = "안녕하세요, 임두현 사진작가입니다.",
                 introduction = "안녕하세요, 임두현 사진작가입니다.",
+                originalProfileImageObjectKey = null,
+                profileImageObjectKey = null,
                 originalProfileImageUri = "",
                 profileImageUri = "",
             )

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
@@ -1,0 +1,121 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.model.NicknameFieldError
+import com.hm.picplz.common.util.NicknameValidator
+import com.hm.picplz.domain.usecase.CheckNicknameAvailabilityUseCase
+import com.hm.picplz.feature.mypage.R
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyPagePhotographerModifyProfileViewModel
+    @Inject
+    constructor(
+        private val checkNicknameAvailabilityUseCase: CheckNicknameAvailabilityUseCase,
+    ) : ViewModel() {
+        private val _state = MutableStateFlow(MyPagePhotographerModifyProfileState.idle())
+        val state: StateFlow<MyPagePhotographerModifyProfileState> get() = _state
+
+        private val _sideEffect = Channel<MyPagePhotographerModifyProfileSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        private var duplicateCheckJob: Job? = null
+
+        fun handleIntent(intent: MyPagePhotographerModifyProfileIntent) {
+            when (intent) {
+                is MyPagePhotographerModifyProfileIntent.ChangeNickname -> handleNicknameChange(intent.value)
+                is MyPagePhotographerModifyProfileIntent.ChangeInstagramId -> {
+                    _state.update { it.copy(instagramId = intent.value, saveErrorMessageResId = null) }
+                }
+                is MyPagePhotographerModifyProfileIntent.ChangeIntroduction -> {
+                    _state.update { it.copy(introduction = intent.value, saveErrorMessageResId = null) }
+                }
+                is MyPagePhotographerModifyProfileIntent.ChangeProfileImage -> {
+                    _state.update { it.copy(profileImageUri = intent.uri, saveErrorMessageResId = null) }
+                }
+                is MyPagePhotographerModifyProfileIntent.Save -> save()
+                is MyPagePhotographerModifyProfileIntent.NavigateBack -> navigateBack()
+            }
+        }
+
+        private fun handleNicknameChange(newNickname: String) {
+            duplicateCheckJob?.cancel()
+
+            val localErrors = NicknameValidator.validate(newNickname)
+            _state.update {
+                it.copy(
+                    nickname = newNickname,
+                    nicknameFieldErrors = localErrors,
+                    isCheckingNickname = false,
+                    saveErrorMessageResId = null,
+                )
+            }
+
+            val currentState = _state.value
+            if (newNickname == currentState.originalNickname || localErrors.isNotEmpty()) {
+                return
+            }
+
+            duplicateCheckJob =
+                viewModelScope.launch {
+                    _state.update { it.copy(isCheckingNickname = true) }
+
+                    checkNicknameAvailabilityUseCase(newNickname)
+                        .onSuccess { isAvailable ->
+                            _state.update { state ->
+                                if (state.nickname != newNickname) {
+                                    state
+                                } else {
+                                    state.copy(
+                                        isCheckingNickname = false,
+                                        nicknameFieldErrors =
+                                            if (isAvailable) {
+                                                emptyList()
+                                            } else {
+                                                listOf(NicknameFieldError.DuplicateNickname())
+                                            },
+                                    )
+                                }
+                            }
+                        }
+                        .onFailure {
+                            _state.update { state ->
+                                if (state.nickname != newNickname) {
+                                    state
+                                } else {
+                                    state.copy(isCheckingNickname = false)
+                                }
+                            }
+                        }
+                }
+        }
+
+        private fun save() {
+            if (!_state.value.isCompleteEnabled) {
+                return
+            }
+
+            _state.update { it.copy(isSaving = true, saveErrorMessageResId = null) }
+            _state.update {
+                it.copy(
+                    isSaving = false,
+                    saveErrorMessageResId = R.string.modify_profile_save_unsupported,
+                )
+            }
+        }
+
+        private fun navigateBack() {
+            viewModelScope.launch {
+                _sideEffect.send(MyPagePhotographerModifyProfileSideEffect.NavigateBack)
+            }
+        }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
@@ -66,7 +66,13 @@ class MyPagePhotographerModifyProfileViewModel
         private fun loadMemberProfile() {
             val memberId = getCurrentMemberIdUseCase()
             if (memberId == null) {
-                _state.update { it.copy(saveErrorMessageResId = R.string.modify_profile_member_not_found) }
+                viewModelScope.launch {
+                    _sideEffect.send(
+                        MyPagePhotographerModifyProfileSideEffect.ShowToast(
+                            R.string.modify_profile_member_not_found,
+                        ),
+                    )
+                }
                 return
             }
 
@@ -95,9 +101,14 @@ class MyPagePhotographerModifyProfileViewModel
                         _state.update {
                             it.copy(
                                 isLoading = false,
-                                saveErrorMessageResId = R.string.modify_profile_load_failed,
+                                saveErrorMessageResId = null,
                             )
                         }
+                        _sideEffect.send(
+                            MyPagePhotographerModifyProfileSideEffect.ShowToast(
+                                R.string.modify_profile_load_failed,
+                            ),
+                        )
                     }
             }
         }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
@@ -4,7 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hm.picplz.common.model.NicknameFieldError
 import com.hm.picplz.common.util.NicknameValidator
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 import com.hm.picplz.domain.usecase.CheckNicknameAvailabilityUseCase
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetMemberProfileUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberProfileUseCase
+import com.hm.picplz.domain.usecase.UploadProfileImageUseCase
 import com.hm.picplz.feature.mypage.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -21,6 +26,10 @@ class MyPagePhotographerModifyProfileViewModel
     @Inject
     constructor(
         private val checkNicknameAvailabilityUseCase: CheckNicknameAvailabilityUseCase,
+        private val getCurrentMemberIdUseCase: GetCurrentMemberIdUseCase,
+        private val getMemberProfileUseCase: GetMemberProfileUseCase,
+        private val updateMemberProfileUseCase: UpdateMemberProfileUseCase,
+        private val uploadProfileImageUseCase: UploadProfileImageUseCase,
     ) : ViewModel() {
         private val _state = MutableStateFlow(MyPagePhotographerModifyProfileState.idle())
         val state: StateFlow<MyPagePhotographerModifyProfileState> get() = _state
@@ -29,6 +38,10 @@ class MyPagePhotographerModifyProfileViewModel
         val sideEffect = _sideEffect.receiveAsFlow()
 
         private var duplicateCheckJob: Job? = null
+
+        init {
+            loadMemberProfile()
+        }
 
         fun handleIntent(intent: MyPagePhotographerModifyProfileIntent) {
             when (intent) {
@@ -42,8 +55,50 @@ class MyPagePhotographerModifyProfileViewModel
                 is MyPagePhotographerModifyProfileIntent.ChangeProfileImage -> {
                     _state.update { it.copy(profileImageUri = intent.uri, saveErrorMessageResId = null) }
                 }
+                is MyPagePhotographerModifyProfileIntent.UploadProfileImage -> {
+                    uploadProfileImage(intent.imageBytes, intent.filename)
+                }
                 is MyPagePhotographerModifyProfileIntent.Save -> save()
                 is MyPagePhotographerModifyProfileIntent.NavigateBack -> navigateBack()
+            }
+        }
+
+        private fun loadMemberProfile() {
+            val memberId = getCurrentMemberIdUseCase()
+            if (memberId == null) {
+                _state.update { it.copy(saveErrorMessageResId = R.string.modify_profile_member_not_found) }
+                return
+            }
+
+            _state.update { it.copy(isLoading = true, memberId = memberId) }
+            viewModelScope.launch {
+                getMemberProfileUseCase(memberId)
+                    .onSuccess { profile ->
+                        _state.update {
+                            it.copy(
+                                memberId = profile.id,
+                                originalNickname = profile.nickname,
+                                nickname = profile.nickname,
+                                originalInstagramId = profile.instagram.orEmpty(),
+                                instagramId = profile.instagram.orEmpty(),
+                                originalIntroduction = profile.introduction.orEmpty(),
+                                introduction = profile.introduction.orEmpty(),
+                                originalProfileImageObjectKey = profile.profileImage,
+                                profileImageObjectKey = profile.profileImage,
+                                originalProfileImageUri = profile.profileImage.orEmpty(),
+                                profileImageUri = profile.profileImage.orEmpty(),
+                                isLoading = false,
+                                saveErrorMessageResId = null,
+                            )
+                        }
+                    }.onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                saveErrorMessageResId = R.string.modify_profile_load_failed,
+                            )
+                        }
+                    }
             }
         }
 
@@ -100,16 +155,67 @@ class MyPagePhotographerModifyProfileViewModel
         }
 
         private fun save() {
-            if (!_state.value.isCompleteEnabled) {
+            val currentState = _state.value
+            if (!currentState.isCompleteEnabled || currentState.isSaving) {
                 return
             }
 
             _state.update { it.copy(isSaving = true, saveErrorMessageResId = null) }
-            _state.update {
-                it.copy(
-                    isSaving = false,
-                    saveErrorMessageResId = R.string.modify_profile_save_unsupported,
-                )
+            viewModelScope.launch {
+                updateMemberProfileUseCase(
+                    UpdateMemberProfileCommand(
+                        id = currentState.memberId ?: return@launch,
+                        nickname = currentState.nickname,
+                        profileImage = currentState.profileImageObjectKey,
+                        introduction = currentState.introduction.ifBlank { null },
+                        instagram = currentState.instagramId.ifBlank { null },
+                    ),
+                ).onSuccess {
+                    _state.update {
+                        it.copy(
+                            originalNickname = it.nickname,
+                            originalInstagramId = it.instagramId,
+                            originalIntroduction = it.introduction,
+                            originalProfileImageObjectKey = it.profileImageObjectKey,
+                            originalProfileImageUri = it.profileImageUri,
+                            isSaving = false,
+                            saveErrorMessageResId = null,
+                        )
+                    }
+                    _sideEffect.send(MyPagePhotographerModifyProfileSideEffect.NavigateBack)
+                }.onFailure {
+                    _state.update {
+                        it.copy(
+                            isSaving = false,
+                            saveErrorMessageResId = R.string.modify_profile_save_failed,
+                        )
+                    }
+                }
+            }
+        }
+
+        private fun uploadProfileImage(
+            imageBytes: ByteArray,
+            filename: String,
+        ) {
+            _state.update { it.copy(isUploadingImage = true, saveErrorMessageResId = null) }
+            viewModelScope.launch {
+                uploadProfileImageUseCase(imageBytes, filename)
+                    .onSuccess { objectKey ->
+                        _state.update {
+                            it.copy(
+                                profileImageObjectKey = objectKey,
+                                isUploadingImage = false,
+                            )
+                        }
+                    }.onFailure {
+                        _state.update {
+                            it.copy(
+                                isUploadingImage = false,
+                                saveErrorMessageResId = R.string.modify_profile_image_upload_failed,
+                            )
+                        }
+                    }
             }
         }
 

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -69,6 +69,7 @@ import com.hm.picplz.feature.mypage.R
 import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageMyReviews
+import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.SignUpPhotographer
 import com.hm.picplz.ui.navigation.BottomNavigationBar
@@ -123,6 +124,9 @@ fun MyPageScreen(
                 }
                 is MyPageSideEffect.NavigateToModifyProfile -> {
                     navController.navigate(MyPageModifyProfile)
+                }
+                is MyPageSideEffect.NavigateToPhotographerModifyProfile -> {
+                    navController.navigate(MyPagePhotographerModifyProfile)
                 }
                 is MyPageSideEffect.NavigateToMyReviews -> {
                     navController.navigate(MyPageMyReviews)
@@ -391,7 +395,7 @@ private fun PhotographerMyPageContent(
     ) {
         PhotographerProfileCard(
             photographerProfile = photographerProfile,
-            onModifyProfileClick = { onIntent(MyPageIntent.NavigateToModifyProfile) },
+            onModifyProfileClick = { onIntent(MyPageIntent.NavigateToPhotographerModifyProfile) },
             onPreviewClick = { onIntent(MyPageIntent.NavigateToPhotographerPreview) },
             onRegionEditClick = { onIntent(MyPageIntent.NavigateToPhotographerRegionEdit) },
             onKeywordEditClick = { onIntent(MyPageIntent.NavigateToPhotographerKeywordEdit) },

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
@@ -5,6 +5,8 @@ sealed interface MyPageSideEffect {
 
     data object NavigateToModifyProfile : MyPageSideEffect
 
+    data object NavigateToPhotographerModifyProfile : MyPageSideEffect
+
     data object NavigateToMyReviews : MyPageSideEffect
 
     data object NavigateToFollowedPhotographers : MyPageSideEffect

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -27,6 +27,9 @@ class MyPageViewModel
                 is MyPageIntent.NavigateToModifyProfile -> {
                     sendSideEffect(MyPageSideEffect.NavigateToModifyProfile)
                 }
+                is MyPageIntent.NavigateToPhotographerModifyProfile -> {
+                    sendSideEffect(MyPageSideEffect.NavigateToPhotographerModifyProfile)
+                }
                 is MyPageIntent.NavigateToShootingHistory -> {
                     sendSideEffect(MyPageSideEffect.NavigateToShootingHistory)
                 }

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -103,7 +103,10 @@
     <string name="modify_profile_introduction">자기소개</string>
     <string name="modify_profile_introduction_placeholder">자기소개를 적어주세요</string>
     <string name="modify_profile_introduction_counter">%1$d/100</string>
-    <string name="modify_profile_save_unsupported">프로필 저장은 아직 지원되지 않습니다.</string>
+    <string name="modify_profile_member_not_found">회원 정보를 찾을 수 없습니다.</string>
+    <string name="modify_profile_load_failed">프로필 정보를 불러오지 못했습니다.</string>
+    <string name="modify_profile_save_failed">프로필 저장에 실패했습니다.</string>
+    <string name="modify_profile_image_upload_failed">프로필 이미지 업로드에 실패했습니다.</string>
 
     <!-- 주문 상세 -->
     <string name="order_detail_title">주문 상세</string>

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -93,10 +93,17 @@
     <string name="modify_profile_nickname">닉네임</string>
     <string name="modify_profile_nickname_placeholder">닉네임을 입력하세요</string>
     <string name="modify_profile_nickname_hint">한글, 영문, 숫자만 가능합니다.</string>
+    <string name="modify_profile_nickname_checking">닉네임을 확인하고 있습니다.</string>
     <string name="modify_profile_nickname_error">허용되지 않는 문자가 포함되어 있습니다.</string>
     <string name="modify_profile_done">완료</string>
     <string name="modify_profile_image">프로필 이미지</string>
     <string name="modify_profile_camera">카메라</string>
+    <string name="modify_profile_instagram_id">인스타그램 아이디</string>
+    <string name="modify_profile_instagram_placeholder">인스타그램 아이디를 적어주세요</string>
+    <string name="modify_profile_introduction">자기소개</string>
+    <string name="modify_profile_introduction_placeholder">자기소개를 적어주세요</string>
+    <string name="modify_profile_introduction_counter">%1$d/100</string>
+    <string name="modify_profile_save_unsupported">프로필 저장은 아직 지원되지 않습니다.</string>
 
     <!-- 주문 상세 -->
     <string name="order_detail_title">주문 상세</string>

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
@@ -1,9 +1,17 @@
 package com.hm.picplz.ui.screen.my_page
 
+import android.content.Context
 import com.hm.picplz.common.model.NicknameFieldError
+import com.hm.picplz.domain.model.MemberProfile
+import com.hm.picplz.domain.model.UpdateMemberProfileCommand
+import com.hm.picplz.domain.repository.AuthRepository
 import com.hm.picplz.domain.repository.MemberRepository
+import com.hm.picplz.domain.repository.S3Repository
 import com.hm.picplz.domain.usecase.CheckNicknameAvailabilityUseCase
-import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetMemberProfileUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberProfileUseCase
+import com.hm.picplz.domain.usecase.UploadProfileImageUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -21,7 +29,8 @@ class MyPagePhotographerModifyProfileViewModelTest {
     @Test
     fun `instagram change enables complete when nickname remains valid`() =
         runTest {
-            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase())
+            val viewModel = createViewModel()
+            advanceUntilIdle()
 
             viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId("new_instagram"))
             advanceUntilIdle()
@@ -33,7 +42,8 @@ class MyPagePhotographerModifyProfileViewModelTest {
     fun `nickname whitespace blocks duplicate check and disables complete`() =
         runTest {
             val memberRepository = FakeMemberRepository()
-            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase(memberRepository))
+            val viewModel = createViewModel(memberRepository = memberRepository)
+            advanceUntilIdle()
 
             viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname("ab cd"))
             advanceUntilIdle()
@@ -50,7 +60,8 @@ class MyPagePhotographerModifyProfileViewModelTest {
     fun `duplicate nickname becomes representative error after local validation passes`() =
         runTest {
             val memberRepository = FakeMemberRepository(isAvailable = false)
-            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase(memberRepository))
+            val viewModel = createViewModel(memberRepository = memberRepository)
+            advanceUntilIdle()
 
             viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname("validnickname"))
             advanceUntilIdle()
@@ -63,32 +74,82 @@ class MyPagePhotographerModifyProfileViewModelTest {
         }
 
     @Test
-    fun `save keeps screen open and exposes unsupported-save message`() =
+    fun `save updates original values when request succeeds`() =
         runTest {
-            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase())
+            val memberRepository = FakeMemberRepository()
+            val viewModel = createViewModel(memberRepository = memberRepository)
+            advanceUntilIdle()
 
             viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction("새 소개글"))
             advanceUntilIdle()
             viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save)
+            advanceUntilIdle()
 
             assertEquals(
-                R.string.modify_profile_save_unsupported,
-                viewModel.state.value.saveErrorMessageResId,
+                "새 소개글",
+                memberRepository.updatedCommand?.introduction,
             )
-            assertTrue(viewModel.state.value.hasChanges)
+            assertFalse(viewModel.state.value.hasChanges)
         }
 
-    private fun createUseCase(memberRepository: FakeMemberRepository = FakeMemberRepository()) =
-        CheckNicknameAvailabilityUseCase(memberRepository)
+    private fun createViewModel(
+        memberRepository: FakeMemberRepository = FakeMemberRepository(),
+        memberId: Long = 1L,
+    ): MyPagePhotographerModifyProfileViewModel =
+        MyPagePhotographerModifyProfileViewModel(
+            checkNicknameAvailabilityUseCase = CheckNicknameAvailabilityUseCase(memberRepository),
+            getCurrentMemberIdUseCase = GetCurrentMemberIdUseCase(FakeAuthRepository(memberId)),
+            getMemberProfileUseCase = GetMemberProfileUseCase(memberRepository),
+            updateMemberProfileUseCase = UpdateMemberProfileUseCase(memberRepository),
+            uploadProfileImageUseCase = UploadProfileImageUseCase(FakeS3Repository()),
+        )
 
     private class FakeMemberRepository(
         private val isAvailable: Boolean = true,
     ) : MemberRepository {
         val requestedNicknames = mutableListOf<String>()
+        var updatedCommand: UpdateMemberProfileCommand? = null
 
         override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> {
             requestedNicknames += nickname
             return Result.success(isAvailable)
         }
+
+        override suspend fun getMemberProfile(memberId: Long): Result<MemberProfile> =
+            Result.success(
+                MemberProfile(
+                    id = memberId,
+                    nickname = "유가영",
+                    profileImage = null,
+                    introduction = "안녕하세요, 임두현 사진작가입니다.",
+                    instagram = "imdooring",
+                ),
+            )
+
+        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit> {
+            updatedCommand = command
+            return Result.success(Unit)
+        }
+    }
+
+    private class FakeAuthRepository(
+        private val memberId: Long,
+    ) : AuthRepository {
+        override suspend fun loginWithKakao(context: Context) = error("unused")
+
+        override suspend fun getKakaoUserInfo() = error("unused")
+
+        override suspend fun unlinkKakao() = error("unused")
+
+        override fun isKakaoTalkLoginAvailable(context: Context) = false
+
+        override fun getCurrentMemberId(): Long = memberId
+    }
+
+    private class FakeS3Repository : S3Repository {
+        override suspend fun uploadProfileImage(
+            imageBytes: ByteArray,
+            filename: String,
+        ): Result<String> = Result.success("profile/object-key.jpg")
     }
 }

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
@@ -1,0 +1,94 @@
+package com.hm.picplz.ui.screen.my_page
+
+import com.hm.picplz.common.model.NicknameFieldError
+import com.hm.picplz.domain.repository.MemberRepository
+import com.hm.picplz.domain.usecase.CheckNicknameAvailabilityUseCase
+import com.hm.picplz.feature.mypage.R
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyPagePhotographerModifyProfileViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `instagram change enables complete when nickname remains valid`() =
+        runTest {
+            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase())
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId("new_instagram"))
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.isCompleteEnabled)
+        }
+
+    @Test
+    fun `nickname whitespace blocks duplicate check and disables complete`() =
+        runTest {
+            val memberRepository = FakeMemberRepository()
+            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase(memberRepository))
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname("ab cd"))
+            advanceUntilIdle()
+
+            assertEquals(0, memberRepository.requestedNicknames.size)
+            assertEquals(
+                NicknameFieldError.Whitespace().message,
+                viewModel.state.value.representativeNicknameError?.message,
+            )
+            assertFalse(viewModel.state.value.isCompleteEnabled)
+        }
+
+    @Test
+    fun `duplicate nickname becomes representative error after local validation passes`() =
+        runTest {
+            val memberRepository = FakeMemberRepository(isAvailable = false)
+            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase(memberRepository))
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname("validnickname"))
+            advanceUntilIdle()
+
+            assertEquals(listOf("validnickname"), memberRepository.requestedNicknames)
+            assertEquals(
+                NicknameFieldError.DuplicateNickname().message,
+                viewModel.state.value.representativeNicknameError?.message,
+            )
+        }
+
+    @Test
+    fun `save keeps screen open and exposes unsupported-save message`() =
+        runTest {
+            val viewModel = MyPagePhotographerModifyProfileViewModel(createUseCase())
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction("새 소개글"))
+            advanceUntilIdle()
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save)
+
+            assertEquals(
+                R.string.modify_profile_save_unsupported,
+                viewModel.state.value.saveErrorMessageResId,
+            )
+            assertTrue(viewModel.state.value.hasChanges)
+        }
+
+    private fun createUseCase(memberRepository: FakeMemberRepository = FakeMemberRepository()) =
+        CheckNicknameAvailabilityUseCase(memberRepository)
+
+    private class FakeMemberRepository(
+        private val isAvailable: Boolean = true,
+    ) : MemberRepository {
+        val requestedNicknames = mutableListOf<String>()
+
+        override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> {
+            requestedNicknames += nickname
+            return Result.success(isAvailable)
+        }
+    }
+}

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
@@ -12,7 +12,10 @@ import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
 import com.hm.picplz.domain.usecase.GetMemberProfileUseCase
 import com.hm.picplz.domain.usecase.UpdateMemberProfileUseCase
 import com.hm.picplz.domain.usecase.UploadProfileImageUseCase
+import com.hm.picplz.feature.mypage.R
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -92,6 +95,22 @@ class MyPagePhotographerModifyProfileViewModelTest {
             assertFalse(viewModel.state.value.hasChanges)
         }
 
+    @Test
+    fun `load failure shows toast and does not keep inline save error`() =
+        runTest {
+            val memberRepository = FakeMemberRepository(loadShouldFail = true)
+            val viewModel = createViewModel(memberRepository = memberRepository)
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            advanceUntilIdle()
+
+            assertEquals(null, viewModel.state.value.saveErrorMessageResId)
+            assertEquals(
+                MyPagePhotographerModifyProfileSideEffect.ShowToast(R.string.modify_profile_load_failed),
+                sideEffectDeferred.await(),
+            )
+        }
+
     private fun createViewModel(
         memberRepository: FakeMemberRepository = FakeMemberRepository(),
         memberId: Long = 1L,
@@ -106,6 +125,7 @@ class MyPagePhotographerModifyProfileViewModelTest {
 
     private class FakeMemberRepository(
         private val isAvailable: Boolean = true,
+        private val loadShouldFail: Boolean = false,
     ) : MemberRepository {
         val requestedNicknames = mutableListOf<String>()
         var updatedCommand: UpdateMemberProfileCommand? = null
@@ -116,15 +136,19 @@ class MyPagePhotographerModifyProfileViewModelTest {
         }
 
         override suspend fun getMemberProfile(memberId: Long): Result<MemberProfile> =
-            Result.success(
-                MemberProfile(
-                    id = memberId,
-                    nickname = "유가영",
-                    profileImage = null,
-                    introduction = "안녕하세요, 임두현 사진작가입니다.",
-                    instagram = "imdooring",
-                ),
-            )
+            if (loadShouldFail) {
+                Result.failure(IllegalStateException("load failed"))
+            } else {
+                Result.success(
+                    MemberProfile(
+                        id = memberId,
+                        nickname = "유가영",
+                        profileImage = null,
+                        introduction = "안녕하세요, 임두현 사진작가입니다.",
+                        instagram = "imdooring",
+                    ),
+                )
+            }
 
         override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit> {
             updatedCommand = command

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
@@ -28,4 +28,19 @@ class MyPageViewModelTest {
                 sideEffectDeferred.await(),
             )
         }
+
+    @Test
+    fun `navigate to photographer modify profile emits dedicated navigation side effect`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToPhotographerModifyProfile)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPageSideEffect.NavigateToPhotographerModifyProfile,
+                sideEffectDeferred.await(),
+            )
+        }
 }


### PR DESCRIPTION
## Summary
- 공용 마이페이지 수정 화면과 분리된 작가 전용 프로필 수정 플로우를 추가했습니다.
- 작가 프로필 수정 화면을 회원 정보 조회/수정 API와 S3 이미지 업로드에 연결했습니다.
- DEV MENU에서 작가 프로필 수정 화면으로 바로 진입할 수 있게 하고, 입력/카운터/하단 CTA UI를 실기기 기준으로 다듬었습니다.

## Changes

### navigation
- `RouteModels.kt`
  - `MyPagePhotographerModifyProfile` route 추가
- `MainNavGraph.kt`
  - 작가 전용 프로필 수정 화면 destination 연결
- `MyPageScreen.kt` / `MyPageViewModel.kt` / `MyPageIntent.kt` / `MyPageSideEffect.kt`
  - 작가 모드 프로필 수정 진입을 전용 route로 분기

### feature/mypage
- `MyPagePhotographerModifyProfileScreen.kt`
  - 작가 전용 프로필 수정 화면 UI 추가
  - 프로필 이미지, 닉네임, 인스타그램, 자기소개 입력 UI 구성
  - 키보드 대응, intro counter, 하단 CTA 구조를 실기기 기준으로 조정
- `MyPagePhotographerModifyProfileViewModel.kt`
  - member profile load/save, nickname duplicate check, profile image upload 흐름 연결
- `MyPagePhotographerModifyProfileState.kt` / `...Intent.kt` / `...SideEffect.kt`
  - 전용 MVI 구조 추가
- `strings.xml`
  - 작가 프로필 수정 관련 문구 추가
- `MyPagePhotographerModifyProfileViewModelTest.kt`
  - load/save/nickname/image 관련 단위 테스트 추가

### core/domain
- `MemberProfile.kt`
  - member profile domain model 및 update command 추가
- `MemberRepository.kt` / `S3Repository.kt`
  - member profile 조회/수정 및 image upload contract 추가
- `GetCurrentMemberIdUseCase.kt`
  - 현재 로그인 member id 조회 usecase 추가
- `GetMemberProfileUseCase.kt` / `UpdateMemberProfileUseCase.kt`
  - member profile 조회/수정 usecase 추가
- `UploadProfileImageUseCase.kt`
  - 프로필 이미지 업로드 usecase 추가
- `CheckNicknameAvailabilityUseCase.kt`
  - feature가 공용 닉네임 중복 검사를 domain 경유로 사용하도록 정리

### core/data + app/di
- `MemberApi.kt` / `MemberSource.kt` / `MemberService.kt` / `MemberRepositoryImpl.kt`
  - `GET /members/{memberId}/info`, `PATCH /members/info` 연동 추가
- `MemberModel.kt`
  - member info request/response DTO 및 mapper 추가
- `S3RepositoryImpl.kt` / `S3Module.kt`
  - S3 upload domain binding 추가
- `TokenManager.kt` / `AuthRepositoryImpl.kt` / `AuthRepository.kt`
  - JWT `sub` 기준 현재 member id 조회 경로 추가
- `MemberModule.kt`
  - `MemberRepository` binding 추가

### feature/main
- `DevScreen.kt`
  - `MyPagePhotographerModifyProfile` direct entry 버튼 추가

### core/common
- `NicknameFieldError.kt` / `NicknameValidator.kt`
  - 닉네임 검증 메시지와 whitespace 처리 정리

## 화면

<img width="400" height="867" alt="KakaoTalk_Video_2026-04-19-20-06-12 (1)" src="https://github.com/user-attachments/assets/80841ac2-4cf7-4619-b54c-4391a762518b" />


## Known Limitations
- 현재 dev token 기준으로 `GET /members/{memberId}/info`가 401을 반환하는 경우가 있어, 초기 프로필 로드는 환경에 따라 실패할 수 있습니다.
- 프로필 저장/업로드 API 코드는 연결되어 있지만, 실제 QA 관점에서는 아직 안정적으로 동작한다고 보기 어려워 이번 PR에서는 UI 확인 중심으로 리뷰 부탁드립니다.

## Reviewer Scenarios

### 1. DEV 진입 확인
- DEV MENU → `MyPagePhotographerModifyProfile`
- 확인 포인트
  - 작가 전용 프로필 수정 화면으로 바로 진입되는지
  - 공용 `MyPageModifyProfile`이 아니라 전용 route로 여는지

### 2. 초기 로드 UI 확인
- 화면 첫 진입
- 확인 포인트
  - load 성공 시 닉네임 / 인스타 / 자기소개 / 프로필 이미지가 채워지는지
  - load 실패 시 화면이 깨지지 않고 toast만 노출되는지

### 3. 닉네임 검증 UI
- 닉네임 입력 변경
- 확인 포인트
  - 공백 입력 시 즉시 whitespace 에러가 뜨는지
  - 형식 오류가 중복 검사보다 먼저 보이는지
  - 유효한 닉네임 입력 시 중복 검사 결과가 반영되는지

### 4. 프로필 이미지 선택 UI
- 프로필 이미지 탭 → 갤러리에서 이미지 선택
- 확인 포인트
  - 선택 즉시 미리보기 반영되는지
  - 업로드 실패 시 오류 메시지가 보이는지

### 5. 자기소개 입력 UI
- 소개 필드에 100자 넘는 텍스트 입력/붙여넣기
- 확인 포인트
  - 100자를 넘기면 앞 100자만 유지되는지
  - `0/100` 카운터가 필드 안 우하단에 보이는지
  - 카운터 아래 footer spacing이 실제로 보이는지

### 6. 하단 CTA UI
- 키보드 열림 상태에서 소개 필드 편집
- 확인 포인트
  - 완료 버튼이 floating FAB처럼 뜨지 않고 하단 CTA 영역째로 올라오는지
  - CTA가 textarea 중간에 걸쳐 보이지 않는지
  - 버튼 크기/위치/하단 여백이 자연스러운지

## Verification
- `./gradlew ktlintCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :feature:mypage:testDebugUnitTest`
- `./gradlew installDebug`

Closes #156
