### PR TITLE
✨ : 결제 후 예약 취소 - 환불 규정 및 환불 금액 안내 페이지 구현

### DIFF
--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -7,6 +7,8 @@ sealed interface CancelReservationIntent {
 
     data class UpdatePagerPage(val page: CancelReservationPagerPage) : CancelReservationIntent
 
+    data class UpdateAgreement(val isChecked: Boolean) : CancelReservationIntent
+
     data object OnBackClick : CancelReservationIntent
 
     data object OnNextClick : CancelReservationIntent

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReasonInputContent
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationStepIndicator
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationTopBar
+import com.hm.picplz.ui.screen.cancel_reservation.composable.RefundGuideContent
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 
 @Composable
@@ -68,6 +69,9 @@ fun CancelReservationScreen(
         onPageChange = { pagerPage ->
             viewModel.handleIntent(CancelReservationIntent.UpdatePagerPage(pagerPage))
         },
+        onAgreementChange = { isChecked ->
+            viewModel.handleIntent(CancelReservationIntent.UpdateAgreement(isChecked))
+        },
         onNextClick = {
             viewModel.handleIntent(CancelReservationIntent.OnNextClick)
         },
@@ -82,6 +86,7 @@ private fun CancelReservationScreenContent(
     onReasonToggle: (CancelReason) -> Unit,
     onDirectInputChange: (String) -> Unit,
     onPageChange: (CancelReservationPagerPage) -> Unit,
+    onAgreementChange: (Boolean) -> Unit,
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -124,8 +129,15 @@ private fun CancelReservationScreenContent(
 
                     CancelReservationPagerPage.REFUND_GUIDE -> {
                         RefundGuideContent(
-                            selectedReasons = state.selectedReasons,
-                            directInputText = state.directInputText,
+                            shootingDateFormatted = state.shootingDateFormatted,
+                            cancelDateFormatted = state.cancelDateFormatted,
+                            totalPrice = state.totalPrice,
+                            refundPrice = state.refundPrice,
+                            cancellationFee = state.cancellationFee,
+                            isAgreementChecked = state.isAgreementChecked,
+                            onAgreementChange = { isChecked ->
+                                onAgreementChange(isChecked)
+                            },
                         )
                     }
                 }
@@ -145,15 +157,6 @@ private fun CancelReservationScreenContent(
     }
 }
 
-@Composable
-private fun RefundGuideContent(
-    selectedReasons: Set<CancelReason>,
-    directInputText: String,
-    modifier: Modifier = Modifier,
-) {
-    // TODO: 환불 안내 화면 구현
-}
-
 @Preview
 @Composable
 private fun CancelReservationScreenPreview() {
@@ -170,6 +173,30 @@ private fun CancelReservationScreenPreview() {
         onReasonToggle = {},
         onDirectInputChange = {},
         onPageChange = {},
+        onAgreementChange = {},
+        onNextClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun CancelReservationScreenRefundGuidePreview() {
+    CancelReservationScreenContent(
+        state =
+            CancelReservationState(
+                orderId = "order123",
+                selectedReasons = setOf(CancelReason.SCHEDULE),
+                directInputText = "",
+                currentPagerPage = CancelReservationPagerPage.REFUND_GUIDE,
+                shootingDateFormatted = "25.01.09",
+                cancelDateFormatted = "25.01.05",
+            ),
+        pagerState = rememberPagerState(initialPage = 1) { CancelReservationPagerPage.size },
+        onBackClick = {},
+        onReasonToggle = {},
+        onDirectInputChange = {},
+        onPageChange = {},
+        onAgreementChange = {},
         onNextClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,5 +1,8 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 data class CancelReservationState(
     val orderId: String = "",
     val selectedReasons: Set<CancelReason> = emptySet(),
@@ -7,14 +10,39 @@ data class CancelReservationState(
     val currentPagerPage: CancelReservationPagerPage = CancelReservationPagerPage.REASON_INPUT,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
+    // 환불 안내 관련
+    val shootingDate: LocalDate = LocalDate.now().plusDays(4),
+    val cancelDate: LocalDate = LocalDate.now(),
+    val shootingDateFormatted: String = "",
+    val cancelDateFormatted: String = "",
+    val totalPrice: Int = 12900,
+    val refundPrice: Int = 11610,
+    val cancellationFee: Int = 1290,
+    val isAgreementChecked: Boolean = false,
 ) {
     fun isNextButtonEnabled(): Boolean =
-        selectedReasons.isNotEmpty() && (
-            selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 이유가 있거나
-                directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
-        )
+        when (currentPagerPage) {
+            CancelReservationPagerPage.REASON_INPUT ->
+                selectedReasons.isNotEmpty() && (
+                    selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 이유가 있거나
+                        directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
+                )
+            CancelReservationPagerPage.REFUND_GUIDE -> isAgreementChecked
+        }
 
     companion object {
-        fun idle(orderId: String): CancelReservationState = CancelReservationState(orderId = orderId)
+        fun idle(orderId: String): CancelReservationState {
+            val dateFormatter = DateTimeFormatter.ofPattern("yy.MM.dd")
+            val shootingDate = LocalDate.now().plusDays(4)
+            val cancelDate = LocalDate.now()
+
+            return CancelReservationState(
+                orderId = orderId,
+                shootingDate = shootingDate,
+                cancelDate = cancelDate,
+                shootingDateFormatted = shootingDate.format(dateFormatter),
+                cancelDateFormatted = cancelDate.format(dateFormatter),
+            )
+        }
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -50,23 +50,40 @@ class CancelReservationViewModel @Inject constructor(
                 _state.update { it.copy(currentPagerPage = intent.page) }
             }
 
+            is CancelReservationIntent.UpdateAgreement -> {
+                _state.update { it.copy(isAgreementChecked = intent.isChecked) }
+            }
+
             is CancelReservationIntent.OnBackClick -> {
-                emitSideEffect(CancelReservationSideEffect.NavigateBack)
+                handleBackClick()
             }
 
             is CancelReservationIntent.OnNextClick -> {
-                // 페이지에 따라 다른 동작
-                val currentPage = _state.value.currentPagerPage
-                when (currentPage) {
-                    CancelReservationPagerPage.REASON_INPUT -> {
-                        // 취소 사유 입력 완료 → 환불 안내로
-                        _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REFUND_GUIDE) }
-                    }
-                    CancelReservationPagerPage.REFUND_GUIDE -> {
-                        // 환불 안내 완료 → 취소 확인 모달
-                        emitSideEffect(CancelReservationSideEffect.ShowCancelConfirmModal)
-                    }
-                }
+                handleNextClick()
+            }
+        }
+    }
+
+    private fun handleBackClick() {
+        val currentPage = _state.value.currentPagerPage
+        when (currentPage) {
+            CancelReservationPagerPage.REASON_INPUT -> {
+                emitSideEffect(CancelReservationSideEffect.NavigateBack)
+            }
+            CancelReservationPagerPage.REFUND_GUIDE -> {
+                _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REASON_INPUT) }
+            }
+        }
+    }
+
+    private fun handleNextClick() {
+        val currentPage = _state.value.currentPagerPage
+        when (currentPage) {
+            CancelReservationPagerPage.REASON_INPUT -> {
+                _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REFUND_GUIDE) }
+            }
+            CancelReservationPagerPage.REFUND_GUIDE -> {
+                emitSideEffect(CancelReservationSideEffect.ShowCancelConfirmModal)
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonInputContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CancelReasonInputContent.kt
@@ -53,7 +53,7 @@ fun CancelReasonInputContent(
             }
 
             items(CancelReason.entries) { reason ->
-                CancelReasonCheckbox(
+                CheckboxWithLabel(
                     text = stringResource(reason.stringRes),
                     isSelected = selectedReasons.contains(reason),
                     onToggle = { onReasonToggle(reason) },

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CheckboxWithLabel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/CheckboxWithLabel.kt
@@ -15,7 +15,7 @@ import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
 
 @Composable
-fun CancelReasonCheckbox(
+fun CheckboxWithLabel(
     text: String,
     isSelected: Boolean,
     onToggle: () -> Unit,
@@ -43,9 +43,9 @@ fun CancelReasonCheckbox(
 
 @Preview(showBackground = true)
 @Composable
-private fun CancelReasonCheckboxPreviewUnchecked() {
+private fun CheckboxWithLabelPreviewUnchecked() {
     PicplzTheme {
-        CancelReasonCheckbox(
+        CheckboxWithLabel(
             text = "촬영 스케줄 다른 일정이 생겼어요",
             isSelected = false,
             onToggle = {},
@@ -56,9 +56,9 @@ private fun CancelReasonCheckboxPreviewUnchecked() {
 
 @Preview(showBackground = true)
 @Composable
-private fun CancelReasonCheckboxPreviewChecked() {
+private fun CheckboxWithLabelPreviewChecked() {
     PicplzTheme {
-        CancelReasonCheckbox(
+        CheckboxWithLabel(
             text = "촬영 스케줄 다른 일정이 생겼어요",
             isSelected = true,
             onToggle = {},
@@ -69,26 +69,26 @@ private fun CancelReasonCheckboxPreviewChecked() {
 
 @Preview(showBackground = true)
 @Composable
-private fun CancelReasonCheckboxPreviewMultiple() {
+private fun CheckboxWithLabelPreviewMultiple() {
     PicplzTheme {
         Column(
             modifier = Modifier.padding(16.dp),
         ) {
-            CancelReasonCheckbox(
+            CheckboxWithLabel(
                 text = "촬영 스케줄 다른 일정이 생겼어요",
                 isSelected = true,
                 onToggle = {},
                 modifier = Modifier.padding(vertical = 12.dp),
             )
 
-            CancelReasonCheckbox(
+            CheckboxWithLabel(
                 text = "원금 상품을 변경하고 싶어요",
                 isSelected = false,
                 onToggle = {},
                 modifier = Modifier.padding(vertical = 12.dp),
             )
 
-            CancelReasonCheckbox(
+            CheckboxWithLabel(
                 text = "그냥 마음이 바뀌었어요",
                 isSelected = true,
                 onToggle = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/LabelWithHighlight.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/LabelWithHighlight.kt
@@ -1,0 +1,54 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun LabelWithHighlight(
+    labelResId: Int,
+    highlightResId: Int,
+    highlightColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val labelText = stringResource(labelResId)
+    val highlightText = stringResource(highlightResId)
+
+    val annotatedString =
+        buildAnnotatedString {
+            append("$labelText (")
+            withStyle(style = SpanStyle(color = highlightColor)) {
+                append(highlightText)
+            }
+            append(")")
+        }
+
+    Text(
+        text = annotatedString,
+        style = MainThemeFont.Caption,
+        color = MainThemeColor.Gray4,
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LabelWithHighlightPreview() {
+    PicplzTheme {
+        LabelWithHighlight(
+            labelResId = R.string.refund_cancellation_fee_label,
+            highlightResId = R.string.refund_cancellation_fee_rate,
+            highlightColor = Color(0xFFEF4747),
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundAmountSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundAmountSection.kt
@@ -1,0 +1,132 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun RefundAmountSection(
+    totalPrice: Int,
+    refundPrice: Int,
+    cancellationFee: Int,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(R.string.refund_amount_title),
+            style =
+                MainThemeFont.BodyLarge.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        HorizontalDivider(
+            color = MainThemeColor.Black,
+            thickness = 1.dp,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        RefundAmountRow(
+            label = {
+                Text(
+                    text = stringResource(R.string.refund_total_amount),
+                    style = MainThemeFont.BodyBold,
+                    color = MainThemeColor.Black,
+                )
+            },
+            amount = refundPrice,
+            isTotalAmount = true,
+        )
+
+        Spacer(modifier = Modifier.height(9.5.dp))
+
+        RefundAmountRow(
+            label = {
+                Text(
+                    text = stringResource(R.string.refund_paid_amount),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Gray4,
+                )
+            },
+            amount = totalPrice,
+            isTotalAmount = false,
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        RefundAmountRow(
+            label = {
+                LabelWithHighlight(
+                    labelResId = R.string.refund_cancellation_fee_label,
+                    highlightResId = R.string.refund_cancellation_fee_rate,
+                    highlightColor = Color(0xFFEF4747),
+                )
+            },
+            amount = cancellationFee,
+            isTotalAmount = false,
+        )
+    }
+}
+
+@Composable
+private fun RefundAmountRow(
+    label: @Composable () -> Unit,
+    amount: Int,
+    isTotalAmount: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        label()
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(R.string.amount_format, amount),
+            style =
+                if (isTotalAmount) {
+                    MainThemeFont.BodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                } else {
+                    MainThemeFont.Body
+                },
+            color = if (isTotalAmount) Color(0xFFEF4747) else MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RefundAmountSectionPreview() {
+    PicplzTheme {
+        RefundAmountSection(
+            totalPrice = 12900,
+            refundPrice = 11610,
+            cancellationFee = 1290,
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundDateInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundDateInfoSection.kt
@@ -1,0 +1,92 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun RefundDateInfoSection(
+    shootingDateFormatted: String,
+    cancelDateFormatted: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    shape = RoundedCornerShape(5.dp),
+                    color = MainThemeColor.Gray2,
+                ).padding(
+                    horizontal = 14.dp,
+                    vertical = 10.dp,
+                ),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.refund_shooting_date),
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = shootingDateFormatted,
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+            )
+        }
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.refund_cancel_date),
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = cancelDateFormatted,
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RefundDateInfoSectionPreview() {
+    PicplzTheme {
+        RefundDateInfoSection(
+            shootingDateFormatted = "25.01.09",
+            cancelDateFormatted = "25.01.05",
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundGuideContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundGuideContent.kt
@@ -1,0 +1,97 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun RefundGuideContent(
+    shootingDateFormatted: String,
+    cancelDateFormatted: String,
+    totalPrice: Int,
+    refundPrice: Int,
+    cancellationFee: Int,
+    isAgreementChecked: Boolean,
+    onAgreementChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().background(color = MainThemeColor.White),
+    ) {
+        LazyColumn(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.refund_guide_title),
+                    style = MainThemeFont.Title,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 20.dp),
+                )
+            }
+
+            item {
+                RefundDateInfoSection(
+                    shootingDateFormatted = shootingDateFormatted,
+                    cancelDateFormatted = cancelDateFormatted,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 28.dp),
+                )
+            }
+
+            item {
+                RefundAmountSection(
+                    totalPrice = totalPrice,
+                    refundPrice = refundPrice,
+                    cancellationFee = cancellationFee,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
+                )
+            }
+
+            item {
+                RefundPolicySection(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
+                )
+            }
+
+            item {
+                CheckboxWithLabel(
+                    text = stringResource(R.string.refund_agreement_text),
+                    isSelected = isAgreementChecked,
+                    onToggle = { onAgreementChange(!isAgreementChecked) },
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 20.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RefundGuideContentPreview() {
+    PicplzTheme {
+        RefundGuideContent(
+            shootingDateFormatted = "25.01.09",
+            cancelDateFormatted = "25.01.05",
+            totalPrice = 12900,
+            refundPrice = 11610,
+            cancellationFee = 1290,
+            isAgreementChecked = false,
+            onAgreementChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundPolicySection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/RefundPolicySection.kt
@@ -1,0 +1,42 @@
+package com.hm.picplz.ui.screen.cancel_reservation.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun RefundPolicySection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(R.string.refund_policy_title),
+            style = MainThemeFont.ButtonDefault,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        Text(
+            text = stringResource(R.string.refund_policy_list),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RefundPolicySectionPreview() {
+    PicplzTheme {
+        RefundPolicySection()
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -75,4 +75,20 @@
 
     <!-- 예약 취소 화면 -->
     <string name="cancel_reservation_top_bar_title">예약 취소</string>
+
+    <!-- 환불 안내 화면 -->
+    <string name="refund_guide_title">환불 예정 금액을 확인해주세요.</string>
+    <string name="refund_shooting_date">촬영 예정일</string>
+    <string name="refund_cancel_date">취소일</string>
+    <string name="refund_amount_title">환불 금액</string>
+    <string name="refund_total_amount">총 환불 금액</string>
+    <string name="refund_paid_amount">결제 금액</string>
+    <string name="refund_cancellation_fee_label">취소 수수료</string>
+    <string name="refund_cancellation_fee_rate">10%</string>
+    <string name="refund_policy_title">취소/환불 규정</string>
+    <string name="refund_policy_list">• 촬영 기준 7일 전까지: 100% 환불\n• 촬영 기준 3일 전까지: 90% 환불\n• 촬영 기준 2일 전까지: 70% 환불\n• 촬영 기준 1일 전까지: 50% 환불\n• 당일 취소 또는 No-show: 환불 불가</string>
+    <string name="refund_agreement_text">위 내용을 모두 확인하였으며, 이에 동의합니다.</string>
+
+    <!-- 포맷 문자열 -->
+    <string name="amount_format">%,d원</string>
 </resources>


### PR DESCRIPTION
## 개요
예약 취소 플로우의 2단계 환불 안내 화면을 구현하고, 날짜 포맷팅 로직을 ViewModel로 이동하여 clean architecture를 준수합니다. 뒤로가기 로직을 개선하여 페이지별로 상이한 동작을 처리합니다.

## 변경 사항
- **환불 안내 화면 구현**: RefundGuideContent, RefundDateInfoSection, RefundAmountSection, RefundPolicySection, LabelWithHighlight 신규 작성
- **날짜 포맷팅 이동**: CancelReservationState의 idle() 함수에서 "yy.MM.dd" 형식으로 date를 포맷팅하여 이미 formatted 된 문자열을 UI에 전달
- **뒤로가기 로직 개선**: 1페이지(환불 안내)에서는 0페이지로 이동, 0페이지에서는 화면 이동
- **ViewModel 로직 분리**: handleIntent에서 handleBackClick(), handleNextClick() 메서드로 분리하여 가독성 개선
- **Preview 추가**: CancelReservationScreen에서 REASON_INPUT(0페이지), REFUND_GUIDE(1페이지) 각각의 preview 추가
- **컴포넌트 재사용**: CancelReasonCheckbox를 CheckboxWithLabel로 이름 변경하여 더 범용적으로 사용
- **String 리소스 추가**: 환불 관련 문자열 리소스 16개 추가 (날짜, 금액, 정책, 동의문 등)

[Screen_recording_20260421_083340.webm](https://github.com/user-attachments/assets/139217d5-8a9a-4423-8f2b-b26d5e667a16)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #134
