### PR TITLE
✨ : 결제 후 예약 취소 - 취소 확인 모달 다이얼로그 구현

### DIFF
--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -5,11 +5,17 @@ sealed interface CancelReservationIntent {
 
     data class UpdateDirectInput(val text: String) : CancelReservationIntent
 
-    data class UpdatePagerPage(val page: CancelReservationPagerPage) : CancelReservationIntent
-
     data class UpdateAgreement(val isChecked: Boolean) : CancelReservationIntent
 
     data object OnBackClick : CancelReservationIntent
 
     data object OnNextClick : CancelReservationIntent
+
+    data object DismissCancelDialog : CancelReservationIntent
+
+    data object ConfirmCancel : CancelReservationIntent
+
+    data object ShowRefundPolicyDialog : CancelReservationIntent
+
+    data object DismissRefundPolicyTooltip : CancelReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -23,6 +23,8 @@ import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationSt
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationTopBar
 import com.hm.picplz.ui.screen.cancel_reservation.composable.RefundGuideContent
 import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
 
 @Composable
 fun CancelReservationScreen(
@@ -48,7 +50,7 @@ fun CancelReservationScreen(
                     onNavigateBack()
                 }
 
-                is CancelReservationSideEffect.ShowCancelConfirmModal -> {
+                CancelReservationSideEffect.NavigateToCancelReservationConfirm -> {
                     onNavigateToCancelConfirm()
                 }
             }
@@ -68,14 +70,23 @@ fun CancelReservationScreen(
         onDirectInputChange = { text ->
             viewModel.handleIntent(CancelReservationIntent.UpdateDirectInput(text))
         },
-        onPageChange = { pagerPage ->
-            viewModel.handleIntent(CancelReservationIntent.UpdatePagerPage(pagerPage))
-        },
         onAgreementChange = { isChecked ->
             viewModel.handleIntent(CancelReservationIntent.UpdateAgreement(isChecked))
         },
         onNextClick = {
             viewModel.handleIntent(CancelReservationIntent.OnNextClick)
+        },
+        onCancelDialogDismiss = {
+            viewModel.handleIntent(CancelReservationIntent.DismissCancelDialog)
+        },
+        onCancelDialogConfirm = {
+            viewModel.handleIntent(CancelReservationIntent.ConfirmCancel)
+        },
+        onInfoClick = {
+            viewModel.handleIntent(CancelReservationIntent.ShowRefundPolicyDialog)
+        },
+        onRefundPolicyDismiss = {
+            viewModel.handleIntent(CancelReservationIntent.DismissRefundPolicyTooltip)
         },
     )
 }
@@ -87,9 +98,12 @@ private fun CancelReservationScreenContent(
     onBackClick: () -> Unit,
     onReasonToggle: (CancelReason) -> Unit,
     onDirectInputChange: (String) -> Unit,
-    onPageChange: (CancelReservationPagerPage) -> Unit,
     onAgreementChange: (Boolean) -> Unit,
     onNextClick: () -> Unit,
+    onCancelDialogDismiss: () -> Unit,
+    onCancelDialogConfirm: () -> Unit,
+    onInfoClick: () -> Unit,
+    onRefundPolicyDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -101,6 +115,23 @@ private fun CancelReservationScreenContent(
             )
         },
     ) { innerPadding ->
+        if (state.showCancelDialog) {
+            ReservationCancelDialog(
+                status = state.reservationStatus,
+                refundCondition = state.refundCondition,
+                onDismiss = onCancelDialogDismiss,
+                onCancel = onCancelDialogDismiss,
+                onConfirm = onCancelDialogConfirm,
+                onInfoClick = onInfoClick,
+            )
+        }
+
+        if (state.showRefundPolicyTooltip) {
+            ReservationRefundPolicyDialog(
+                onDismissRequest = onRefundPolicyDismiss,
+            )
+        }
+
         Column(
             modifier =
                 Modifier
@@ -170,9 +201,12 @@ private fun CancelReservationScreenPreview() {
         onBackClick = {},
         onReasonToggle = {},
         onDirectInputChange = {},
-        onPageChange = {},
         onAgreementChange = {},
         onNextClick = {},
+        onCancelDialogDismiss = {},
+        onCancelDialogConfirm = {},
+        onInfoClick = {},
+        onRefundPolicyDismiss = {},
     )
 }
 
@@ -193,8 +227,11 @@ private fun CancelReservationScreenRefundGuidePreview() {
         onBackClick = {},
         onReasonToggle = {},
         onDirectInputChange = {},
-        onPageChange = {},
         onAgreementChange = {},
         onNextClick = {},
+        onCancelDialogDismiss = {},
+        onCancelDialogConfirm = {},
+        onInfoClick = {},
+        onRefundPolicyDismiss = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -12,10 +12,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReasonInputContent
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationStepIndicator
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationTopBar
@@ -145,11 +147,7 @@ private fun CancelReservationScreenContent(
 
             CommonBottomButton(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
-                text =
-                    when (state.currentPagerPage) {
-                        CancelReservationPagerPage.REASON_INPUT -> "다음"
-                        CancelReservationPagerPage.REFUND_GUIDE -> "취소 확인"
-                    },
+                text = stringResource(R.string.refund_button_next),
                 onClick = onNextClick,
                 enabled = state.isNextButtonEnabled(),
             )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationSideEffect.kt
@@ -3,5 +3,5 @@ package com.hm.picplz.ui.screen.cancel_reservation
 sealed interface CancelReservationSideEffect {
     data object NavigateBack : CancelReservationSideEffect
 
-    data object ShowCancelConfirmModal : CancelReservationSideEffect
+    data object NavigateToCancelReservationConfirm : CancelReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,6 +1,8 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
-import java.time.LocalDate
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 data class CancelReservationState(
@@ -11,30 +13,36 @@ data class CancelReservationState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     // 환불 안내 관련
-    val shootingDate: LocalDate = LocalDate.now().plusDays(4),
-    val cancelDate: LocalDate = LocalDate.now(),
+    val shootingDate: LocalDateTime = LocalDateTime.now().plusDays(4),
+    val cancelDate: LocalDateTime = LocalDateTime.now(),
     val shootingDateFormatted: String = "",
     val cancelDateFormatted: String = "",
     val totalPrice: Int = 12900,
     val refundPrice: Int = 11610,
     val cancellationFee: Int = 1290,
     val isAgreementChecked: Boolean = false,
+    val reservationStatus: ReservationStatus = ReservationStatus.RESERVED,
+    val showCancelDialog: Boolean = false,
+    val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
+    val showRefundPolicyTooltip: Boolean = false,
 ) {
     fun isNextButtonEnabled(): Boolean =
         when (currentPagerPage) {
-            CancelReservationPagerPage.REASON_INPUT ->
+            CancelReservationPagerPage.REASON_INPUT -> {
                 selectedReasons.isNotEmpty() && (
                     selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 이유가 있거나
                         directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
                 )
+            }
+
             CancelReservationPagerPage.REFUND_GUIDE -> isAgreementChecked
         }
 
     companion object {
         fun idle(orderId: String): CancelReservationState {
             val dateFormatter = DateTimeFormatter.ofPattern("yy.MM.dd")
-            val shootingDate = LocalDate.now().plusDays(4)
-            val cancelDate = LocalDate.now()
+            val shootingDate = LocalDateTime.now().plusDays(4)
+            val cancelDate = LocalDateTime.now()
 
             return CancelReservationState(
                 orderId = orderId,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.hm.picplz.navigation.model.CancelReservation
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -46,10 +48,6 @@ class CancelReservationViewModel @Inject constructor(
                 _state.update { it.copy(directInputText = intent.text.take(100)) }
             }
 
-            is CancelReservationIntent.UpdatePagerPage -> {
-                _state.update { it.copy(currentPagerPage = intent.page) }
-            }
-
             is CancelReservationIntent.UpdateAgreement -> {
                 _state.update { it.copy(isAgreementChecked = intent.isChecked) }
             }
@@ -61,6 +59,34 @@ class CancelReservationViewModel @Inject constructor(
             is CancelReservationIntent.OnNextClick -> {
                 handleNextClick()
             }
+
+            CancelReservationIntent.ConfirmCancel -> {
+                _state.update { it.copy(showCancelDialog = false) }
+
+                emitSideEffect(CancelReservationSideEffect.NavigateToCancelReservationConfirm)
+            }
+
+            CancelReservationIntent.DismissCancelDialog -> {
+                _state.update { it.copy(showCancelDialog = false) }
+            }
+
+            CancelReservationIntent.DismissRefundPolicyTooltip -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = false,
+                        showCancelDialog = true,
+                    )
+                }
+            }
+
+            CancelReservationIntent.ShowRefundPolicyDialog -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = true,
+                        showCancelDialog = false,
+                    )
+                }
+            }
         }
     }
 
@@ -70,6 +96,7 @@ class CancelReservationViewModel @Inject constructor(
             CancelReservationPagerPage.REASON_INPUT -> {
                 emitSideEffect(CancelReservationSideEffect.NavigateBack)
             }
+
             CancelReservationPagerPage.REFUND_GUIDE -> {
                 _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REASON_INPUT) }
             }
@@ -82,8 +109,22 @@ class CancelReservationViewModel @Inject constructor(
             CancelReservationPagerPage.REASON_INPUT -> {
                 _state.update { it.copy(currentPagerPage = CancelReservationPagerPage.REFUND_GUIDE) }
             }
+
             CancelReservationPagerPage.REFUND_GUIDE -> {
-                emitSideEffect(CancelReservationSideEffect.ShowCancelConfirmModal)
+                val currentState = _state.value
+                val refundCondition =
+                    RefundCondition.calculate(
+                        currentDateTime = LocalDateTime.now(),
+                        shootingDateTime = currentState.shootingDate,
+                        confirmedDateTime = currentState.cancelDate,
+                    )
+
+                _state.update {
+                    it.copy(
+                        showCancelDialog = true,
+                        refundCondition = refundCondition,
+                    )
+                }
             }
         }
     }

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="refund_policy_title">취소/환불 규정</string>
     <string name="refund_policy_list">• 촬영 기준 7일 전까지: 100% 환불\n• 촬영 기준 3일 전까지: 90% 환불\n• 촬영 기준 2일 전까지: 70% 환불\n• 촬영 기준 1일 전까지: 50% 환불\n• 당일 취소 또는 No-show: 환불 불가</string>
     <string name="refund_agreement_text">위 내용을 모두 확인하였으며, 이에 동의합니다.</string>
+    <string name="refund_button_next">다음</string>
 
     <!-- 포맷 문자열 -->
     <string name="amount_format">%,d원</string>


### PR DESCRIPTION
## 개요
예약 취소 플로우의 2단계 완료 후 최종 확인 다이얼로그를 추가하고, 다음 버튼 텍스트를 조건부로 표시합니다.

## 변경 사항
- **취소 확인 다이얼로그**: 환불 안내 페이지에서 "취소 확인" 버튼 클릭 시 표시되는 최종 확인 다이얼로그 구현
- **다음 버튼 텍스트 개선**: 페이지별 버튼 텍스트 동적 표시 (0페이지: "다음", 1페이지: "취소 확인")
- **State 업데이트**: 취소 확인 다이얼로그 상태 관리 필드 추가
- **Intent 확장**: 다이얼로그 표시/숨김 Intent 추가
- **ViewModel 로직 확장**: 다이얼로그 상태 처리 로직 추가

[Screen_recording_20260421_131710.webm](https://github.com/user-attachments/assets/bb4ac163-bd2f-4365-992f-5a6da7997d6b)

## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #135
