### PR TITLE
✨ : 결제 후 예약 취소 - 취소 완료 화면 구현 [Reapply]

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.hm.picplz.common.model.CancelConfirmType
 import com.hm.picplz.navigation.model.CancelReservation
 import com.hm.picplz.navigation.model.CancelReservationConfirm
 import com.hm.picplz.navigation.model.Chat
@@ -96,7 +97,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 navController.popBackStack()
             },
             onNavigateCancelReservationConfirm = {
-                navController.navigate(CancelReservationConfirm)
+                navController.navigate(CancelReservationConfirm(cancelType = CancelConfirmType.WITHOUT_REFUND))
             },
             onNavigateToOrderDetail = { orderId ->
                 navController.navigate(OrderDetail(orderId = orderId))
@@ -135,7 +136,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 navController.popBackStack()
             },
             onNavigateToCancelConfirm = {
-                navController.navigate(CancelReservationConfirm)
+                navController.navigate(CancelReservationConfirm(cancelType = CancelConfirmType.WITH_REFUND))
             },
         )
     }

--- a/core/common/src/main/kotlin/com/hm/picplz/common/model/CancelConfirmType.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/model/CancelConfirmType.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.common.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CancelConfirmType {
+    WITH_REFUND, // 결제 이후 예약 취소 (환불 처리)
+    WITHOUT_REFUND, // 결제 전 예약 취소 (환불 없음)
+}

--- a/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
@@ -48,4 +48,80 @@ object DateTimeUtil {
             }
         return calendar.timeInMillis
     }
+
+    // === 예약 관련 날짜 계산 함수 (API 24 안전) ===
+
+    /**
+     * 두 시간 사이의 시간 차이를 계산합니다. (버전 분기 처리)
+     * @param startMillis 시작 시간 (milliseconds)
+     * @param endMillis 종료 시간 (milliseconds)
+     * @return 시간 차이
+     */
+    fun hoursBetween(
+        startMillis: Long,
+        endMillis: Long,
+    ): Long {
+        return (endMillis - startMillis) / (1000 * 60 * 60)
+    }
+
+    /**
+     * 두 날짜 사이의 일수 차이를 계산합니다. (시간 제거 후 비교)
+     * @param startMillis 시작 날짜 (milliseconds)
+     * @param endMillis 종료 날짜 (milliseconds)
+     * @return 일수 차이
+     */
+    fun daysBetween(
+        startMillis: Long,
+        endMillis: Long,
+    ): Long {
+        val startDate =
+            Calendar.getInstance().apply {
+                timeInMillis = startMillis
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        val endDate =
+            Calendar.getInstance().apply {
+                timeInMillis = endMillis
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+        return (endDate.timeInMillis - startDate.timeInMillis) / (1000 * 60 * 60 * 24)
+    }
+
+    /**
+     * 주어진 pattern 으로 날짜를 포맷팅합니다.
+     * @param timestamp 날짜 (milliseconds)
+     * @param pattern 포맷 패턴 (예: "yy.MM.dd")
+     * @return 포맷된 문자열
+     */
+    fun formatDate(
+        timestamp: Long,
+        pattern: String,
+    ): String {
+        val format = SimpleDateFormat(pattern, Locale.getDefault())
+        return format.format(Date(timestamp))
+    }
+
+    /**
+     * 주어진 날짜에서 days 만큼 더한 날짜를 반환합니다.
+     * @param timestamp 시작 날짜 (milliseconds)
+     * @param days 더할 일수
+     * @return 더해진 날짜 (milliseconds)
+     */
+    fun plusDays(
+        timestamp: Long,
+        days: Int,
+    ): Long {
+        return Calendar.getInstance()
+            .apply {
+                timeInMillis = timestamp
+                add(Calendar.DAY_OF_MONTH, days)
+            }
+            .timeInMillis
+    }
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.navigation.model
 
+import com.hm.picplz.common.model.CancelConfirmType
 import com.hm.picplz.common.model.User
 import kotlinx.serialization.Serializable
 
@@ -117,7 +118,7 @@ data class DetailPhotographerPortfolioDetail(val portfolioId: Int, val photoInde
 data object DetailReservation : NavigationRoute
 
 @Serializable
-data object CancelReservationConfirm : NavigationRoute
+data class CancelReservationConfirm(val cancelType: CancelConfirmType) : NavigationRoute
 
 @Serializable
 data class OrderDetail(val orderId: String) : NavigationRoute

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,9 +1,8 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
+import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 data class CancelReservationState(
     val orderId: String = "",
@@ -13,8 +12,8 @@ data class CancelReservationState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     // 환불 안내 관련
-    val shootingDate: LocalDateTime = LocalDateTime.now().plusDays(4),
-    val cancelDate: LocalDateTime = LocalDateTime.now(),
+    val shootingDateMillis: Long = System.currentTimeMillis(),
+    val cancelDateMillis: Long = System.currentTimeMillis(),
     val shootingDateFormatted: String = "",
     val cancelDateFormatted: String = "",
     val totalPrice: Int = 12900,
@@ -40,16 +39,16 @@ data class CancelReservationState(
 
     companion object {
         fun idle(orderId: String): CancelReservationState {
-            val dateFormatter = DateTimeFormatter.ofPattern("yy.MM.dd")
-            val shootingDate = LocalDateTime.now().plusDays(4)
-            val cancelDate = LocalDateTime.now()
+            val currentTimeMillis = System.currentTimeMillis()
+            val shootingDateMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
+            val cancelDateMillis = currentTimeMillis
 
             return CancelReservationState(
                 orderId = orderId,
-                shootingDate = shootingDate,
-                cancelDate = cancelDate,
-                shootingDateFormatted = shootingDate.format(dateFormatter),
-                cancelDateFormatted = cancelDate.format(dateFormatter),
+                shootingDateMillis = shootingDateMillis,
+                cancelDateMillis = cancelDateMillis,
+                shootingDateFormatted = DateTimeUtil.formatDate(shootingDateMillis, "yy.MM.dd"),
+                cancelDateFormatted = DateTimeUtil.formatDate(cancelDateMillis, "yy.MM.dd"),
             )
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -114,9 +113,9 @@ class CancelReservationViewModel @Inject constructor(
                 val currentState = _state.value
                 val refundCondition =
                     RefundCondition.calculate(
-                        currentDateTime = LocalDateTime.now(),
-                        shootingDateTime = currentState.shootingDate,
-                        confirmedDateTime = currentState.cancelDate,
+                        currentMillis = System.currentTimeMillis(),
+                        shootingMillis = currentState.shootingDateMillis,
+                        confirmedMillis = currentState.cancelDateMillis,
                     )
 
                 _state.update {

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
@@ -81,7 +81,9 @@ private fun CancelReservationConfirmScreenContent(
                     .padding(innerPadding)
                     .fillMaxWidth(),
         ) {
-            CancelReservationCheckIcon()
+            CancelReservationCheckIcon(
+                modifier = Modifier.padding(top = 80.dp, bottom = 24.dp),
+            )
 
             CancelReservationTitle()
 
@@ -105,7 +107,6 @@ private fun CancelReservationCheckIcon(modifier: Modifier = Modifier) {
     Image(
         modifier =
             modifier
-                .padding(top = 40.dp, bottom = 24.dp)
                 .fillMaxWidth(),
         painter = painterResource(CoreR.drawable.check_circle),
         contentDescription = "예약 취소 완료",

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.ui.screen.cancel_reservation_confirm
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -17,6 +19,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.common.model.CancelConfirmType
 import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
@@ -42,8 +46,11 @@ fun CancelReservationConfirmScreen(
         }
     }
 
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
     CancelReservationConfirmScreenContent(
         modifier = modifier,
+        cancelType = state.cancelType,
         onNavigateBack = onNavigateBack,
         onHistoryClick = { viewModel.handleIntent(CancelReservationConfirmIntent.NavigateToHistory) },
         onHomeClick = { viewModel.handleIntent(CancelReservationConfirmIntent.NavigateToHome) },
@@ -52,6 +59,7 @@ fun CancelReservationConfirmScreen(
 
 @Composable
 private fun CancelReservationConfirmScreenContent(
+    cancelType: CancelConfirmType,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
     onHistoryClick: () -> Unit = {},
@@ -77,7 +85,7 @@ private fun CancelReservationConfirmScreenContent(
 
             CancelReservationTitle()
 
-            CancelReservationDescription()
+            CancelReservationDescription(cancelType = cancelType)
 
             Spacer(modifier = Modifier.weight(1f))
 
@@ -119,12 +127,21 @@ private fun CancelReservationTitle(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun CancelReservationDescription(modifier: Modifier = Modifier) {
+private fun CancelReservationDescription(
+    cancelType: CancelConfirmType,
+    modifier: Modifier = Modifier,
+) {
+    val descriptionText =
+        when (cancelType) {
+            CancelConfirmType.WITHOUT_REFUND -> stringResource(R.string.cancel_reservation_description)
+            CancelConfirmType.WITH_REFUND -> stringResource(R.string.cancel_reservation_description_with_refund)
+        }
+
     Text(
         modifier =
             modifier
                 .fillMaxWidth(),
-        text = stringResource(R.string.cancel_reservation_description),
+        text = descriptionText,
         style = pretendardTypography.bodyLarge,
         color = MainThemeColor.Black,
         textAlign = TextAlign.Center,
@@ -133,23 +150,26 @@ private fun CancelReservationDescription(modifier: Modifier = Modifier) {
 
 @Composable
 private fun CancelReservationGuide(modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
+    Column(
+        modifier =
+            modifier
+                .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
         Text(
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier,
             text = stringResource(R.string.cancel_reservation_guide),
             style = pretendardTypography.bodyMedium,
             color = MainThemeColor.Gray4,
         )
 
         Text(
-            modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(R.string.cancel_reservation_notice_prefix),
             style = pretendardTypography.bodyMedium,
             color = MainThemeColor.Gray4,
         )
 
         Text(
-            modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(R.string.cancel_reservation_notice_suffix),
             style = pretendardTypography.bodyMedium,
             color = MainThemeColor.Gray4,
@@ -187,9 +207,23 @@ private fun CancelReservationButtons(
 @Suppress("UnusedPrivateMember")
 @Preview
 @Composable
-private fun CancelReservationConfirmScreenPreview() {
-    CancelReservationConfirmScreen(
+private fun CancelReservationConfirmScreenWithRefundPreview() {
+    CancelReservationConfirmScreenContent(
+        cancelType = CancelConfirmType.WITH_REFUND,
         onNavigateBack = { },
-        onNavigateHome = { },
+        onHistoryClick = { },
+        onHomeClick = { },
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview
+@Composable
+private fun CancelReservationConfirmScreenWithoutRefundPreview() {
+    CancelReservationConfirmScreenContent(
+        cancelType = CancelConfirmType.WITHOUT_REFUND,
+        onNavigateBack = { },
+        onHistoryClick = { },
+        onHomeClick = { },
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmState.kt
@@ -1,3 +1,7 @@
 package com.hm.picplz.ui.screen.cancel_reservation_confirm
 
-class CancelReservationConfirmState
+import com.hm.picplz.common.model.CancelConfirmType
+
+data class CancelReservationConfirmState(
+    val cancelType: CancelConfirmType = CancelConfirmType.WITHOUT_REFUND,
+)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmViewModel.kt
@@ -1,7 +1,10 @@
 package com.hm.picplz.ui.screen.cancel_reservation_confirm
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.CancelReservationConfirm
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,8 +14,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CancelReservationConfirmViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow(CancelReservationConfirmState())
+class CancelReservationConfirmViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val cancelType = savedStateHandle.toRoute<CancelReservationConfirm>().cancelType
+
+    private val _state = MutableStateFlow(CancelReservationConfirmState(cancelType = cancelType))
     val state: StateFlow<CancelReservationConfirmState> get() = _state
 
     private val _sideEffect = MutableSharedFlow<CancelReservationConfirmSideEffect>()

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -2,14 +2,13 @@ package com.hm.picplz.ui.screen.detail_reservation
 
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
-import java.time.LocalDateTime
 
 data class DetailReservationState(
     val orderId: String = "",
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
     val showCancelDialog: Boolean = false,
-    val shootingDateTime: LocalDateTime = LocalDateTime.now(),
-    val confirmedDateTime: LocalDateTime = LocalDateTime.now(),
+    val shootingDateTimeMillis: Long = System.currentTimeMillis(),
+    val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
     val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
     val showRefundPolicyTooltip: Boolean = false,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.detail_reservation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,7 +12,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,13 +25,14 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
     init {
         // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
         // 임시로 더미 데이터 설정 (촬영일: 4일 후)
-        val dummyShootingDateTime = LocalDateTime.now().plusDays(4)
-        val dummyConfirmedDateTime = LocalDateTime.now().minusHours(12)
+        val currentTimeMillis = System.currentTimeMillis()
+        val dummyShootingDateTimeMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
+        val dummyConfirmedDateTimeMillis = currentTimeMillis - (12 * 60 * 60 * 1000) // 12시간 전
 
         _state.update {
             it.copy(
-                shootingDateTime = dummyShootingDateTime,
-                confirmedDateTime = dummyConfirmedDateTime,
+                shootingDateTimeMillis = dummyShootingDateTimeMillis,
+                confirmedDateTimeMillis = dummyConfirmedDateTimeMillis,
             )
         }
     }
@@ -50,9 +51,9 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                 val currentState = _state.value
                 val refundCondition =
                     RefundCondition.calculate(
-                        currentDateTime = LocalDateTime.now(),
-                        shootingDateTime = currentState.shootingDateTime,
-                        confirmedDateTime = currentState.confirmedDateTime,
+                        currentMillis = System.currentTimeMillis(),
+                        shootingMillis = currentState.shootingDateTimeMillis,
+                        confirmedMillis = currentState.confirmedDateTimeMillis,
                     )
 
                 _state.update {

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/RefundCondition.kt
@@ -1,9 +1,8 @@
 package com.hm.picplz.ui.screen.detail_reservation.model
 
 import androidx.annotation.StringRes
+import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.feature.reservation.R
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 enum class RefundCondition(
     val percent: Int,
@@ -53,26 +52,25 @@ enum class RefundCondition(
          * - 촬영일 기준 2일 전까지: 70%
          * - 촬영일 기준 1일 전까지: 50%
          * - 당일 취소: 0% (환불 불가)
+         * @param currentMillis 현재 시간 (milliseconds)
+         * @param shootingMillis 촬영 예정 시간 (milliseconds)
+         * @param confirmedMillis 촬영 확정 시간 (milliseconds, nullable)
          */
         fun calculate(
-            currentDateTime: LocalDateTime,
-            shootingDateTime: LocalDateTime,
-            confirmedDateTime: LocalDateTime?,
+            currentMillis: Long,
+            shootingMillis: Long,
+            confirmedMillis: Long?,
         ): RefundCondition {
             // 촬영 확정 후 24시간 이내 체크
-            confirmedDateTime?.let {
-                val hoursSinceConfirmed = ChronoUnit.HOURS.between(it, currentDateTime)
+            confirmedMillis?.let {
+                val hoursSinceConfirmed = DateTimeUtil.hoursBetween(it, currentMillis)
                 if (hoursSinceConfirmed < 24) {
                     return WITHIN_24_HOURS
                 }
             }
 
             // 촬영일까지 남은 일수 계산
-            val daysUntilShooting =
-                ChronoUnit.DAYS.between(
-                    currentDateTime.toLocalDate(),
-                    shootingDateTime.toLocalDate(),
-                )
+            val daysUntilShooting = DateTimeUtil.daysBetween(currentMillis, shootingMillis)
 
             return when {
                 daysUntilShooting >= 7 -> BEFORE_7_DAYS

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -44,9 +44,10 @@
     <!-- 취소 완료 화면 -->
     <string name="cancel_reservation_title">예약이 취소되었습니다</string>
     <string name="cancel_reservation_description">예약이 정상적으로 취소되었습니다.</string>
+    <string name="cancel_reservation_description_with_refund">환불은 이용하신 카드사를 통해\n영업일 기준 5~7일 이내로 처리됩니다.</string>
     <string name="cancel_reservation_guide">자세한 구매내역은 \'마이페이지 > 촬영내역\' 에서\n확인할 수 있습니다.</string>
-    <string name="cancel_reservation_notice_prefix">추기 인내해야할 사항들~</string>
-    <string name="cancel_reservation_notice_suffix">추기 인내해야할 사항들~</string>
+    <string name="cancel_reservation_notice_prefix">추가 안내해야할 사항들~</string>
+    <string name="cancel_reservation_notice_suffix">추가 안내해야할 사항들~</string>
     <string name="cancel_reservation_button_history">취소내역 확인</string>
     <string name="cancel_reservation_button_home">홈으로</string>
 


### PR DESCRIPTION
## 기존 PR이 잘못된 base branch로 머지되어 올바른 base branch 대상(develop)으로 다시 올리는 PR입니다. (바로 머지 예정)

## 개요
예약 취소 완료 화면에 cancelType enum을 통한 분기 처리를 구현하고, java.time 버전 분기를 DateTimeUtil로 추상화하여 API 24 호환성을 확보한 작업도 포함되어 있습니다..

## 변경 사항
- **CancelConfirmType enum**: core/common 모듈의 com.hm.picplz.common.model 패키지에 생성 (WITH_REFUND / WITHOUT_REFUND)
- **RouteModels 수정**: CancelReservationConfirm을 data class로 변경, cancelType 파라미터 추가
- **MainNavGraph 업데이트**: DetailReservation → WITHOUT_REFUND, CancelReservation → WITH_REFUND로 분기 처리
- **CancelReservationConfirmScreen**: cancelType에 따라 설명 텍스트 및 안내 문구 동적 표시
- **DateTimeUtil 함수 추가**: hoursBetween(), daysBetween(), formatDate(), plusDays() 추가 (Calendar/SimpleDateFormat 기반, API 24 안전)
- **LocalDateTime → Long 타입 통일**: RefundCondition, DetailReservationState/ViewModel, CancelReservationState/ViewModel에서 Long(epoch millis)으로 변경
- **java.time 제거**: java.time.LocalDateTime, java.time.temporal.ChronoUnit 사용 제거, DateTimeUtil로 중앙화

결제 이전 취소(환불 X)

[Screen_recording_20260421_134703.webm](https://github.com/user-attachments/assets/aa4e9862-f2d7-4270-994a-464980e3ca2d)

결제 이후 취소(환불 O)

[Screen_recording_20260421_134724.webm](https://github.com/user-attachments/assets/93bf4328-a053-46cb-899b-9949a4dc96a6)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #136
