### PR TITLE
프로필 수정 사진 권한 안내 화면 개선

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ main ← develop ← feat/이슈번호
 - 파일 위치: `core/ui/src/main/res/values/strings.xml` (공통) 또는 각 feature 모듈의 `res/values/strings.xml`
 - 네이밍: `{화면}_{용도}` (예: `quick_shoot_permission_denied_title`, `cancel_reservation_button_home`)
 - `contentDescription`도 string resource 사용
+- Compose `Text`에서 줄바꿈이 필요한 문자열은 `\n` 사용 — `&#10;` 엔티티는 실제 UI에서 줄바꿈이 보장되지 않음
 
 ## MIGRATION STATUS (refactor/77)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <application
         android:name=".MyApplication"

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -194,6 +194,14 @@ fun DevScreen(navController: NavHostController) {
             DevButton("MyPageModifyProfile") { navController.navigate(MyPageModifyProfile) }
             DevButton("MyPagePhotographerModifyProfile") { navController.navigate(MyPagePhotographerModifyProfile) }
             DevButton("MyPagePackageEdit (패키지 등록 placeholder)") { navController.navigate(MyPagePackageEdit) }
+            DevButton("MyPagePhotographerModifyProfile (권한 설정 → 거부 후 테스트)") {
+                context.startActivity(
+                    Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.parse("package:${context.packageName}"),
+                    ),
+                )
+            }
             DevButton("MyPageShootingHistory") { navController.navigate(MyPageShootingHistory()) }
             DevButton("MyPageShootingHistory (Empty)") {
                 navController.navigate(MyPageShootingHistory(forceEmpty = true))

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotoPermissionScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotoPermissionScreen.kt
@@ -1,13 +1,12 @@
 package com.hm.picplz.ui.screen.my_page
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -17,20 +16,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.mypage.R
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 
 private object MyPagePhotoPermissionScreenDefaults {
-    val HorizontalPadding = 24.dp
-    val TitleDescriptionSpacing = 20.dp
-    val DescriptionButtonSpacing = 32.dp
-    val ButtonWidth = 256.dp
-    val ButtonHeight = 50.dp
-    val ButtonCornerRadius = 5.dp
-    val ButtonVerticalPadding = 14.dp
-    val ButtonHorizontalPadding = 20.dp
+    val HorizontalPadding: Dp = 24.dp
+    const val TOP_WEIGHT = 0.42f
+    const val BOTTOM_WEIGHT = 0.58f
+    val TitleDescriptionSpacing: Dp = 20.dp
+    val DescriptionButtonSpacing: Dp = 32.dp
+    val ButtonHeight: Dp = 50.dp
+    val ButtonCornerRadius: Dp = 5.dp
+    val ButtonVerticalPadding: Dp = 14.dp
+    val ButtonHorizontalPadding: Dp = 20.dp
 }
 
 @Composable
@@ -39,10 +40,12 @@ fun MyPagePhotoPermissionScreen(
     actionLabel: String,
     onActionClick: () -> Unit,
 ) {
-    Box(
-        modifier = modifier,
-        contentAlignment = Alignment.Center,
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        Spacer(modifier = Modifier.weight(MyPagePhotoPermissionScreenDefaults.TOP_WEIGHT))
+
         Column(
             modifier = Modifier.padding(horizontal = MyPagePhotoPermissionScreenDefaults.HorizontalPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -65,12 +68,11 @@ fun MyPagePhotoPermissionScreen(
             PhotoPermissionActionButton(
                 text = actionLabel,
                 onClick = onActionClick,
-                modifier =
-                    Modifier
-                        .width(MyPagePhotoPermissionScreenDefaults.ButtonWidth)
-                        .height(MyPagePhotoPermissionScreenDefaults.ButtonHeight),
+                modifier = Modifier.height(MyPagePhotoPermissionScreenDefaults.ButtonHeight),
             )
         }
+
+        Spacer(modifier = Modifier.weight(MyPagePhotoPermissionScreenDefaults.BOTTOM_WEIGHT))
     }
 }
 
@@ -95,6 +97,10 @@ private fun PhotoPermissionActionButton(
                 horizontal = MyPagePhotoPermissionScreenDefaults.ButtonHorizontalPadding,
             ),
     ) {
-        Text(text = text)
+        Text(
+            text = text,
+            style = MainThemeFont.ButtonDefault,
+            color = MainThemeColor.White,
+        )
     }
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotoPermissionScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotoPermissionScreen.kt
@@ -1,0 +1,100 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+
+private object MyPagePhotoPermissionScreenDefaults {
+    val HorizontalPadding = 24.dp
+    val TitleDescriptionSpacing = 20.dp
+    val DescriptionButtonSpacing = 32.dp
+    val ButtonWidth = 256.dp
+    val ButtonHeight = 50.dp
+    val ButtonCornerRadius = 5.dp
+    val ButtonVerticalPadding = 14.dp
+    val ButtonHorizontalPadding = 20.dp
+}
+
+@Composable
+fun MyPagePhotoPermissionScreen(
+    modifier: Modifier = Modifier,
+    actionLabel: String,
+    onActionClick: () -> Unit,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = MyPagePhotoPermissionScreenDefaults.HorizontalPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.modify_profile_photo_permission_title),
+                style = MainThemeFont.Title,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(MyPagePhotoPermissionScreenDefaults.TitleDescriptionSpacing))
+            Text(
+                text = stringResource(R.string.modify_profile_photo_permission_description),
+                style = MainThemeFont.BodyLarge,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(MyPagePhotoPermissionScreenDefaults.DescriptionButtonSpacing))
+            PhotoPermissionActionButton(
+                text = actionLabel,
+                onClick = onActionClick,
+                modifier =
+                    Modifier
+                        .width(MyPagePhotoPermissionScreenDefaults.ButtonWidth)
+                        .height(MyPagePhotoPermissionScreenDefaults.ButtonHeight),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotoPermissionActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MainThemeColor.Black,
+                contentColor = MainThemeColor.White,
+            ),
+        shape = RoundedCornerShape(MyPagePhotoPermissionScreenDefaults.ButtonCornerRadius),
+        contentPadding =
+            PaddingValues(
+                vertical = MyPagePhotoPermissionScreenDefaults.ButtonVerticalPadding,
+                horizontal = MyPagePhotoPermissionScreenDefaults.ButtonHorizontalPadding,
+            ),
+    ) {
+        Text(text = text)
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileIntent.kt
@@ -1,6 +1,16 @@
 package com.hm.picplz.ui.screen.my_page
 
 sealed interface MyPagePhotographerModifyProfileIntent {
+    data object ClickPhotoPermissionAction : MyPagePhotographerModifyProfileIntent
+
+    data object ClickProfileImage : MyPagePhotographerModifyProfileIntent
+
+    data class SyncPhotoPermissionState(
+        val granted: Boolean,
+        val hasRequested: Boolean,
+        val permanentlyDenied: Boolean,
+    ) : MyPagePhotographerModifyProfileIntent
+
     data class ChangeNickname(val value: String) : MyPagePhotographerModifyProfileIntent
 
     data class ChangeInstagramId(val value: String) : MyPagePhotographerModifyProfileIntent

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileScreen.kt
@@ -1,6 +1,13 @@
 package com.hm.picplz.ui.screen.my_page
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -28,6 +35,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -43,7 +51,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -93,6 +106,18 @@ fun MyPagePhotographerModifyProfileScreen(
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle().value
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val photoPermissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            syncPhotoPermissionState(
+                context = context,
+                viewModel = viewModel,
+                grantedOverride = granted,
+            )
+        }
 
     val filePickerLauncher =
         rememberLauncherForActivityResult(
@@ -114,9 +139,47 @@ fun MyPagePhotographerModifyProfileScreen(
         }
 
     LaunchedEffect(Unit) {
+        syncPhotoPermissionState(
+            context = context,
+            viewModel = viewModel,
+        )
+    }
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    syncPhotoPermissionState(
+                        context = context,
+                        viewModel = viewModel,
+                    )
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(Unit) {
         viewModel.sideEffect.collectLatest { sideEffect ->
             when (sideEffect) {
                 MyPagePhotographerModifyProfileSideEffect.NavigateBack -> navController.popBackStack()
+                MyPagePhotographerModifyProfileSideEffect.RequestPhotoPermission -> {
+                    setHasRequestedPhotoPermission(context)
+                    photoPermissionLauncher.launch(photoPermission())
+                }
+                MyPagePhotographerModifyProfileSideEffect.OpenPhotoPermissionSettings -> {
+                    context.startActivity(
+                        Intent(
+                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                            Uri.parse("package:${context.packageName}"),
+                        ),
+                    )
+                }
+                MyPagePhotographerModifyProfileSideEffect.LaunchImagePicker -> {
+                    filePickerLauncher.launch("image/*")
+                }
                 is MyPagePhotographerModifyProfileSideEffect.ShowToast -> {
                     Toast.makeText(context, sideEffect.messageResId, Toast.LENGTH_SHORT).show()
                 }
@@ -136,79 +199,168 @@ fun MyPagePhotographerModifyProfileScreen(
                 .fillMaxSize()
                 .systemBarsPadding(),
     ) { innerPadding ->
-        val scrollState = rememberScrollState()
+        if (state.showPhotoPermissionScreen) {
+            MyPagePhotoPermissionScreen(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                actionLabel =
+                    stringResource(
+                        if (state.shouldOpenPhotoPermissionSettings) {
+                            R.string.modify_profile_photo_permission_settings_button
+                        } else {
+                            R.string.modify_profile_photo_permission_allow_button
+                        },
+                    ),
+                onActionClick = {
+                    viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ClickPhotoPermissionAction)
+                },
+            )
+        } else {
+            val scrollState = rememberScrollState()
 
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .imePadding(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
             Column(
                 modifier =
                     Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
-                        .verticalScroll(scrollState),
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .imePadding(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Spacer(modifier = Modifier.height(10.dp))
+                Column(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .verticalScroll(scrollState),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(modifier = Modifier.height(10.dp))
 
-                PhotographerProfileImageSection(
-                    profileImageUri = state.profileImageUri,
-                    onChangeImage = { filePickerLauncher.launch("image/*") },
-                )
+                    PhotographerProfileImageSection(
+                        profileImageUri = state.profileImageUri,
+                        onChangeImage = {
+                            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ClickProfileImage)
+                        },
+                    )
 
-                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.ProfileToFormSpacing))
+                    Spacer(
+                        modifier =
+                            Modifier.height(
+                                MyPagePhotographerModifyProfileLayoutDefaults.ProfileToFormSpacing,
+                            ),
+                    )
 
-                PhotographerNicknameSection(
-                    nickname = state.nickname,
-                    isCheckingNickname = state.isCheckingNickname,
-                    errorMessage = state.representativeNicknameError?.message,
-                    onNicknameChange = {
-                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname(it))
-                    },
-                )
+                    PhotographerNicknameSection(
+                        nickname = state.nickname,
+                        isCheckingNickname = state.isCheckingNickname,
+                        errorMessage = state.representativeNicknameError?.message,
+                        onNicknameChange = {
+                            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeNickname(it))
+                        },
+                    )
 
-                PhotographerTextFieldSection(
-                    title = stringResource(R.string.modify_profile_instagram_id),
-                    value = state.instagramId,
-                    placeholder = stringResource(R.string.modify_profile_instagram_placeholder),
-                    onValueChange = {
-                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId(it))
-                    },
-                )
+                    PhotographerTextFieldSection(
+                        title = stringResource(R.string.modify_profile_instagram_id),
+                        value = state.instagramId,
+                        placeholder = stringResource(R.string.modify_profile_instagram_placeholder),
+                        onValueChange = {
+                            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeInstagramId(it))
+                        },
+                    )
 
-                PhotographerIntroductionSection(
-                    introduction = state.introduction,
-                    saveErrorMessage = state.saveErrorMessageResId?.let { stringResource(it) },
-                    onIntroductionChange = {
-                        viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
-                    },
-                )
+                    PhotographerIntroductionSection(
+                        introduction = state.introduction,
+                        saveErrorMessage = state.saveErrorMessageResId?.let { stringResource(it) },
+                        onIntroductionChange = {
+                            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeIntroduction(it))
+                        },
+                    )
 
-                Spacer(modifier = Modifier.height(MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding))
-            }
+                    Spacer(
+                        modifier =
+                            Modifier.height(
+                                MyPagePhotographerModifyProfileLayoutDefaults.SectionVerticalPadding,
+                            ),
+                    )
+                }
 
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(MyPagePhotographerModifyProfileLayoutDefaults.BottomActionAreaHeight)
-                        .padding(horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding),
-                contentAlignment = Alignment.Center,
-            ) {
-                CommonBottomButton(
-                    text = stringResource(R.string.modify_profile_done),
-                    onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
-                    enabled = state.isCompleteEnabled && !state.isLoading,
-                )
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(MyPagePhotographerModifyProfileLayoutDefaults.BottomActionAreaHeight)
+                            .padding(horizontal = MyPagePhotographerModifyProfileLayoutDefaults.HorizontalPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CommonBottomButton(
+                        text = stringResource(R.string.modify_profile_done),
+                        onClick = { viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.Save) },
+                        enabled = state.isCompleteEnabled && !state.isLoading,
+                    )
+                }
             }
         }
     }
 }
+
+private fun syncPhotoPermissionState(
+    context: Context,
+    viewModel: MyPagePhotographerModifyProfileViewModel,
+    grantedOverride: Boolean? = null,
+) {
+    val granted = grantedOverride ?: hasPhotoPermission(context)
+    val hasRequested = hasRequestedPhotoPermission(context)
+    val permanentlyDenied = !granted && hasRequested && !shouldShowPhotoPermissionRationale(context)
+
+    viewModel.handleIntent(
+        MyPagePhotographerModifyProfileIntent.SyncPhotoPermissionState(
+            granted = granted,
+            hasRequested = hasRequested,
+            permanentlyDenied = permanentlyDenied,
+        ),
+    )
+}
+
+private fun photoPermission(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+private fun hasPhotoPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(
+        context,
+        photoPermission(),
+    ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+private fun shouldShowPhotoPermissionRationale(context: Context): Boolean {
+    val activity = context.findActivity() ?: return false
+    return ActivityCompat.shouldShowRequestPermissionRationale(activity, photoPermission())
+}
+
+private fun Context.findActivity(): Activity? =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }
+
+private fun hasRequestedPhotoPermission(context: Context): Boolean =
+    context.getSharedPreferences(PHOTO_PERMISSION_PREFS_NAME, Context.MODE_PRIVATE)
+        .getBoolean(KEY_HAS_REQUESTED_PHOTO_PERMISSION, false)
+
+private fun setHasRequestedPhotoPermission(context: Context) {
+    context.getSharedPreferences(PHOTO_PERMISSION_PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putBoolean(KEY_HAS_REQUESTED_PHOTO_PERMISSION, true)
+        .apply()
+}
+
+private const val PHOTO_PERMISSION_PREFS_NAME = "mypage_photo_permission_prefs"
+private const val KEY_HAS_REQUESTED_PHOTO_PERMISSION = "has_requested_photo_permission"
 
 @Composable
 private fun PhotographerProfileImageSection(

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileSideEffect.kt
@@ -3,5 +3,11 @@ package com.hm.picplz.ui.screen.my_page
 sealed interface MyPagePhotographerModifyProfileSideEffect {
     data object NavigateBack : MyPagePhotographerModifyProfileSideEffect
 
+    data object RequestPhotoPermission : MyPagePhotographerModifyProfileSideEffect
+
+    data object OpenPhotoPermissionSettings : MyPagePhotographerModifyProfileSideEffect
+
+    data object LaunchImagePicker : MyPagePhotographerModifyProfileSideEffect
+
     data class ShowToast(val messageResId: Int) : MyPagePhotographerModifyProfileSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileState.kt
@@ -13,6 +13,10 @@ data class MyPagePhotographerModifyProfileState(
     val originalProfileImageObjectKey: String?,
     val profileImageObjectKey: String?,
     val originalProfileImageUri: String,
+    val photoPermissionGranted: Boolean = false,
+    val hasRequestedPhotoPermission: Boolean = false,
+    val isPhotoPermissionPermanentlyDenied: Boolean = false,
+    val uploadedProfileImageUri: String,
     val profileImageUri: String,
     val nicknameFieldErrors: List<NicknameFieldError> = emptyList(),
     val isCheckingNickname: Boolean = false,
@@ -23,6 +27,12 @@ data class MyPagePhotographerModifyProfileState(
 ) {
     val representativeNicknameError: NicknameFieldError?
         get() = nicknameFieldErrors.firstOrNull()
+
+    val showPhotoPermissionScreen: Boolean
+        get() = !photoPermissionGranted
+
+    val shouldOpenPhotoPermissionSettings: Boolean
+        get() = hasRequestedPhotoPermission && isPhotoPermissionPermanentlyDenied
 
     val hasChanges: Boolean
         get() =
@@ -57,6 +67,10 @@ data class MyPagePhotographerModifyProfileState(
                 originalProfileImageObjectKey = null,
                 profileImageObjectKey = null,
                 originalProfileImageUri = "",
+                photoPermissionGranted = false,
+                hasRequestedPhotoPermission = false,
+                isPhotoPermissionPermanentlyDenied = false,
+                uploadedProfileImageUri = "",
                 profileImageUri = "",
             )
     }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModel.kt
@@ -45,6 +45,17 @@ class MyPagePhotographerModifyProfileViewModel
 
         fun handleIntent(intent: MyPagePhotographerModifyProfileIntent) {
             when (intent) {
+                MyPagePhotographerModifyProfileIntent.ClickPhotoPermissionAction -> handlePhotoPermissionAction()
+                MyPagePhotographerModifyProfileIntent.ClickProfileImage -> handleProfileImageClick()
+                is MyPagePhotographerModifyProfileIntent.SyncPhotoPermissionState -> {
+                    _state.update {
+                        it.copy(
+                            photoPermissionGranted = intent.granted,
+                            hasRequestedPhotoPermission = intent.hasRequested,
+                            isPhotoPermissionPermanentlyDenied = intent.permanentlyDenied,
+                        )
+                    }
+                }
                 is MyPagePhotographerModifyProfileIntent.ChangeNickname -> handleNicknameChange(intent.value)
                 is MyPagePhotographerModifyProfileIntent.ChangeInstagramId -> {
                     _state.update { it.copy(instagramId = intent.value, saveErrorMessageResId = null) }
@@ -60,6 +71,26 @@ class MyPagePhotographerModifyProfileViewModel
                 }
                 is MyPagePhotographerModifyProfileIntent.Save -> save()
                 is MyPagePhotographerModifyProfileIntent.NavigateBack -> navigateBack()
+            }
+        }
+
+        private fun handleProfileImageClick() {
+            viewModelScope.launch {
+                if (_state.value.photoPermissionGranted) {
+                    _sideEffect.send(MyPagePhotographerModifyProfileSideEffect.LaunchImagePicker)
+                } else {
+                    handlePhotoPermissionAction()
+                }
+            }
+        }
+
+        private fun handlePhotoPermissionAction() {
+            viewModelScope.launch {
+                if (_state.value.shouldOpenPhotoPermissionSettings) {
+                    _sideEffect.send(MyPagePhotographerModifyProfileSideEffect.OpenPhotoPermissionSettings)
+                } else {
+                    _sideEffect.send(MyPagePhotographerModifyProfileSideEffect.RequestPhotoPermission)
+                }
             }
         }
 
@@ -92,6 +123,7 @@ class MyPagePhotographerModifyProfileViewModel
                                 originalProfileImageObjectKey = profile.profileImage,
                                 profileImageObjectKey = profile.profileImage,
                                 originalProfileImageUri = profile.profileImage.orEmpty(),
+                                uploadedProfileImageUri = profile.profileImage.orEmpty(),
                                 profileImageUri = profile.profileImage.orEmpty(),
                                 isLoading = false,
                                 saveErrorMessageResId = null,
@@ -189,6 +221,7 @@ class MyPagePhotographerModifyProfileViewModel
                             originalIntroduction = it.introduction,
                             originalProfileImageObjectKey = it.profileImageObjectKey,
                             originalProfileImageUri = it.profileImageUri,
+                            uploadedProfileImageUri = it.profileImageUri,
                             isSaving = false,
                             saveErrorMessageResId = null,
                         )
@@ -216,12 +249,14 @@ class MyPagePhotographerModifyProfileViewModel
                         _state.update {
                             it.copy(
                                 profileImageObjectKey = objectKey,
+                                uploadedProfileImageUri = it.profileImageUri,
                                 isUploadingImage = false,
                             )
                         }
                     }.onFailure {
                         _state.update {
                             it.copy(
+                                profileImageUri = it.uploadedProfileImageUri,
                                 isUploadingImage = false,
                                 saveErrorMessageResId = R.string.modify_profile_image_upload_failed,
                             )

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@
     <string name="modify_profile_save_failed">프로필 저장에 실패했습니다.</string>
     <string name="modify_profile_image_upload_failed">프로필 이미지 업로드에 실패했습니다.</string>
     <string name="modify_profile_photo_permission_title">사진 접근 권한을 허용해주세요</string>
-    <string name="modify_profile_photo_permission_description">갤러리에서 사진을 가져오기 위해,&#10;아래 권한이 필요해요.</string>
+    <string name="modify_profile_photo_permission_description">갤러리에서 사진을 가져오기 위해,\n아래 권한이 필요해요.</string>
     <string name="modify_profile_photo_permission_allow_button">사진 접근 허용하기</string>
     <string name="modify_profile_photo_permission_settings_button">설정에서 권한 허용하기</string>
 

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -111,6 +111,10 @@
     <string name="modify_profile_load_failed">프로필 정보를 불러오지 못했습니다.</string>
     <string name="modify_profile_save_failed">프로필 저장에 실패했습니다.</string>
     <string name="modify_profile_image_upload_failed">프로필 이미지 업로드에 실패했습니다.</string>
+    <string name="modify_profile_photo_permission_title">사진 접근 권한을 허용해주세요</string>
+    <string name="modify_profile_photo_permission_description">갤러리에서 사진을 가져오기 위해,&#10;아래 권한이 필요해요.</string>
+    <string name="modify_profile_photo_permission_allow_button">사진 접근 허용하기</string>
+    <string name="modify_profile_photo_permission_settings_button">설정에서 권한 허용하기</string>
 
     <!-- 주문 상세 -->
     <string name="order_detail_title">주문 상세</string>

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.util.ArrayDeque
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MyPagePhotographerModifyProfileViewModelTest {
@@ -111,16 +112,154 @@ class MyPagePhotographerModifyProfileViewModelTest {
             )
         }
 
+    @Test
+    fun `click profile image launches image picker side effect`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.SyncPhotoPermissionState(
+                    granted = true,
+                    hasRequested = true,
+                    permanentlyDenied = false,
+                ),
+            )
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ClickProfileImage)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPagePhotographerModifyProfileSideEffect.LaunchImagePicker,
+                sideEffectDeferred.await(),
+            )
+        }
+
+    @Test
+    fun `photo permission action requests permission when settings redirect is not needed`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.SyncPhotoPermissionState(
+                    granted = false,
+                    hasRequested = false,
+                    permanentlyDenied = false,
+                ),
+            )
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ClickPhotoPermissionAction)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPagePhotographerModifyProfileSideEffect.RequestPhotoPermission,
+                sideEffectDeferred.await(),
+            )
+        }
+
+    @Test
+    fun `photo permission action opens settings when permission is permanently denied`() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.SyncPhotoPermissionState(
+                    granted = false,
+                    hasRequested = true,
+                    permanentlyDenied = true,
+                ),
+            )
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ClickPhotoPermissionAction)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPagePhotographerModifyProfileSideEffect.OpenPhotoPermissionSettings,
+                sideEffectDeferred.await(),
+            )
+        }
+
+    @Test
+    fun `upload failure restores previous preview and clears image-only dirty state`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    s3Repository =
+                        FakeS3Repository(
+                            uploadResults = listOf(Result.failure(IllegalStateException("upload failed"))),
+                        ),
+                )
+            advanceUntilIdle()
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeProfileImage("content://picked-image"))
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.UploadProfileImage(
+                    imageBytes = byteArrayOf(1),
+                    filename = "profile.jpg",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.state.value.profileImageUri)
+            assertEquals(null, viewModel.state.value.profileImageObjectKey)
+            assertEquals(R.string.modify_profile_image_upload_failed, viewModel.state.value.saveErrorMessageResId)
+            assertFalse(viewModel.state.value.isCompleteEnabled)
+        }
+
+    @Test
+    fun `upload failure after previous success restores last valid preview and preserves object key`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    s3Repository =
+                        FakeS3Repository(
+                            uploadResults =
+                                listOf(
+                                    Result.success("profile/first-object-key.jpg"),
+                                    Result.failure(IllegalStateException("upload failed")),
+                                ),
+                        ),
+                )
+            advanceUntilIdle()
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeProfileImage("content://first-image"))
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.UploadProfileImage(
+                    imageBytes = byteArrayOf(1),
+                    filename = "first.jpg",
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.handleIntent(MyPagePhotographerModifyProfileIntent.ChangeProfileImage("content://second-image"))
+            viewModel.handleIntent(
+                MyPagePhotographerModifyProfileIntent.UploadProfileImage(
+                    imageBytes = byteArrayOf(2),
+                    filename = "second.jpg",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals("content://first-image", viewModel.state.value.profileImageUri)
+            assertEquals("profile/first-object-key.jpg", viewModel.state.value.profileImageObjectKey)
+            assertEquals(R.string.modify_profile_image_upload_failed, viewModel.state.value.saveErrorMessageResId)
+            assertTrue(viewModel.state.value.isCompleteEnabled)
+        }
+
     private fun createViewModel(
         memberRepository: FakeMemberRepository = FakeMemberRepository(),
         memberId: Long = 1L,
+        s3Repository: FakeS3Repository = FakeS3Repository(),
     ): MyPagePhotographerModifyProfileViewModel =
         MyPagePhotographerModifyProfileViewModel(
             checkNicknameAvailabilityUseCase = CheckNicknameAvailabilityUseCase(memberRepository),
             getCurrentMemberIdUseCase = GetCurrentMemberIdUseCase(FakeAuthRepository(memberId)),
             getMemberProfileUseCase = GetMemberProfileUseCase(memberRepository),
             updateMemberProfileUseCase = UpdateMemberProfileUseCase(memberRepository),
-            uploadProfileImageUseCase = UploadProfileImageUseCase(FakeS3Repository()),
+            uploadProfileImageUseCase = UploadProfileImageUseCase(s3Repository),
         )
 
     private class FakeMemberRepository(
@@ -171,9 +310,22 @@ class MyPagePhotographerModifyProfileViewModelTest {
     }
 
     private class FakeS3Repository : S3Repository {
+        private val uploadResults = ArrayDeque<Result<String>>()
+
+        constructor(
+            uploadResults: List<Result<String>> = listOf(Result.success("profile/object-key.jpg")),
+        ) {
+            this.uploadResults.addAll(uploadResults)
+        }
+
         override suspend fun uploadProfileImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> = Result.success("profile/object-key.jpg")
+        ): Result<String> =
+            if (uploadResults.isEmpty()) {
+                Result.success("profile/object-key.jpg")
+            } else {
+                uploadResults.removeFirst()
+            }
     }
 }


### PR DESCRIPTION
## Summary
- 작가 프로필 수정 화면에서 사진 접근 권한 미허용 시 전용 안내 화면을 표시합니다.
- 권한 설정 복귀와 거부 상태 테스트를 위해 DevScreen 진입 버튼을 추가합니다.
- Compose 문자열 줄바꿈은 `\n`을 사용하도록 프로젝트 지침을 보강합니다.

## Changes

### app
- Android 13+ 사진 권한 요청을 위한 manifest 권한을 정리했습니다.

### feature/main
- DevScreen에 MyPage 작가 프로필 수정 사진 권한 거부 테스트용 설정 이동 버튼을 추가했습니다.

### feature/mypage
- 사진 권한 상태를 MVI state/intent/side effect로 관리합니다.
- 권한 미허용 시 프로필 수정 폼 대신 전체 권한 안내 화면을 표시합니다.
- 권한 요청, 설정 이동, 이미지 선택 side effect를 분리했습니다.
- 권한 관련 ViewModel 테스트를 추가했습니다.

### docs
- Compose `Text` 줄바꿈 문자열은 `\n`을 사용하도록 AGENTS.md에 기록했습니다.

### 구현 화면

<img width="400" height="867" alt="KakaoTalk_Video_2026-05-03-12-00-20" src="https://github.com/user-attachments/assets/57a12376-412b-46d3-a4e1-84f35b77ec5f" />

## Verification
- `./gradlew ktlintCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :feature:mypage:compileDebugKotlin`
- `./gradlew :feature:mypage:ktlintCheck`
- `./gradlew :feature:main:compileDebugKotlin`
- `./gradlew :feature:main:ktlintCheck`
- `./gradlew installDebug`

Closes #162
