### PR TITLE
✨ 작가 - 예약 신청 알림 채팅 메시지 구현

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -24,6 +24,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographer
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
+import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationScreen
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
@@ -43,6 +44,7 @@ import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
+import com.hm.picplz.ui.screen.photographer_chat_room.PhotographerChatRoomScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
@@ -69,6 +71,16 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
     composable<ChatRoom> { backStackEntry ->
         val args = backStackEntry.toRoute<ChatRoom>()
         ChatRoomScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            _roomId = args.roomId,
+        )
+    }
+
+    composable<PhotographerChatRoom> { backStackEntry ->
+        val args = backStackEntry.toRoute<PhotographerChatRoom>()
+        PhotographerChatRoomScreen(
             onNavigateBack = {
                 navController.popBackStack()
             },

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -68,7 +68,12 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<ChatRoom> { backStackEntry ->
         val args = backStackEntry.toRoute<ChatRoom>()
-        ChatRoomScreen(navController = navController, _roomId = args.roomId)
+        ChatRoomScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            _roomId = args.roomId,
+        )
     }
 
     composable<MyPage> {

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -139,3 +139,6 @@ data class OrderDetail(val orderId: String) : NavigationRoute
 
 @Serializable
 data class CancelReservation(val orderId: String) : NavigationRoute
+
+@Serializable
+data class PhotographerChatRoom(val roomId: String) : NavigationRoute

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -30,8 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.domain.model.ButtonActionType
 import com.hm.picplz.domain.model.MessageContent
@@ -54,13 +53,40 @@ import com.hm.picplz.ui.theme.Pretendard
 
 @Composable
 fun ChatRoomScreen(
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ChatRoomViewModel = hiltViewModel(),
-    navController: NavHostController,
     @Suppress("UNUSED_PARAMETER") _roomId: String,
 ) {
-    val currentState = viewModel.state.collectAsState().value
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is ChatRoomSideEffect.NavigateToPrev -> onNavigateBack()
+            }
+        }
+    }
+
+    ChatRoomScreenContent(
+        modifier = modifier,
+        state = state,
+        onBackClick = {
+            viewModel.handleIntent(ChatRoomIntent.NavigateToPrev)
+        },
+        onMenuClick = {
+            // TODO: Implement menu click action
+        },
+    )
+}
+
+@Composable
+private fun ChatRoomScreenContent(
+    state: ChatRoomState,
+    onBackClick: () -> Unit,
+    onMenuClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(
         containerColor = MainThemeColor.White,
         topBar = {
@@ -68,14 +94,8 @@ fun ChatRoomScreen(
                 text = "유가영 작가",
                 subText = "당장 촬영 가능",
                 subTextStyle = caption.copy(color = MainThemeColor.Green120),
-                onClickBack = {
-                    viewModel.handleIntent(
-                        ChatRoomIntent.NavigateToPrev,
-                    )
-                },
-                onClickMenu = {
-                    // TODO: Implement menu click action
-                },
+                onClickBack = onBackClick,
+                onClickMenu = onMenuClick,
             )
         },
         modifier =
@@ -90,7 +110,7 @@ fun ChatRoomScreen(
                     .padding(innerPadding),
         ) {
             ReservationStep(
-                reservationStep = currentState.reservationStep,
+                reservationStep = state.reservationStep,
             )
             Box(
                 modifier =
@@ -264,26 +284,16 @@ fun ChatRoomScreen(
             ChatInput()
         }
     }
-
-    LaunchedEffect(Unit) {
-        viewModel.sideEffect.collect { sideEffect ->
-            when (sideEffect) {
-                is ChatRoomSideEffect.NavigateToPrev -> {
-                    navController.popBackStack()
-                }
-            }
-        }
-    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun ChatRoomScreenPreview() {
-    val navController = rememberNavController()
+private fun ChatRoomScreenPreview() {
     PicplzTheme {
-        ChatRoomScreen(
-            navController = navController,
-            _roomId = "1",
+        ChatRoomScreenContent(
+            state = ChatRoomState.idle(),
+            onBackClick = {},
+            onMenuClick = {},
         )
     }
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
@@ -346,6 +346,39 @@ val dummyChatMessages =
         ),
     )
 
+val dummyReservationChatMessages =
+    listOf(
+        ChatMessage(
+            id = 100,
+            direction = MessageDirection.RECEIVED,
+            sender =
+                User(
+                    id = "2",
+                    nickname = "유가영작가",
+                    profileImageUri = "https://pbs.twimg.com/media/GlRFZh2akAA6KLR?format=jpg&name=large",
+                ),
+            receiver =
+                User(
+                    id = "1",
+                    nickname = "나",
+                    profileImageUri = null,
+                ),
+            content =
+                MessageContent.Notification(
+                    title = "[자연스러운프사] 상품",
+                    subtitle = "예약 신청이 도착했어요",
+                    content = "애니프사 님으로부터 [자연스러운프사] 예약이 도착했습니다.",
+                    type = NotificationType.POSITIVE,
+                    button =
+                        MessageButton(
+                            text = "예약 정보 확인",
+                            actionType = ButtonActionType.CONFIRM_ORDER,
+                        ),
+                ),
+            timestamp = System.currentTimeMillis() - 1000,
+        ),
+    )
+
 val dummySuggestedChat =
     listOf(
         "촬영 소요 시간은 얼마나 걸리나요",

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
@@ -346,6 +346,10 @@ val dummyChatMessages =
         ),
     )
 
+val reservationCustomerName = "애니프사"
+val reservationProductName = "자연스러운프사"
+val reservationProfileUri = "https://pbs.twimg.com/media/GlRFZh2akAA6KLR?format=jpg&name=large"
+
 val dummyReservationChatMessages =
     listOf(
         ChatMessage(
@@ -354,8 +358,8 @@ val dummyReservationChatMessages =
             sender =
                 User(
                     id = "2",
-                    nickname = "유가영작가",
-                    profileImageUri = "https://pbs.twimg.com/media/GlRFZh2akAA6KLR?format=jpg&name=large",
+                    nickname = reservationCustomerName,
+                    profileImageUri = reservationProfileUri,
                 ),
             receiver =
                 User(
@@ -365,9 +369,9 @@ val dummyReservationChatMessages =
                 ),
             content =
                 MessageContent.Notification(
-                    title = "[자연스러운프사] 상품",
+                    title = "[$reservationProductName] 상품",
                     subtitle = "예약 신청이 도착했어요",
-                    content = "애니프사 님으로부터 [자연스러운프사] 예약이 도착했습니다.",
+                    content = "$reservationCustomerName 님으로부터 [$reservationProductName] 예약이 도착했습니다.",
                     type = NotificationType.POSITIVE,
                     button =
                         MessageButton(

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/ReservationStep.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/ReservationStep.kt
@@ -58,7 +58,7 @@ fun ReservationStep(
                 color = MainThemeColor.Black,
             )
             Text(
-                text = "서비스 진행",
+                text = "예약 진행",
                 style = caption,
                 color =
                     if (

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.composable
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,20 +8,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -57,6 +54,7 @@ internal fun ChatRoomScreenContent(
     onBackClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
+    reservationInfoSection: @Composable (() -> Unit)? = null,
 ) {
     val chatListItem =
         remember(chatMessages) {
@@ -94,22 +92,12 @@ internal fun ChatRoomScreenContent(
             ReservationStep(
                 reservationStep = reservationStep,
             )
-            Box(
-                modifier =
-                    modifier
-                        .fillMaxWidth()
-                        .height(10.dp)
-                        .background(
-                            brush =
-                                Brush.verticalGradient(
-                                    colors =
-                                        listOf(
-                                            Color.Black.copy(alpha = 0.08f),
-                                            Color.Transparent,
-                                        ),
-                                ),
-                        ),
+
+            HorizontalDivider(
+                color = MainThemeColor.Gray2,
             )
+
+            reservationInfoSection?.invoke()
             LazyColumn(
                 modifier =
                     Modifier
@@ -133,7 +121,7 @@ internal fun ChatRoomScreenContent(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .padding(top = 2.dp, bottom = 16.dp),
+                                        .padding(vertical = 16.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 Text(

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
@@ -1,0 +1,264 @@
+package com.hm.picplz.ui.screen.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.hm.picplz.common.util.DateTimeUtil
+import com.hm.picplz.domain.model.ButtonActionType
+import com.hm.picplz.domain.model.ChatMessage
+import com.hm.picplz.domain.model.MessageContent
+import com.hm.picplz.domain.model.MessageDirection
+import com.hm.picplz.ui.screen.chat_room.ChatListItem
+import com.hm.picplz.ui.screen.chat_room.ReservationStep
+import com.hm.picplz.ui.screen.chat_room.composable.ChatInput
+import com.hm.picplz.ui.screen.chat_room.composable.ChatMessageProfile
+import com.hm.picplz.ui.screen.chat_room.composable.ReservationStep
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.ChangeTimeBubble
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.ChatMessageBubble
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.ChatSuggest
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.CompleteBubble
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.DealConfirmationBubble
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.ImageChat
+import com.hm.picplz.ui.screen.chat_room.composable.bubble.NotificationBubble
+import com.hm.picplz.ui.theme.MainFontFamily.caption
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.Pretendard
+
+@Composable
+internal fun ChatRoomScreenContent(
+    title: String,
+    subtitle: String,
+    reservationStep: ReservationStep,
+    chatMessages: List<ChatMessage>,
+    onBackClick: () -> Unit,
+    onMenuClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val chatListItem =
+        remember(chatMessages) {
+            chatMessages
+                .groupBy { chat ->
+                    DateTimeUtil.truncateToDate(chat.timestamp)
+                }.flatMap { (date, rest) ->
+                    buildList {
+                        add(ChatListItem.DateHeader(date))
+                        addAll(rest.map { ChatListItem.MessageItem(it) })
+                    }
+                }
+        }
+
+    Scaffold(
+        containerColor = MainThemeColor.White,
+        topBar = {
+            ChatRoomTopBar(
+                title = title,
+                subtitle = subtitle,
+                onBackClick = onBackClick,
+                onMenuClick = onMenuClick,
+            )
+        },
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+    ) { innerPadding ->
+        Column(
+            modifier =
+                modifier
+                    .padding(innerPadding),
+        ) {
+            ReservationStep(
+                reservationStep = reservationStep,
+            )
+            Box(
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .height(10.dp)
+                        .background(
+                            brush =
+                                Brush.verticalGradient(
+                                    colors =
+                                        listOf(
+                                            Color.Black.copy(alpha = 0.08f),
+                                            Color.Transparent,
+                                        ),
+                                ),
+                        ),
+            )
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                contentPadding = PaddingValues(8.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                items(
+                    items = chatListItem,
+                    key = { item ->
+                        when (item) {
+                            is ChatListItem.DateHeader -> "date_${item.date}"
+                            is ChatListItem.MessageItem -> "message_${item.message.id}"
+                        }
+                    },
+                ) { item ->
+                    when (item) {
+                        is ChatListItem.DateHeader -> {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 2.dp, bottom = 16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = DateTimeUtil.getFormattedDate(item.date),
+                                    style = caption,
+                                    color = MainThemeColor.Black,
+                                )
+                            }
+                        }
+
+                        is ChatListItem.MessageItem -> {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment =
+                                    when (item.message.content) {
+                                        is MessageContent.Text -> Alignment.CenterVertically
+                                        is MessageContent.Image -> Alignment.Top
+                                        is MessageContent.Notification -> Alignment.Top
+                                        is MessageContent.Completion -> Alignment.Top
+                                        is MessageContent.ChangeTime -> Alignment.Top
+                                        is MessageContent.DealConfirmation -> Alignment.Top
+                                        is MessageContent.ChatSuggest -> Alignment.Top
+                                    },
+                                horizontalArrangement =
+                                    if (item.message.direction === MessageDirection.RECEIVED) {
+                                        Arrangement.Start
+                                    } else {
+                                        Arrangement.End
+                                    },
+                            ) {
+                                if (item.message.direction == MessageDirection.RECEIVED) {
+                                    ChatMessageProfile(
+                                        profileImageUri = item.message.sender.profileImageUri,
+                                    )
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                }
+                                Row(
+                                    verticalAlignment = Alignment.Bottom,
+                                ) {
+                                    val timeFontStyle =
+                                        TextStyle(
+                                            fontFamily = Pretendard,
+                                            fontWeight = FontWeight.Normal,
+                                            fontSize = 8.sp,
+                                            lineHeight = 8.sp * 1.4,
+                                            letterSpacing = 0.sp,
+                                            color = MainThemeColor.Gray3,
+                                        )
+                                    if (item.message.direction == MessageDirection.SENT &&
+                                        item.message.content !is MessageContent.ChatSuggest
+                                    ) {
+                                        Text(
+                                            text = DateTimeUtil.getFormattedTime(item.message.timestamp),
+                                            style = timeFontStyle,
+                                        )
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                    }
+                                    when (item.message.content) {
+                                        is MessageContent.Text -> {
+                                            ChatMessageBubble(
+                                                chatMessage = item.message,
+                                            )
+                                        }
+
+                                        is MessageContent.Image -> {
+                                            val imageContent = item.message.content as MessageContent.Image
+                                            ImageChat(
+                                                imageUris = imageContent.imageUris,
+                                            )
+                                        }
+
+                                        is MessageContent.Notification -> {
+                                            NotificationBubble(
+                                                chatMessage = item.message,
+                                                onButtonClick = { button ->
+                                                    when (button.actionType) {
+                                                        ButtonActionType.OPEN_ORDER_FORM -> {}
+                                                        ButtonActionType.FIND_ANOTHER_ARTIST -> {}
+                                                        ButtonActionType.CONFIRM_ORDER -> {}
+                                                        ButtonActionType.OPEN_URL -> {}
+                                                    }
+                                                },
+                                            )
+                                        }
+
+                                        is MessageContent.Completion -> {
+                                            CompleteBubble(
+                                                chatMessage = item.message,
+                                            )
+                                        }
+
+                                        is MessageContent.ChangeTime -> {
+                                            ChangeTimeBubble(
+                                                chatMessage = item.message,
+                                            )
+                                        }
+
+                                        is MessageContent.DealConfirmation -> {
+                                            DealConfirmationBubble(
+                                                chatMessage = item.message,
+                                                onButtonClick = {},
+                                            )
+                                        }
+
+                                        is MessageContent.ChatSuggest -> {
+                                            val suggestContent = item.message.content as MessageContent.ChatSuggest
+                                            ChatSuggest(
+                                                suggestedChats = suggestContent.suggestedChats,
+                                            )
+                                        }
+                                    }
+                                    if (item.message.direction == MessageDirection.RECEIVED) {
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(
+                                            text = DateTimeUtil.getFormattedTime(item.message.timestamp),
+                                            style = timeFontStyle,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ChatInput()
+        }
+    }
+}

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomTopBar.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomTopBar.kt
@@ -1,0 +1,31 @@
+package com.hm.picplz.ui.screen.composable
+
+import androidx.compose.runtime.Composable
+import com.hm.picplz.ui.screen.common.CommonTopBarWithMenu
+import com.hm.picplz.ui.screen.common.CommonTopBarWithSubtitle
+import com.hm.picplz.ui.theme.MainFontFamily.caption
+import com.hm.picplz.ui.theme.MainThemeColor
+
+@Composable
+fun ChatRoomTopBar(
+    title: String,
+    subtitle: String,
+    onBackClick: () -> Unit,
+    onMenuClick: () -> Unit,
+) {
+    if (subtitle.isEmpty()) {
+        CommonTopBarWithMenu(
+            text = title,
+            onClickBack = onBackClick,
+            onClickMenu = onMenuClick,
+        )
+    } else {
+        CommonTopBarWithSubtitle(
+            text = title,
+            subText = subtitle,
+            subTextStyle = caption.copy(color = MainThemeColor.Green120),
+            onClickBack = onBackClick,
+            onClickMenu = onMenuClick,
+        )
+    }
+}

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomIntent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomIntent.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.photographer_chat_room
+
+sealed interface PhotographerChatRoomIntent {
+    data object NavigateToPrev : PhotographerChatRoomIntent
+}

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
@@ -9,6 +9,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.chat_room.dummyReservationChatMessages
 import com.hm.picplz.ui.screen.composable.ChatRoomScreenContent
+import com.hm.picplz.ui.screen.photographer_chat_room.composable.ReservationInfoBanner
 import com.hm.picplz.ui.theme.PicplzTheme
 
 @Composable
@@ -40,6 +41,16 @@ fun PhotographerChatRoomScreen(
         onMenuClick = {
             // TODO: Implement menu click action
         },
+        reservationInfoSection = {
+            ReservationInfoBanner(
+                customerName = state.customerName,
+                productName = state.productName,
+                customerProfileImageUri = state.customerImageUrl,
+                onClick = {
+                    // TODO: 예약 정보 화면으로 이동
+                },
+            )
+        },
     )
 }
 
@@ -54,6 +65,14 @@ private fun PhotographerChatRoomScreenPreview() {
             chatMessages = dummyReservationChatMessages,
             onBackClick = {},
             onMenuClick = {},
+            reservationInfoSection = {
+                ReservationInfoBanner(
+                    customerName = "애니프사",
+                    productName = "자연스러운프사",
+                    customerProfileImageUri = null,
+                    onClick = {},
+                )
+            },
         )
     }
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
@@ -1,4 +1,4 @@
-package com.hm.picplz.ui.screen.chat_room
+package com.hm.picplz.ui.screen.photographer_chat_room
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -7,14 +7,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.ui.screen.chat_room.dummyReservationChatMessages
 import com.hm.picplz.ui.screen.composable.ChatRoomScreenContent
 import com.hm.picplz.ui.theme.PicplzTheme
 
 @Composable
-fun ChatRoomScreen(
+fun PhotographerChatRoomScreen(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ChatRoomViewModel = hiltViewModel(),
+    viewModel: PhotographerChatRoomViewModel = hiltViewModel(),
     @Suppress("UNUSED_PARAMETER") _roomId: String,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -22,19 +23,19 @@ fun ChatRoomScreen(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is ChatRoomSideEffect.NavigateToPrev -> onNavigateBack()
+                is PhotographerChatRoomSideEffect.NavigateToPrev -> onNavigateBack()
             }
         }
     }
 
     ChatRoomScreenContent(
         modifier = modifier,
-        title = "유가영 작가",
-        subtitle = "당장 촬영 가능",
+        title = "유가영",
+        subtitle = "",
         reservationStep = state.reservationStep,
-        chatMessages = dummyChatMessages,
+        chatMessages = state.chatMessages,
         onBackClick = {
-            viewModel.handleIntent(ChatRoomIntent.NavigateToPrev)
+            viewModel.handleIntent(PhotographerChatRoomIntent.NavigateToPrev)
         },
         onMenuClick = {
             // TODO: Implement menu click action
@@ -44,13 +45,13 @@ fun ChatRoomScreen(
 
 @Preview(showBackground = true)
 @Composable
-private fun ChatRoomScreenPreview() {
+private fun PhotographerChatRoomScreenPreview() {
     PicplzTheme {
         ChatRoomScreenContent(
-            title = "유가영 작가",
-            subtitle = "당장 촬영 가능",
-            reservationStep = ChatRoomState.idle().reservationStep,
-            chatMessages = dummyChatMessages,
+            title = "유가영",
+            subtitle = "",
+            reservationStep = PhotographerChatRoomState.idle().reservationStep,
+            chatMessages = dummyReservationChatMessages,
             onBackClick = {},
             onMenuClick = {},
         )

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomSideEffect.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.photographer_chat_room
+
+sealed interface PhotographerChatRoomSideEffect {
+    data object NavigateToPrev : PhotographerChatRoomSideEffect
+}

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomState.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomState.kt
@@ -1,0 +1,16 @@
+package com.hm.picplz.ui.screen.photographer_chat_room
+
+import com.hm.picplz.domain.model.ChatMessage
+import com.hm.picplz.ui.screen.chat_room.ReservationStep
+
+data class PhotographerChatRoomState(
+    val chatRoomId: Int = 0,
+    val reservationStep: ReservationStep = ReservationStep.PENDING,
+    val chatMessages: List<ChatMessage> = emptyList(),
+) {
+    companion object {
+        fun idle(): PhotographerChatRoomState {
+            return PhotographerChatRoomState()
+        }
+    }
+}

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomState.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomState.kt
@@ -7,6 +7,9 @@ data class PhotographerChatRoomState(
     val chatRoomId: Int = 0,
     val reservationStep: ReservationStep = ReservationStep.PENDING,
     val chatMessages: List<ChatMessage> = emptyList(),
+    val customerName: String = "",
+    val customerImageUrl: String = "",
+    val productName: String = "",
 ) {
     companion object {
         fun idle(): PhotographerChatRoomState {

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
@@ -1,0 +1,38 @@
+package com.hm.picplz.ui.screen.photographer_chat_room
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.ui.screen.chat_room.dummyReservationChatMessages
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PhotographerChatRoomViewModel
+    @Inject
+    constructor() : ViewModel() {
+        private val _state =
+            MutableStateFlow(
+                PhotographerChatRoomState
+                    .idle()
+                    .copy(chatMessages = dummyReservationChatMessages),
+            )
+        val state: StateFlow<PhotographerChatRoomState> = _state
+
+        private val _sideEffect = MutableSharedFlow<PhotographerChatRoomSideEffect>()
+        val sideEffect: SharedFlow<PhotographerChatRoomSideEffect> = _sideEffect
+
+        fun handleIntent(intent: PhotographerChatRoomIntent) {
+            when (intent) {
+                is PhotographerChatRoomIntent.NavigateToPrev -> {
+                    viewModelScope.launch {
+                        _sideEffect.emit(PhotographerChatRoomSideEffect.NavigateToPrev)
+                    }
+                }
+            }
+        }
+    }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
@@ -3,6 +3,9 @@ package com.hm.picplz.ui.screen.photographer_chat_room
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hm.picplz.ui.screen.chat_room.dummyReservationChatMessages
+import com.hm.picplz.ui.screen.chat_room.reservationCustomerName
+import com.hm.picplz.ui.screen.chat_room.reservationProductName
+import com.hm.picplz.ui.screen.chat_room.reservationProfileUri
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +22,12 @@ class PhotographerChatRoomViewModel
             MutableStateFlow(
                 PhotographerChatRoomState
                     .idle()
-                    .copy(chatMessages = dummyReservationChatMessages),
+                    .copy(
+                        chatMessages = dummyReservationChatMessages,
+                        customerName = reservationCustomerName,
+                        customerImageUrl = reservationProfileUri,
+                        productName = reservationProductName,
+                    ),
             )
         val state: StateFlow<PhotographerChatRoomState> = _state
 

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/composable/ReservationInfoBanner.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/composable/ReservationInfoBanner.kt
@@ -1,0 +1,118 @@
+package com.hm.picplz.ui.screen.photographer_chat_room.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainFontFamily
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.feature.chat.R as ChatR
+
+@Composable
+fun ReservationInfoBanner(
+    customerName: String,
+    productName: String,
+    customerProfileImageUri: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onClick)
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            AsyncImage(
+                model =
+                    ImageRequest
+                        .Builder(LocalContext.current)
+                        .data(customerProfileImageUri ?: R.drawable.active_dot)
+                        .crossfade(true)
+                        .placeholder(R.drawable.active_dot)
+                        .error(R.drawable.active_dot)
+                        .build(),
+                contentDescription = "고객 프로필",
+                modifier =
+                    Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(MainThemeColor.Gray2),
+                contentScale = ContentScale.Crop,
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text =
+                        stringResource(
+                            id = ChatR.string.photographer_chat_room_reservation_info_label,
+                            customerName,
+                        ),
+                    style = MainFontFamily.caption,
+                    color = MainThemeColor.Gray4,
+                )
+                Spacer(modifier = Modifier.size(2.dp))
+                Text(
+                    text = productName,
+                    style = MainFontFamily.buttonDefault,
+                    color = MainThemeColor.Black,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            Icon(
+                painter = painterResource(id = R.drawable.triangle_right),
+                contentDescription = "예약 정보 보기",
+                modifier = Modifier.size(12.dp),
+                tint = MainThemeColor.Gray4,
+            )
+        }
+
+        HorizontalDivider(
+            color = MainThemeColor.Gray2,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReservationInfoBannerPreview() {
+    PicplzTheme {
+        ReservationInfoBanner(
+            customerName = "애니프사",
+            productName = "자연스러운프사",
+            customerProfileImageUri = null,
+            onClick = {},
+        )
+    }
+}

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 작가 채팅방 - 예약 정보 배너 -->
+    <string name="photographer_chat_room_reservation_info_label">예약 정보 - %1$s 님</string>
+</resources>

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -49,6 +49,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographer
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
+import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerEquipmentSetting
 import com.hm.picplz.navigation.model.PhotographerMain
 import com.hm.picplz.navigation.model.QuickShoot
@@ -247,6 +248,9 @@ fun DevScreen(navController: NavHostController) {
             // === Chat ===
             SectionTitle("Chat")
             DevButton("ChatRoom (test-room)") { navController.navigate(ChatRoom(roomId = "test-room-123")) }
+            DevButton("PhotographerChatRoom (작가 입장)") {
+                navController.navigate(PhotographerChatRoom(roomId = "test-room-123"))
+            }
 
             // === Reservation ===
             SectionTitle("Reservation")


### PR DESCRIPTION
## 개요
작가 입장의 채팅방 화면(`PhotographerChatRoomScreen`)을 신규 추가하고, 기존 고객용 `ChatRoomScreen`과 공통 UI를 공유할 수 있도록 채팅방 구조를 정리했습니다. 작가 채팅방에는 진입 시 노출되는 예약 정보 배너도 함께 추가했습니다.

> 예약 정보 배너의 "예약 정보 확인" 클릭 시 화면 이동 및 작가 기준 예약 정보 화면(`PhotographerDetailReservationScreen`) 작업은 PR이 비대해질 것 같아 분리하여 다음 PR에서 작업할 예정입니다.

## 화면 분리 이유 (작가 / 고객)
공통 enum 분기 대신 작가/고객 채팅방을 별도 Screen·ViewModel·State·Intent·SideEffect로 분리한 이유는 다음과 같습니다.
- 동일한 UI 구조이지만 **로직 분기점이 명확함**: 예약 승인/거절(작가), 결제·환불 안내(고객), 취소 사유 입력 등 한쪽에만 존재하는 흐름이 늘어날 가능성
- 결제/환불처럼 한쪽에만 붙을 기능이 추후 추가될 때 enum 분기로 가면 `if (role == CUSTOMER)` 가 곳곳에 박히고, 그 시점에 다시 쪼개는 비용이 더 큼
- 공통 UI는 `ChatRoomScreenContent` / `ChatRoomTopBar`로 추출해 중복을 최소화했으며, 분기는 각 wrapper Screen에서만 발생하도록 구성

## 변경 사항
- `ChatRoomScreen` 구조 정리
  - 내부 UI를 `ChatRoomScreenContent` private composable로 분리
  - `NavHostController` 의존을 `onNavigateBack` 람다로 교체
  - `collectAsState` → `collectAsStateWithLifecycle`, `LaunchedEffect`를 Screen 함수 상단으로 이동
- 공통 UI 컴포넌트 분리 (`ui/screen/composable/`)
  - `ChatRoomScreenContent` / `ChatRoomTopBar`를 양쪽 화면이 공유
- 작가용 채팅방 화면 신규 추가 (`ui/screen/photographer_chat_room/`)
  - Screen / ViewModel / State / Intent / SideEffect 5개 파일 (옵션 B 분리 구조)
  - `PhotographerChatRoom` 라우트 모델 및 네비게이션 그래프 추가
  - `DevScreen`에 작가용 채팅방 진입 버튼 추가
- 작가 채팅방 - 예약 정보 배너 추가
  - `ReservationInfoBanner` 컴포저블 (프로필 / "예약 정보 - {고객명} 님" / 상품명 / 우측 화살표)
  - `ChatRoomScreenContent`에 `reservationInfoSection` 슬롯 추가하여 작가 화면에서만 노출
  - `PhotographerChatRoomState`에 customerName / customerImageUrl / productName 필드 추가
  - `feature/chat` 모듈 `strings.xml` 신규 생성, 배너 라벨 문자열 자원화

[Screen_recording_20260510_170612.webm](https://github.com/user-attachments/assets/c73648ad-6c40-4b75-8220-9274d1ef923c)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #167
