### PR TITLE
✨ 작가 프로필 미리보기 플로우 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ fabric.properties
 /.idea
 
 .claude/
+.omx/

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -19,6 +19,7 @@ import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPageOrderSheet
+import com.hm.picplz.navigation.model.MyPagePackageEdit
 import com.hm.picplz.navigation.model.MyPagePhotographer
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
@@ -36,6 +37,7 @@ import com.hm.picplz.ui.screen.main.MainSearchScreen
 import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
+import com.hm.picplz.ui.screen.my_page.MyPagePackageEditRoute
 import com.hm.picplz.ui.screen.my_page.MyPagePhotographerModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
@@ -94,6 +96,14 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MyPagePhotographerModifyProfile> {
         MyPagePhotographerModifyProfileScreen(navController = navController)
+    }
+
+    composable<MyPagePackageEdit> {
+        MyPagePackageEditRoute(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+        )
     }
 
     composable<MyPageMyReviews> {

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -83,6 +83,8 @@ data class MyPagePhotographer(
 
 @Serializable object MyPagePhotographerModifyProfile : NavigationRoute
 
+@Serializable object MyPagePackageEdit : NavigationRoute
+
 @Serializable object MyPageMyReviews : NavigationRoute
 
 @Serializable
@@ -101,7 +103,10 @@ data class MyPageShootingHistory(
 
 // === Detail Screens ===
 @Serializable
-data class DetailPhotographer(val photographerId: Int) : NavigationRoute
+data class DetailPhotographer(
+    val photographerId: Int,
+    val previewMode: Boolean = false,
+) : NavigationRoute
 
 @Serializable
 data class ReviewPhotographer(val photographerId: Int) : NavigationRoute

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="menu">메뉴</string>
     <string name="booking_button">예약하기</string>
     <string name="booking_unavailable">현재 예약을 받지 않아요</string>
-
     <!-- DetailProfileSection -->
     <string name="instagram">인스타그램</string>
     <string name="quick_shoot_label">바로 촬영</string>

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -44,6 +44,7 @@ import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.navigation.model.MyPage
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageOrderSheet
+import com.hm.picplz.navigation.model.MyPagePackageEdit
 import com.hm.picplz.navigation.model.MyPagePhotographer
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
@@ -178,12 +179,21 @@ fun DevScreen(navController: NavHostController) {
                     ),
                 )
             }
+            DevButton("MyPage (작가 미리보기 테스트)") {
+                navController.navigate(
+                    MyPagePhotographer(
+                        hasPackagePreview = true,
+                        hasPortfolioPreview = false,
+                    ),
+                )
+            }
 
             // === Main Sub Screens ===
             SectionTitle("Main Sub")
             DevButton("MainSearch") { navController.navigate(MainSearch) }
             DevButton("MyPageModifyProfile") { navController.navigate(MyPageModifyProfile) }
             DevButton("MyPagePhotographerModifyProfile") { navController.navigate(MyPagePhotographerModifyProfile) }
+            DevButton("MyPagePackageEdit (패키지 등록 placeholder)") { navController.navigate(MyPagePackageEdit) }
             DevButton("MyPageShootingHistory") { navController.navigate(MyPageShootingHistory()) }
             DevButton("MyPageShootingHistory (Empty)") {
                 navController.navigate(MyPageShootingHistory(forceEmpty = true))
@@ -210,6 +220,9 @@ fun DevScreen(navController: NavHostController) {
             // === Detail Photographer ===
             SectionTitle("Detail Photographer")
             DevButton("DetailPhotographer") { navController.navigate(DetailPhotographer(1)) }
+            DevButton("DetailPhotographer (작가 preview mode)") {
+                navController.navigate(DetailPhotographer(1, previewMode = true))
+            }
             DevButton("DetailPhotographer (차단)") { navController.navigate(DetailPhotographer(-1)) }
             DevButton("ReviewPhotographer") { navController.navigate(ReviewPhotographer(1)) }
             DevButton("DetailPhotographerPhotoReviews") {

--- a/feature/mypage/src/androidTest/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreenTest.kt
+++ b/feature/mypage/src/androidTest/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreenTest.kt
@@ -7,13 +7,14 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.platform.app.InstrumentationRegistry
 import com.hm.picplz.feature.mypage.R
 import com.hm.picplz.ui.theme.PicplzTheme
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import com.hm.picplz.core.ui.R as CoreR
 
 class MyPageScreenTest {
     @get:Rule
@@ -53,6 +54,7 @@ class MyPageScreenTest {
     @Test
     fun photographerPreviewButtonIsEnabledWithPackage() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val intents = mutableListOf<MyPageIntent>()
 
         composeRule.setContent {
             PicplzTheme {
@@ -61,14 +63,14 @@ class MyPageScreenTest {
                         photographerState(
                             packagePreview =
                                 PhotographerPackagePreview(
-                                    imageResId = CoreR.drawable.logo,
+                                    imageUrl = "https://picsum.photos/seed/test-package/300/200",
                                     title = "남친생기는 프사",
                                     price = 66000,
                                     meta = "프로필 촬영 · 30분",
                                     description = "원본 20장과 보정본 3장을 제공해요.",
                                 ),
                         ),
-                    onIntent = {},
+                    onIntent = { intents += it },
                     navController = rememberNavController(),
                 )
             }
@@ -77,6 +79,11 @@ class MyPageScreenTest {
         composeRule
             .onNodeWithText(context.getString(R.string.my_page_preview_profile))
             .assertIsEnabled()
+            .performClick()
+
+        composeRule.runOnIdle {
+            assertTrue(intents.contains(MyPageIntent.NavigateToPhotographerPreview))
+        }
 
         composeRule.onNodeWithText("남친생기는 프사").assertIsDisplayed()
 
@@ -132,12 +139,35 @@ class MyPageScreenTest {
             .assertIsDisplayed()
     }
 
+    @Test
+    fun packageEditPlaceholderShowsDisabledSave() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        composeRule.setContent {
+            PicplzTheme {
+                MyPagePackageEditScreen(
+                    state = MyPagePackageEditState.idle(),
+                    onIntent = {},
+                )
+            }
+        }
+
+        composeRule
+            .onNodeWithText(context.getString(R.string.package_edit_placeholder_title))
+            .assertIsDisplayed()
+
+        composeRule
+            .onNodeWithText(context.getString(R.string.package_edit_save))
+            .assertIsNotEnabled()
+    }
+
     private fun photographerState(packagePreview: PhotographerPackagePreview?): MyPageState {
         return MyPageState(
             nickname = "임두현",
             hasPhotographerRole = true,
             photographerProfile =
                 PhotographerProfile(
+                    photographerId = 1,
                     displayName = "유가영 작가",
                     followerCount = 128,
                     packageCount = if (packagePreview == null) 0 else 1,

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditIntent.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePackageEditIntent {
+    data object NavigateBack : MyPagePackageEditIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditScreen.kt
@@ -1,0 +1,126 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonFixedTopBar
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun MyPagePackageEditRoute(
+    viewModel: MyPagePackageEditViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is MyPagePackageEditSideEffect.NavigateBack -> onNavigateBack()
+            }
+        }
+    }
+
+    MyPagePackageEditScreen(
+        state = state,
+        onIntent = viewModel::handleIntent,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun MyPagePackageEditScreen(
+    state: MyPagePackageEditState,
+    onIntent: (MyPagePackageEditIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonFixedTopBar(
+                title = stringResource(R.string.package_edit_title),
+                onClickBack = { onIntent(MyPagePackageEditIntent.NavigateBack) },
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 24.dp),
+            ) {
+                CommonBottomButton(
+                    text = stringResource(R.string.package_edit_save),
+                    onClick = {},
+                    enabled = state.isSaveEnabled,
+                )
+            }
+        },
+        modifier =
+            modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(MainThemeColor.White)
+                    .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(120.dp))
+            Text(
+                text = stringResource(R.string.package_edit_placeholder_title),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.package_edit_placeholder_description),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun MyPagePackageEditScreenPreview() {
+    PicplzTheme {
+        MyPagePackageEditScreen(
+            state = MyPagePackageEditState.idle(),
+            onIntent = {},
+        )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePackageEditSideEffect {
+    data object NavigateBack : MyPagePackageEditSideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditState.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.ui.screen.my_page
+
+data class MyPagePackageEditState(
+    val isSaveEnabled: Boolean = false,
+) {
+    companion object {
+        fun idle() = MyPagePackageEditState()
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModel.kt
@@ -1,0 +1,34 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyPagePackageEditViewModel
+    @Inject
+    constructor() : ViewModel() {
+        private val _state = MutableStateFlow(MyPagePackageEditState.idle())
+        val state: StateFlow<MyPagePackageEditState> = _state
+
+        private val _sideEffect = Channel<MyPagePackageEditSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        fun handleIntent(intent: MyPagePackageEditIntent) {
+            when (intent) {
+                is MyPagePackageEditIntent.NavigateBack -> sendSideEffect(MyPagePackageEditSideEffect.NavigateBack)
+            }
+        }
+
+        private fun sendSideEffect(effect: MyPagePackageEditSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.send(effect)
+            }
+        }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -66,9 +66,11 @@ import coil.compose.AsyncImage
 import com.hm.picplz.common.model.User
 import com.hm.picplz.common.model.UserType
 import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageMyReviews
+import com.hm.picplz.navigation.model.MyPagePackageEdit
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.SignUpPhotographer
@@ -128,6 +130,9 @@ fun MyPageScreen(
                 is MyPageSideEffect.NavigateToPhotographerModifyProfile -> {
                     navController.navigate(MyPagePhotographerModifyProfile)
                 }
+                is MyPageSideEffect.NavigateToPackageEdit -> {
+                    navController.navigate(MyPagePackageEdit)
+                }
                 is MyPageSideEffect.NavigateToMyReviews -> {
                     navController.navigate(MyPageMyReviews)
                 }
@@ -136,6 +141,14 @@ fun MyPageScreen(
                 }
                 is MyPageSideEffect.NavigateToShootingHistory -> {
                     navController.navigate(MyPageShootingHistory)
+                }
+                is MyPageSideEffect.NavigateToPhotographerPreview -> {
+                    navController.navigate(
+                        DetailPhotographer(
+                            photographerId = effect.photographerId,
+                            previewMode = true,
+                        ),
+                    )
                 }
                 is MyPageSideEffect.NavigateToSettings -> {
                     toastMessage = context.getString(R.string.my_page_settings_pending)
@@ -535,6 +548,8 @@ private fun PhotographerProfileCard(
 
         Spacer(modifier = Modifier.height(20.dp))
 
+        val canPreviewProfile = photographerProfile.canPreviewProfile
+
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(5.dp),
@@ -551,7 +566,7 @@ private fun PhotographerProfileCard(
                 modifier = Modifier.weight(1f),
                 isPrimary = false,
                 showArrow = true,
-                enabled = photographerProfile.hasPackages,
+                enabled = canPreviewProfile,
             )
         }
 

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
@@ -7,6 +7,8 @@ sealed interface MyPageSideEffect {
 
     data object NavigateToPhotographerModifyProfile : MyPageSideEffect
 
+    data object NavigateToPackageEdit : MyPageSideEffect
+
     data object NavigateToMyReviews : MyPageSideEffect
 
     data object NavigateToFollowedPhotographers : MyPageSideEffect
@@ -14,6 +16,8 @@ sealed interface MyPageSideEffect {
     data object NavigateToShootingHistory : MyPageSideEffect
 
     data object NavigateToSettings : MyPageSideEffect
+
+    data class NavigateToPhotographerPreview(val photographerId: Int) : MyPageSideEffect
 
     data class ShowToast(val messageResId: Int) : MyPageSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageState.kt
@@ -14,6 +14,7 @@ data class MyPageState(
 }
 
 data class PhotographerProfile(
+    val photographerId: Int = 0,
     val displayName: String = "",
     val profileImageUri: String = "",
     val followerCount: Int = 0,
@@ -29,7 +30,10 @@ data class PhotographerProfile(
     val packagePreview: PhotographerPackagePreview? = null,
     val portfolioPreviewImageUrls: List<String> = emptyList(),
     val satisfactionSummary: PhotographerSatisfactionSummary = PhotographerSatisfactionSummary(),
-)
+) {
+    val canPreviewProfile: Boolean
+        get() = hasPackages && photographerId > 0
+}
 
 data class PhotographerPackagePreview(
     val imageUrl: String,

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -54,9 +54,13 @@ class MyPageViewModel
                     sendSideEffect(MyPageSideEffect.NavigateToPhotographerSignUp)
                 }
                 is MyPageIntent.NavigateToPhotographerPreview -> {
-                    val hasPackages = _state.value.photographerProfile.hasPackages
-                    if (hasPackages) {
-                        sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_preview_pending))
+                    val photographerProfile = _state.value.photographerProfile
+                    if (photographerProfile.canPreviewProfile) {
+                        sendSideEffect(
+                            MyPageSideEffect.NavigateToPhotographerPreview(
+                                photographerProfile.photographerId,
+                            ),
+                        )
                     } else {
                         sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_preview_requires_package))
                     }
@@ -74,7 +78,7 @@ class MyPageViewModel
                     sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_settlement_pending))
                 }
                 is MyPageIntent.NavigateToPackageEdit -> {
-                    sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_package_edit_pending))
+                    sendSideEffect(MyPageSideEffect.NavigateToPackageEdit)
                 }
                 is MyPageIntent.NavigateToPortfolioEdit -> {
                     sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_portfolio_edit_pending))
@@ -142,6 +146,7 @@ class MyPageViewModel
                     ongoingShootings = emptyList(),
                     photographerProfile =
                         PhotographerProfile(
+                            photographerId = 1,
                             displayName = "유가영 작가",
                             profileImageUri = "",
                             followerCount = 128,

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -87,6 +87,10 @@
     <string name="my_page_portfolio_edit_pending">포트폴리오 편집 기능은 준비 중입니다.</string>
     <string name="my_page_preview_pending">프로필 미리보기 기능은 준비 중입니다.</string>
     <string name="my_page_preview_requires_package">촬영 패키지를 등록해야 미리보기 화면을 볼 수 있습니다.</string>
+    <string name="package_edit_title">촬영 패키지 등록</string>
+    <string name="package_edit_placeholder_title">패키지 등록을 준비 중입니다</string>
+    <string name="package_edit_placeholder_description">지금은 미리보기 진입 조건만 확인할 수 있으며, 실제 패키지 등록은 추후 API 연동 후 지원됩니다.</string>
+    <string name="package_edit_save">저장</string>
 
     <!-- 프로필 수정 -->
     <string name="modify_profile_title">프로필 수정</string>

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModelTest.kt
@@ -1,0 +1,39 @@
+package com.hm.picplz.ui.screen.my_page
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyPagePackageEditViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `initial state disables save`() {
+        val viewModel = MyPagePackageEditViewModel()
+
+        assertFalse(viewModel.state.value.isSaveEnabled)
+    }
+
+    @Test
+    fun `navigate back emits navigation side effect`() =
+        runTest {
+            val viewModel = MyPagePackageEditViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPagePackageEditIntent.NavigateBack)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPagePackageEditSideEffect.NavigateBack,
+                sideEffectDeferred.await(),
+            )
+        }
+}

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -43,4 +45,62 @@ class MyPageViewModelTest {
                 sideEffectDeferred.await(),
             )
         }
+
+    @Test
+    fun `navigate to package edit emits dedicated navigation side effect`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToPackageEdit)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPageSideEffect.NavigateToPackageEdit,
+                sideEffectDeferred.await(),
+            )
+        }
+
+    @Test
+    fun `photographer preview without package emits requires package toast`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToPhotographerPreview)
+            advanceUntilIdle()
+
+            assertEquals(
+                MyPageSideEffect.ShowToast(com.hm.picplz.feature.mypage.R.string.my_page_preview_requires_package),
+                sideEffectDeferred.await(),
+            )
+        }
+
+    @Test
+    fun `photographer preview with package emits detail navigation side effect`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            viewModel.handleIntent(
+                MyPageIntent.ApplyDevPhotographerPreview(
+                    hasShootings = false,
+                    hasPackagePreview = true,
+                    hasPortfolioPreview = false,
+                ),
+            )
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToPhotographerPreview)
+            advanceUntilIdle()
+
+            val sideEffect = sideEffectDeferred.await()
+            assertTrue(sideEffect is MyPageSideEffect.NavigateToPhotographerPreview)
+            assertEquals(1, (sideEffect as MyPageSideEffect.NavigateToPhotographerPreview).photographerId)
+        }
+
+    @Test
+    fun `photographer preview availability requires package and photographer id`() {
+        assertFalse(PhotographerProfile(hasPackages = false, photographerId = 1).canPreviewProfile)
+        assertFalse(PhotographerProfile(hasPackages = true, photographerId = 0).canPreviewProfile)
+        assertTrue(PhotographerProfile(hasPackages = true, photographerId = 1).canPreviewProfile)
+    }
 }

--- a/feature/photographer/build.gradle.kts
+++ b/feature/photographer/build.gradle.kts
@@ -60,5 +60,8 @@ dependencies {
     // Kakao Map
     implementation(libs.kakao.maps)
 
+    testImplementation(libs.junit)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+
     debugImplementation(libs.androidx.ui.tooling)
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerIntent.kt
@@ -5,6 +5,8 @@ import com.hm.picplz.ui.screen.detail_photographer.review.ReviewSortType
 sealed interface DetailPhotographerIntent {
     data object NavigateToPrev : DetailPhotographerIntent
 
+    data object SelectBooking : DetailPhotographerIntent
+
     data object ToggleFollow : DetailPhotographerIntent
 
     data object ToggleInfoExpanded : DetailPhotographerIntent
@@ -24,6 +26,8 @@ sealed interface DetailPhotographerIntent {
     data object DismissFullScreenPhoto : DetailPhotographerIntent
 
     data object ToggleReportSheet : DetailPhotographerIntent
+
+    data object DismissPreviewActionDialog : DetailPhotographerIntent
 
     data class SwitchReview(val reviewIndex: Int) : DetailPhotographerIntent
 

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerScreen.kt
@@ -14,33 +14,39 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonButtonModal
 import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.detail_photographer.review.ReportBottomSheet
 import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
 import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.feature.photographer.R as PhotographerR
 
 @Composable
 fun DetailPhotographerScreen(
     viewModel: DetailPhotographerViewModel = hiltViewModel(),
     navController: NavHostController,
 ) {
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val paddingModifier = Modifier.padding(horizontal = 15.dp)
 
     Scaffold(
@@ -82,7 +88,9 @@ fun DetailPhotographerScreen(
                         } else {
                             stringResource(R.string.booking_unavailable)
                         },
-                    onClick = { },
+                    onClick = {
+                        viewModel.handleIntent(DetailPhotographerIntent.SelectBooking)
+                    },
                     enabled = state.profileInfo.isBookable,
                 )
             }
@@ -166,7 +174,11 @@ fun DetailPhotographerScreen(
         onBlock = {
             viewModel.handleIntent(DetailPhotographerIntent.ToggleBlock)
         },
-        onReport = { /* TODO: 작가 신고 플로우 (리뷰 신고와 별개) */ },
+        onReport = {
+            if (state.isPreviewMode) {
+                viewModel.handleIntent(DetailPhotographerIntent.ToggleReportSheet)
+            }
+        },
     )
 
     // 리뷰 신고 바텀시트
@@ -177,6 +189,15 @@ fun DetailPhotographerScreen(
         },
         onSelect = { /* TODO: 신고 API 연동 */ },
     )
+
+    state.previewActionDialog?.let { action ->
+        DetailPreviewActionDialog(
+            action = action,
+            onDismiss = {
+                viewModel.handleIntent(DetailPhotographerIntent.DismissPreviewActionDialog)
+            },
+        )
+    }
 
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collectLatest { sideEffect ->
@@ -196,6 +217,50 @@ fun DetailPhotographerScreen(
         },
     )
 }
+
+@Composable
+private fun DetailPreviewActionDialog(
+    action: DetailPreviewAction,
+    onDismiss: () -> Unit,
+) {
+    CommonButtonModal(
+        onDismissRequest = onDismiss,
+        cancelText = stringResource(PhotographerR.string.preview_action_dialog_cancel),
+        confirmText = stringResource(PhotographerR.string.preview_action_dialog_confirm),
+        onCancel = onDismiss,
+        onConfirm = onDismiss,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(PhotographerR.string.preview_action_dialog_title),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            Text(
+                text = stringResource(previewActionDescriptionResId(action)),
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+private fun previewActionDescriptionResId(action: DetailPreviewAction): Int =
+    when (action) {
+        DetailPreviewAction.Booking -> PhotographerR.string.preview_action_dialog_booking
+        DetailPreviewAction.Follow -> PhotographerR.string.preview_action_dialog_follow
+        DetailPreviewAction.Block -> PhotographerR.string.preview_action_dialog_block
+        DetailPreviewAction.Report -> PhotographerR.string.preview_action_dialog_report
+    }
 
 @Composable
 private fun SectionDivider() {

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerState.kt
@@ -13,6 +13,7 @@ import com.hm.picplz.data.model.ShootingPackage
 import com.hm.picplz.ui.screen.detail_photographer.review.ReviewSortType
 
 data class DetailPhotographerState(
+    val isPreviewMode: Boolean = false,
     val profileInfo: PhotographerInfo = mockPhotographerInfo,
     val reviewSummary: PhotographerReviewSummary = mockReviewSummary,
     val reviews: List<PhotographerReview> = mockReviews,
@@ -28,6 +29,7 @@ data class DetailPhotographerState(
     val currentReviewIndex: Int = 0,
     val fullScreenImageUri: String? = null,
     val isReportSheetVisible: Boolean = false,
+    val previewActionDialog: DetailPreviewAction? = null,
     val toastMessage: String? = null,
 ) {
     companion object {
@@ -35,8 +37,30 @@ data class DetailPhotographerState(
             return DetailPhotographerState()
         }
 
+        fun preview(): DetailPhotographerState {
+            return DetailPhotographerState(
+                isPreviewMode = true,
+                profileInfo = mockPhotographerInfo.copy(photoPortfolios = emptyList()),
+                reviewSummary =
+                    mockReviewSummary.copy(
+                        totalReviewCount = 0,
+                        totalPhotoReviewCount = 0,
+                        photoReviews = emptyList(),
+                    ),
+                reviews = emptyList(),
+                portfolios = emptyList(),
+            )
+        }
+
         fun blocked(): DetailPhotographerState {
             return DetailPhotographerState(isBlocked = true)
         }
     }
+}
+
+enum class DetailPreviewAction {
+    Booking,
+    Follow,
+    Block,
+    Report,
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModel.kt
@@ -21,14 +21,19 @@ open class DetailPhotographerViewModel
         private val photographerService: PhotographerService,
     ) : ViewModel() {
         val photographerId: Int = savedStateHandle.get<Int>("photographerId") ?: 0
+        private val isPreviewMode: Boolean = savedStateHandle.get<Boolean>("previewMode") ?: false
 
         private val _state =
             MutableStateFlow(
-                if (photographerId == DEV_BLOCKED_PHOTOGRAPHER_ID) {
-                    DetailPhotographerState.blocked()
-                } else {
-                    DetailPhotographerState.idle()
-                },
+                (
+                    if (isPreviewMode) {
+                        DetailPhotographerState.preview()
+                    } else if (photographerId == DEV_BLOCKED_PHOTOGRAPHER_ID) {
+                        DetailPhotographerState.blocked()
+                    } else {
+                        DetailPhotographerState.idle()
+                    }
+                ),
             )
         val state: StateFlow<DetailPhotographerState> = _state
 
@@ -36,7 +41,9 @@ open class DetailPhotographerViewModel
         val sideEffect = _sideEffect.receiveAsFlow()
 
         init {
-            loadPhotographerInfo()
+            if (!isPreviewMode) {
+                loadPhotographerInfo()
+            }
         }
 
         fun handleIntent(intent: DetailPhotographerIntent) {
@@ -46,20 +53,33 @@ open class DetailPhotographerViewModel
                         _sideEffect.send(DetailPhotographerSideEffect.NavigateToPrev)
                     }
                 }
+                is DetailPhotographerIntent.SelectBooking -> {
+                    if (isPreviewMode) {
+                        handlePreviewAction(DetailPreviewAction.Booking)
+                    }
+                }
                 is DetailPhotographerIntent.ToggleFollow -> {
-                    _state.update { it.copy(isFollow = !it.isFollow) }
+                    if (isPreviewMode) {
+                        handlePreviewAction(DetailPreviewAction.Follow)
+                    } else {
+                        _state.update { it.copy(isFollow = !it.isFollow) }
+                    }
                 }
                 is DetailPhotographerIntent.ToggleInfoExpanded -> {
                     _state.update { it.copy(isInfoExpanded = !it.isInfoExpanded) }
                 }
                 is DetailPhotographerIntent.ToggleBlock -> {
-                    val wasBlocked = _state.value.isBlocked
-                    val name = _state.value.profileInfo.name
-                    _state.update {
-                        it.copy(
-                            isBlocked = !it.isBlocked,
-                            toastMessage = if (!wasBlocked) "'$name'님이 차단되었습니다." else null,
-                        )
+                    if (isPreviewMode) {
+                        handlePreviewAction(DetailPreviewAction.Block)
+                    } else {
+                        val wasBlocked = _state.value.isBlocked
+                        val name = _state.value.profileInfo.name
+                        _state.update {
+                            it.copy(
+                                isBlocked = !it.isBlocked,
+                                toastMessage = if (!wasBlocked) "'$name'님이 차단되었습니다." else null,
+                            )
+                        }
                     }
                 }
                 is DetailPhotographerIntent.ToggleAreaExpanded -> {
@@ -86,9 +106,16 @@ open class DetailPhotographerViewModel
                     _state.update { it.copy(fullScreenImageUri = null) }
                 }
                 is DetailPhotographerIntent.ToggleReportSheet -> {
-                    _state.update {
-                        it.copy(isReportSheetVisible = !it.isReportSheetVisible)
+                    if (isPreviewMode) {
+                        handlePreviewAction(DetailPreviewAction.Report)
+                    } else {
+                        _state.update {
+                            it.copy(isReportSheetVisible = !it.isReportSheetVisible)
+                        }
                     }
+                }
+                is DetailPhotographerIntent.DismissPreviewActionDialog -> {
+                    _state.update { it.copy(previewActionDialog = null) }
                 }
                 is DetailPhotographerIntent.SwitchReview -> {
                     _state.update { it.copy(currentReviewIndex = intent.reviewIndex) }
@@ -101,6 +128,10 @@ open class DetailPhotographerViewModel
 
         companion object {
             const val DEV_BLOCKED_PHOTOGRAPHER_ID = -1
+        }
+
+        private fun handlePreviewAction(action: DetailPreviewAction) {
+            _state.update { it.copy(previewActionDialog = action) }
         }
 
         private fun loadPhotographerInfo() {

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -33,6 +33,15 @@
     <string name="blocked_account_message">차단된 계정입니다.</string>
     <string name="unblock_button">차단 해제</string>
 
+    <!-- 작가 상세 - 미리보기 안내 -->
+    <string name="preview_action_dialog_title">미리보기에서는 이용할 수 없는 기능입니다</string>
+    <string name="preview_action_dialog_booking">고객 예약 동작은 미리보기에서 실행되지 않습니다.</string>
+    <string name="preview_action_dialog_follow">고객 팔로우 동작은 미리보기에서 실행되지 않습니다.</string>
+    <string name="preview_action_dialog_block">고객 차단 동작은 미리보기에서 실행되지 않습니다.</string>
+    <string name="preview_action_dialog_report">고객 신고 동작은 미리보기에서 실행되지 않습니다.</string>
+    <string name="preview_action_dialog_cancel">닫기</string>
+    <string name="preview_action_dialog_confirm">확인</string>
+
     <!-- 리뷰 페이지 -->
     <string name="review_title">리뷰</string>
     <string name="shooting_satisfaction">촬영 만족도</string>

--- a/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModelTest.kt
+++ b/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModelTest.kt
@@ -1,0 +1,174 @@
+package com.hm.picplz.ui.screen.detail_photographer
+
+import androidx.lifecycle.SavedStateHandle
+import com.hm.picplz.data.model.CreatePhotographerRequest
+import com.hm.picplz.data.model.PhotographerInfo
+import com.hm.picplz.data.model.PhotographerRatingDto
+import com.hm.picplz.data.model.PortfolioDto
+import com.hm.picplz.data.model.ProductDto
+import com.hm.picplz.data.model.ReviewListDto
+import com.hm.picplz.data.service.PhotographerService
+import com.hm.picplz.domain.model.FilteredPhotographers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailPhotographerViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `preview mode does not load photographer info`() =
+        runTest {
+            val service = FakePhotographerService()
+
+            DetailPhotographerViewModel(
+                savedStateHandle = previewSavedStateHandle(),
+                photographerService = service,
+            )
+            advanceUntilIdle()
+
+            assertEquals(0, service.getPhotographerInfoCallCount)
+        }
+
+    @Test
+    fun `preview mode starts with empty reviews and portfolios`() =
+        runTest {
+            val viewModel =
+                DetailPhotographerViewModel(
+                    savedStateHandle = previewSavedStateHandle(),
+                    photographerService = FakePhotographerService(),
+                )
+
+            assertTrue(viewModel.state.value.isPreviewMode)
+            assertTrue(viewModel.state.value.reviews.isEmpty())
+            assertTrue(viewModel.state.value.portfolios.isEmpty())
+            assertEquals(0, viewModel.state.value.reviewSummary.totalReviewCount)
+            assertEquals(0, viewModel.state.value.reviewSummary.totalPhotoReviewCount)
+            assertTrue(viewModel.state.value.reviewSummary.photoReviews.isEmpty())
+            assertTrue(viewModel.state.value.profileInfo.photoPortfolios.isEmpty())
+            assertTrue(viewModel.state.value.shootingPackages.isNotEmpty())
+        }
+
+    @Test
+    fun `booking in preview mode shows preview action dialog`() =
+        runTest {
+            val viewModel =
+                DetailPhotographerViewModel(
+                    savedStateHandle = previewSavedStateHandle(),
+                    photographerService = FakePhotographerService(),
+                )
+
+            viewModel.handleIntent(DetailPhotographerIntent.SelectBooking)
+            advanceUntilIdle()
+
+            assertEquals(DetailPreviewAction.Booking, viewModel.state.value.previewActionDialog)
+        }
+
+    @Test
+    fun `follow in preview mode shows dialog without changing follow state`() =
+        runTest {
+            val viewModel =
+                DetailPhotographerViewModel(
+                    savedStateHandle = previewSavedStateHandle(),
+                    photographerService = FakePhotographerService(),
+                )
+            val initialFollowState = viewModel.state.value.isFollow
+
+            viewModel.handleIntent(DetailPhotographerIntent.ToggleFollow)
+            advanceUntilIdle()
+
+            assertEquals(DetailPreviewAction.Follow, viewModel.state.value.previewActionDialog)
+            assertEquals(initialFollowState, viewModel.state.value.isFollow)
+        }
+
+    @Test
+    fun `normal mode follow toggles follow state`() =
+        runTest {
+            val service = FakePhotographerService()
+            val viewModel =
+                DetailPhotographerViewModel(
+                    savedStateHandle = normalSavedStateHandle(),
+                    photographerService = service,
+                )
+            advanceUntilIdle()
+            val initialFollowState = viewModel.state.value.isFollow
+
+            viewModel.handleIntent(DetailPhotographerIntent.ToggleFollow)
+
+            assertFalse(viewModel.state.value.isPreviewMode)
+            assertEquals(1, service.getPhotographerInfoCallCount)
+            assertTrue(viewModel.state.value.previewActionDialog == null)
+            assertEquals(!initialFollowState, viewModel.state.value.isFollow)
+        }
+
+    @Test
+    fun `booking in normal mode keeps existing no-op behavior`() =
+        runTest {
+            val viewModel =
+                DetailPhotographerViewModel(
+                    savedStateHandle = normalSavedStateHandle(),
+                    photographerService = FakePhotographerService(),
+                )
+
+            viewModel.handleIntent(DetailPhotographerIntent.SelectBooking)
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.previewActionDialog == null)
+        }
+
+    private fun previewSavedStateHandle() =
+        SavedStateHandle(
+            mapOf(
+                "photographerId" to 1,
+                "previewMode" to true,
+            ),
+        )
+
+    private fun normalSavedStateHandle() =
+        SavedStateHandle(
+            mapOf(
+                "photographerId" to 1,
+                "previewMode" to false,
+            ),
+        )
+}
+
+private class FakePhotographerService : PhotographerService {
+    var getPhotographerInfoCallCount = 0
+        private set
+
+    override suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit> = Result.success(Unit)
+
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): Result<FilteredPhotographers> = Result.failure(NotImplementedError())
+
+    override suspend fun getPhotographerInfo(photographerId: Long): Result<PhotographerInfo> {
+        getPhotographerInfoCallCount += 1
+        return Result.failure(NotImplementedError())
+    }
+
+    override suspend fun getPhotographerRating(photographerId: Long): Result<PhotographerRatingDto> =
+        Result.failure(NotImplementedError())
+
+    override suspend fun getPhotographerReviews(
+        photographerId: Long,
+        page: Int,
+        size: Int,
+        sort: String,
+    ): Result<ReviewListDto> = Result.failure(NotImplementedError())
+
+    override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+        Result.failure(NotImplementedError())
+
+    override suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto> = Result.failure(NotImplementedError())
+}

--- a/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/MainDispatcherRule.kt
+++ b/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.ui.screen.detail_photographer
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## Summary
- 작가 MyPage에서 패키지 조건을 만족하면 기존 작가 상세 화면으로 미리보기 진입을 연결했습니다.
- 패키지 등록 화면은 placeholder로 추가하고, preview mode에서는 실제 사용자 액션 대신 안내 다이얼로그를 표시합니다.

## Changes

### navigation
- `DetailPhotographer` route에 `previewMode` 옵션을 추가했습니다.
- `MyPagePackageEdit` route와 MyPage package edit graph를 추가했습니다.

### feature/mypage
- `PhotographerProfile.canPreviewProfile`로 미리보기 버튼 활성화 조건을 선언형으로 분리했습니다.
- 미리보기/패키지 등록 side effect를 실제 navigation으로 연결했습니다.
- 패키지 등록 placeholder UI와 ViewModel, 단위/계측 테스트를 추가했습니다.

### feature/photographer
- preview mode에서는 service load를 건너뛰고 empty reviews/portfolios + mock packages를 사용합니다.
- 예약/팔로우/차단/신고 액션은 실제 동작 대신 preview 안내 다이얼로그로 차단합니다.
- preview mode 및 normal mode 회귀 테스트를 추가했습니다.

### dev
- DevScreen에 MyPage preview, package edit placeholder, DetailPhotographer preview mode 진입 버튼을 추가했습니다.

## 구현화면

<img width="315" height="683" alt="KakaoTalk_Video_2026-05-03-21-41-55 (1)" src="https://github.com/user-attachments/assets/c2a3be2c-e7ef-4af7-97c1-0435ac9fcda9" />


## Verification
- `./gradlew ktlintCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :feature:mypage:compileDebugKotlin`
- `./gradlew :feature:photographer:compileDebugKotlin`
- `./gradlew :feature:main:compileDebugKotlin`
- `./gradlew :feature:mypage:testDebugUnitTest`
- `./gradlew :feature:photographer:testDebugUnitTest`
- `./gradlew :feature:mypage:compileDebugAndroidTestKotlin`

Closes #164

