### PR TITLE
✨ 작가 - 예약정보 확인 화면(승인 전) 구현

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -25,6 +25,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerChatRoom
+import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationScreen
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
@@ -45,6 +46,7 @@ import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
 import com.hm.picplz.ui.screen.photographer_chat_room.PhotographerChatRoomScreen
+import com.hm.picplz.ui.screen.photographer_detail_reservation.PhotographerDetailReservationScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
@@ -83,6 +85,9 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         PhotographerChatRoomScreen(
             onNavigateBack = {
                 navController.popBackStack()
+            },
+            onNavigatePhotographerDetailReservation = {
+                navController.navigate(PhotographerDetailReservation)
             },
             _roomId = args.roomId,
         )
@@ -143,6 +148,20 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             },
             onNavigateCancelReservationConfirm = {
                 navController.navigate(CancelReservationConfirm(cancelType = CancelConfirmType.WITHOUT_REFUND))
+            },
+            onNavigateToOrderDetail = { orderId ->
+                navController.navigate(OrderDetail(orderId = orderId))
+            },
+        )
+    }
+
+    composable<PhotographerDetailReservation> {
+        PhotographerDetailReservationScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            onNavigateRejectReservationConfirm = {
+                // TODO
             },
             onNavigateToOrderDetail = { orderId ->
                 navController.navigate(OrderDetail(orderId = orderId))

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -132,6 +132,9 @@ data class DetailPhotographerPortfolioDetail(val portfolioId: Int, val photoInde
 data object DetailReservation : NavigationRoute
 
 @Serializable
+data object PhotographerDetailReservation : NavigationRoute
+
+@Serializable
 data class CancelReservationConfirm(val cancelType: CancelConfirmType) : NavigationRoute
 
 @Serializable

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Chat.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Chat.kt
@@ -30,11 +30,18 @@ enum class MessageDirection {
     RECEIVED,
 }
 
-enum class ButtonActionType {
-    OPEN_ORDER_FORM,
-    FIND_ANOTHER_ARTIST,
-    CONFIRM_ORDER,
-    OPEN_URL,
+sealed interface ButtonActionType {
+    data object OpenOrderForm : ButtonActionType
+
+    data object FindAnotherArtist : ButtonActionType
+
+    data object ConfirmOrder : ButtonActionType
+
+    data class OpenUrl(
+        val url: String,
+    ) : ButtonActionType
+
+    data object OpenPhotographerDetailReservation : ButtonActionType
 }
 
 data class MessageButton(

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
@@ -36,7 +36,7 @@ fun ChatRoomScreen(
         onBackClick = {
             viewModel.handleIntent(ChatRoomIntent.NavigateToPrev)
         },
-        onMessageClick = {},
+        onMessageButtonClick = {},
         onMenuClick = {
             // TODO: Implement menu click action
         },
@@ -54,7 +54,7 @@ private fun ChatRoomScreenPreview() {
             chatMessages = dummyChatMessages,
             onBackClick = {},
             onMenuClick = {},
-            onMessageClick = {},
+            onMessageButtonClick = {},
         )
     }
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomScreen.kt
@@ -36,6 +36,7 @@ fun ChatRoomScreen(
         onBackClick = {
             viewModel.handleIntent(ChatRoomIntent.NavigateToPrev)
         },
+        onMessageClick = {},
         onMenuClick = {
             // TODO: Implement menu click action
         },
@@ -53,6 +54,7 @@ private fun ChatRoomScreenPreview() {
             chatMessages = dummyChatMessages,
             onBackClick = {},
             onMenuClick = {},
+            onMessageClick = {},
         )
     }
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/ChatRoomState.kt
@@ -136,7 +136,7 @@ val dummyChatMessages =
                     button =
                         MessageButton(
                             text = "확인",
-                            actionType = ButtonActionType.CONFIRM_ORDER,
+                            actionType = ButtonActionType.ConfirmOrder,
                         ),
                 ),
             timestamp = System.currentTimeMillis() - 1000,
@@ -192,7 +192,7 @@ val dummyChatMessages =
                     button =
                         MessageButton(
                             text = "거래 확정",
-                            actionType = ButtonActionType.CONFIRM_ORDER,
+                            actionType = ButtonActionType.ConfirmOrder,
                         ),
                 ),
             timestamp = System.currentTimeMillis() - 1000,
@@ -217,7 +217,7 @@ val dummyChatMessages =
                     button =
                         MessageButton(
                             text = "거래 확정",
-                            actionType = ButtonActionType.CONFIRM_ORDER,
+                            actionType = ButtonActionType.ConfirmOrder,
                         ),
                 ),
             timestamp = System.currentTimeMillis() - 1000,
@@ -313,7 +313,7 @@ val dummyChatMessages =
                     button =
                         MessageButton(
                             text = "확인",
-                            actionType = ButtonActionType.CONFIRM_ORDER,
+                            actionType = ButtonActionType.ConfirmOrder,
                         ),
                 ),
             timestamp = System.currentTimeMillis() - 1000,
@@ -376,7 +376,7 @@ val dummyReservationChatMessages =
                     button =
                         MessageButton(
                             text = "예약 정보 확인",
-                            actionType = ButtonActionType.CONFIRM_ORDER,
+                            actionType = ButtonActionType.OpenPhotographerDetailReservation,
                         ),
                 ),
             timestamp = System.currentTimeMillis() - 1000,

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/bubble/DealConfirmationBubble.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/bubble/DealConfirmationBubble.kt
@@ -143,7 +143,7 @@ fun DealConfirmationBubbleReceivedPreview() {
                         MessageContent.DealConfirmation(
                             MessageButton(
                                 text = "거래 확정",
-                                actionType = ButtonActionType.CONFIRM_ORDER,
+                                actionType = ButtonActionType.ConfirmOrder,
                             ),
                         ),
                     timestamp = System.currentTimeMillis() - 100000,

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/bubble/NotificationBubble.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/chat_room/composable/bubble/NotificationBubble.kt
@@ -142,7 +142,7 @@ fun NotificationBubblePreview() {
                             button =
                                 MessageButton(
                                     text = "확인",
-                                    actionType = ButtonActionType.FIND_ANOTHER_ARTIST,
+                                    actionType = ButtonActionType.FindAnotherArtist,
                                 ),
                         ),
                     sender =
@@ -181,7 +181,7 @@ fun NotificationBubbleButtonPreview() {
                             button =
                                 MessageButton(
                                     text = "확인",
-                                    actionType = ButtonActionType.FIND_ANOTHER_ARTIST,
+                                    actionType = ButtonActionType.FindAnotherArtist,
                                 ),
                         ),
                     sender =
@@ -221,7 +221,7 @@ fun NotificationBubbleSendPreview() {
                             button =
                                 MessageButton(
                                     text = "확인",
-                                    actionType = ButtonActionType.FIND_ANOTHER_ARTIST,
+                                    actionType = ButtonActionType.FindAnotherArtist,
                                 ),
                             caption = "캡션",
                         ),
@@ -263,7 +263,7 @@ fun NotificationBubbleCaptionButtonPreview() {
                             button =
                                 MessageButton(
                                     text = "주문서 확인하기",
-                                    actionType = ButtonActionType.FIND_ANOTHER_ARTIST,
+                                    actionType = ButtonActionType.FindAnotherArtist,
                                 ),
                         ),
                     sender =

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hm.picplz.common.util.DateTimeUtil
-import com.hm.picplz.domain.model.ButtonActionType
 import com.hm.picplz.domain.model.ChatMessage
+import com.hm.picplz.domain.model.MessageButton
 import com.hm.picplz.domain.model.MessageContent
 import com.hm.picplz.domain.model.MessageDirection
 import com.hm.picplz.ui.screen.chat_room.ChatListItem
@@ -53,7 +53,7 @@ internal fun ChatRoomScreenContent(
     chatMessages: List<ChatMessage>,
     onBackClick: () -> Unit,
     onMenuClick: () -> Unit,
-    onMessageClick: () -> Unit,
+    onMessageButtonClick: (MessageButton) -> Unit,
     modifier: Modifier = Modifier,
     reservationInfoSection: @Composable (() -> Unit)? = null,
 ) {
@@ -197,14 +197,7 @@ internal fun ChatRoomScreenContent(
                                         is MessageContent.Notification -> {
                                             NotificationBubble(
                                                 chatMessage = item.message,
-                                                onButtonClick = { button ->
-                                                    when (button.actionType) {
-                                                        ButtonActionType.OPEN_ORDER_FORM -> {}
-                                                        ButtonActionType.FIND_ANOTHER_ARTIST -> {}
-                                                        ButtonActionType.CONFIRM_ORDER -> {}
-                                                        ButtonActionType.OPEN_URL -> {}
-                                                    }
-                                                },
+                                                onButtonClick = onMessageButtonClick,
                                             )
                                         }
 

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/composable/ChatRoomScreenContent.kt
@@ -53,6 +53,7 @@ internal fun ChatRoomScreenContent(
     chatMessages: List<ChatMessage>,
     onBackClick: () -> Unit,
     onMenuClick: () -> Unit,
+    onMessageClick: () -> Unit,
     modifier: Modifier = Modifier,
     reservationInfoSection: @Composable (() -> Unit)? = null,
 ) {

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomIntent.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomIntent.kt
@@ -2,4 +2,6 @@ package com.hm.picplz.ui.screen.photographer_chat_room
 
 sealed interface PhotographerChatRoomIntent {
     data object NavigateToPrev : PhotographerChatRoomIntent
+
+    data object ClickReservationDetail : PhotographerChatRoomIntent
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
@@ -15,6 +15,7 @@ import com.hm.picplz.ui.theme.PicplzTheme
 @Composable
 fun PhotographerChatRoomScreen(
     onNavigateBack: () -> Unit,
+    onNavigatePhotographerDetailReservation: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PhotographerChatRoomViewModel = hiltViewModel(),
     @Suppress("UNUSED_PARAMETER") _roomId: String,
@@ -24,7 +25,13 @@ fun PhotographerChatRoomScreen(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is PhotographerChatRoomSideEffect.NavigateToPrev -> onNavigateBack()
+                is PhotographerChatRoomSideEffect.NavigateToPrev -> {
+                    onNavigateBack()
+                }
+
+                PhotographerChatRoomSideEffect.NavigateToPhotographerDetailReservation -> {
+                    onNavigatePhotographerDetailReservation()
+                }
             }
         }
     }
@@ -41,13 +48,15 @@ fun PhotographerChatRoomScreen(
         onMenuClick = {
             // TODO: Implement menu click action
         },
+        onMessageClick = {
+        },
         reservationInfoSection = {
             ReservationInfoBanner(
                 customerName = state.customerName,
                 productName = state.productName,
                 customerProfileImageUri = state.customerImageUrl,
                 onClick = {
-                    // TODO: 예약 정보 화면으로 이동
+                    viewModel.handleIntent(PhotographerChatRoomIntent.ClickReservationDetail)
                 },
             )
         },
@@ -65,6 +74,7 @@ private fun PhotographerChatRoomScreenPreview() {
             chatMessages = dummyReservationChatMessages,
             onBackClick = {},
             onMenuClick = {},
+            onMessageClick = {},
             reservationInfoSection = {
                 ReservationInfoBanner(
                     customerName = "애니프사",

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.domain.model.ButtonActionType
 import com.hm.picplz.ui.screen.chat_room.dummyReservationChatMessages
 import com.hm.picplz.ui.screen.composable.ChatRoomScreenContent
 import com.hm.picplz.ui.screen.photographer_chat_room.composable.ReservationInfoBanner
@@ -48,7 +49,14 @@ fun PhotographerChatRoomScreen(
         onMenuClick = {
             // TODO: Implement menu click action
         },
-        onMessageClick = {
+        onMessageButtonClick = { button ->
+            when (button.actionType) {
+                is ButtonActionType.OpenPhotographerDetailReservation -> {
+                    viewModel.handleIntent(PhotographerChatRoomIntent.ClickReservationDetail)
+                }
+
+                else -> { }
+            }
         },
         reservationInfoSection = {
             ReservationInfoBanner(
@@ -74,7 +82,7 @@ private fun PhotographerChatRoomScreenPreview() {
             chatMessages = dummyReservationChatMessages,
             onBackClick = {},
             onMenuClick = {},
-            onMessageClick = {},
+            onMessageButtonClick = {},
             reservationInfoSection = {
                 ReservationInfoBanner(
                     customerName = "애니프사",

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomSideEffect.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomSideEffect.kt
@@ -2,4 +2,6 @@ package com.hm.picplz.ui.screen.photographer_chat_room
 
 sealed interface PhotographerChatRoomSideEffect {
     data object NavigateToPrev : PhotographerChatRoomSideEffect
+
+    data object NavigateToPhotographerDetailReservation : PhotographerChatRoomSideEffect
 }

--- a/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/hm/picplz/ui/screen/photographer_chat_room/PhotographerChatRoomViewModel.kt
@@ -41,6 +41,12 @@ class PhotographerChatRoomViewModel
                         _sideEffect.emit(PhotographerChatRoomSideEffect.NavigateToPrev)
                     }
                 }
+
+                PhotographerChatRoomIntent.ClickReservationDetail -> {
+                    viewModelScope.launch {
+                        _sideEffect.emit(PhotographerChatRoomSideEffect.NavigateToPhotographerDetailReservation)
+                    }
+                }
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
@@ -31,6 +31,7 @@ fun DetailReservationBottomButtons(
                 onClick = onChatClick,
             )
         }
+
         ReservationStatus.RESERVED -> {
             Row(
                 modifier = modifier,
@@ -47,6 +48,7 @@ fun DetailReservationBottomButtons(
                 )
             }
         }
+
         ReservationStatus.COMPLETED -> {
             Row(
                 modifier = modifier,
@@ -64,6 +66,18 @@ fun DetailReservationBottomButtons(
             }
         }
     }
+}
+
+@Composable
+fun ReservationApproveButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_reservation_approve),
+        onClick = onClick,
+    )
 }
 
 @Composable

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
@@ -16,11 +16,20 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont.Body
 
 @Composable
-fun ReservationInfoSection(modifier: Modifier = Modifier) {
+fun ReservationInfoSection(
+    modifier: Modifier = Modifier,
+    customerName: String = "",
+) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
+        if (customerName.isNotBlank()) {
+            ReservationInfoItem(
+                title = "고객명",
+                description = customerName,
+            )
+        }
         ReservationInfoItem(
             title = "촬영 상품명",
             description = "프로필 패키지",

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
@@ -50,6 +50,31 @@ fun ReservationStatusHeader(
 
         if (currentReservationStatus.showCancelButton()) {
             ReservationCancelButton(
+                text = stringResource(R.string.reservation_cancel),
+                onClick = onCancelClick,
+            )
+        }
+    }
+}
+
+@Composable
+fun PhotographerReservationStatusHeader(
+    currentReservationStatus: ReservationStatus,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        ReservationStatusInfo(
+            title = stringResource(currentReservationStatus.titleResId),
+            description = stringResource(currentReservationStatus.descriptionResId),
+        )
+
+        if (currentReservationStatus.showCancelButton()) {
+            ReservationCancelButton(
+                text = stringResource(R.string.reservation_reject),
                 onClick = onCancelClick,
             )
         }
@@ -81,6 +106,7 @@ private fun ReservationStatusInfo(
 
 @Composable
 private fun ReservationCancelButton(
+    text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -96,7 +122,7 @@ private fun ReservationCancelButton(
             onClick = onClick,
         ) {
             Text(
-                text = stringResource(R.string.reservation_cancel),
+                text = text,
                 modifier =
                     Modifier
                         .padding(horizontal = 15.dp, vertical = 6.dp)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
@@ -61,6 +61,7 @@ fun ReservationStatusHeader(
 fun PhotographerReservationStatusHeader(
     currentReservationStatus: ReservationStatus,
     onCancelClick: () -> Unit,
+    onCancelReject: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -72,11 +73,26 @@ fun PhotographerReservationStatusHeader(
             description = stringResource(currentReservationStatus.descriptionResId),
         )
 
-        if (currentReservationStatus.showCancelButton()) {
-            ReservationCancelButton(
-                text = stringResource(R.string.reservation_reject),
-                onClick = onCancelClick,
-            )
+        when (currentReservationStatus) {
+            ReservationStatus.WAITING_APPROVAL -> {
+                ReservationCancelButton(
+                    text = stringResource(R.string.reservation_reject),
+                    onClick = onCancelReject,
+                )
+            }
+
+            ReservationStatus.WAITING_PAYMENT,
+            ReservationStatus.RESERVED,
+            -> {
+                ReservationCancelButton(
+                    text = stringResource(R.string.reservation_cancel),
+                    onClick = onCancelClick,
+                )
+            }
+
+            else -> {
+                return
+            }
         }
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.ui.screen.photographer_detail_reservation
+
+sealed interface PhotographerDetailReservationIntent {
+    data object NavigateToChat : PhotographerDetailReservationIntent
+
+    data object NavigateToHistory : PhotographerDetailReservationIntent
+
+    data object ConfirmReservation : PhotographerDetailReservationIntent
+
+    data object ShowCancelDialog : PhotographerDetailReservationIntent
+
+    data object DismissCancelDialog : PhotographerDetailReservationIntent
+
+    data object ConfirmCancel : PhotographerDetailReservationIntent
+
+    data object ShowRefundPolicyDialog : PhotographerDetailReservationIntent
+
+    data object DismissRefundPolicyTooltip : PhotographerDetailReservationIntent
+
+    data object NavigateBack : PhotographerDetailReservationIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -18,10 +18,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerReservationStatusHeader
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationApproveButton
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import com.hm.picplz.ui.theme.MainThemeColor
 
 @Suppress("LongParameterList")
@@ -67,6 +69,12 @@ fun PhotographerDetailReservationScreen(
         onCancelClick = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.ShowCancelDialog)
         },
+        onCancelReject = {
+            // TODO
+        },
+        onReservationApproveClick = {
+            // TODO
+        },
         onCancelDialogDismiss = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.DismissCancelDialog)
         },
@@ -93,6 +101,8 @@ private fun PhotographerDetailReservationScreen(
     onHistoryClick: () -> Unit,
     onConfirmClick: () -> Unit,
     onCancelClick: () -> Unit,
+    onCancelReject: () -> Unit,
+    onReservationApproveClick: () -> Unit,
     onCancelDialogDismiss: () -> Unit,
     onCancelDialogConfirm: () -> Unit,
     onInfoClick: () -> Unit,
@@ -139,6 +149,7 @@ private fun PhotographerDetailReservationScreen(
                         modifier = Modifier.padding(vertical = 20.dp),
                         currentReservationStatus = state.reservationStatus,
                         onCancelClick = onCancelClick,
+                        onCancelReject = onCancelReject,
                     )
                 }
 
@@ -160,13 +171,20 @@ private fun PhotographerDetailReservationScreen(
                 }
             }
 
-            DetailReservationBottomButtons(
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
-                currentReservationStatus = state.reservationStatus,
-                onChatClick = onChatClick,
-                onHistoryClick = onHistoryClick,
-                onConfirmClick = onConfirmClick,
-            )
+            if (state.reservationStatus != ReservationStatus.WAITING_APPROVAL) {
+                DetailReservationBottomButtons(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
+                    currentReservationStatus = state.reservationStatus,
+                    onChatClick = onChatClick,
+                    onHistoryClick = onHistoryClick,
+                    onConfirmClick = onConfirmClick,
+                )
+            } else {
+                ReservationApproveButton(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
+                    onClick = onReservationApproveClick,
+                )
+            }
         }
     }
 }
@@ -181,6 +199,8 @@ private fun PhotographerDetailReservationScreenPreview() {
         onHistoryClick = {},
         onConfirmClick = {},
         onCancelClick = {},
+        onCancelReject = {},
+        onReservationApproveClick = {},
         onCancelDialogDismiss = {},
         onCancelDialogConfirm = {},
         onInfoClick = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -17,11 +17,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
+import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerReservationStatusHeader
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
-import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
 import com.hm.picplz.ui.theme.MainThemeColor
 
 @Suppress("LongParameterList")
@@ -135,7 +135,7 @@ private fun PhotographerDetailReservationScreen(
                 contentPadding = PaddingValues(horizontal = 16.dp),
             ) {
                 item {
-                    ReservationStatusHeader(
+                    PhotographerReservationStatusHeader(
                         modifier = Modifier.padding(vertical = 20.dp),
                         currentReservationStatus = state.reservationStatus,
                         onCancelClick = onCancelClick,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -1,0 +1,187 @@
+package com.hm.picplz.ui.screen.photographer_detail_reservation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
+import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
+import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
+import com.hm.picplz.ui.theme.MainThemeColor
+
+@Suppress("LongParameterList")
+@Composable
+fun PhotographerDetailReservationScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateRejectReservationConfirm: () -> Unit,
+    onNavigateToOrderDetail: (orderId: String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PhotographerDetailReservationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is PhotographerDetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
+
+                is PhotographerDetailReservationSideEffect.NavigateToRejectReservationConfirm -> {
+                    onNavigateRejectReservationConfirm()
+                }
+
+                is PhotographerDetailReservationSideEffect.NavigateToOrderDetail ->
+                    onNavigateToOrderDetail(
+                        state.orderId,
+                    )
+            }
+        }
+    }
+
+    PhotographerDetailReservationScreen(
+        modifier = modifier,
+        state = state,
+        onChatClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateToChat)
+        },
+        onHistoryClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateToHistory)
+        },
+        onConfirmClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.ConfirmReservation)
+        },
+        onCancelClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.ShowCancelDialog)
+        },
+        onCancelDialogDismiss = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.DismissCancelDialog)
+        },
+        onCancelDialogConfirm = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.ConfirmCancel)
+        },
+        onInfoClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.ShowRefundPolicyDialog)
+        },
+        onRefundPolicyDismiss = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.DismissRefundPolicyTooltip)
+        },
+        onCloseClick = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateBack)
+        },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun PhotographerDetailReservationScreen(
+    state: PhotographerDetailReservationState,
+    onChatClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onCancelDialogDismiss: () -> Unit,
+    onCancelDialogConfirm: () -> Unit,
+    onInfoClick: () -> Unit,
+    onRefundPolicyDismiss: () -> Unit,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = MainThemeColor.White,
+    ) { innerPadding ->
+        if (state.showCancelDialog) {
+            ReservationCancelDialog(
+                status = state.reservationStatus,
+                refundCondition = state.refundCondition,
+                onDismiss = onCancelDialogDismiss,
+                onCancel = onCancelDialogDismiss,
+                onConfirm = onCancelDialogConfirm,
+                onInfoClick = onInfoClick,
+            )
+        }
+
+        if (state.showRefundPolicyTooltip) {
+            ReservationRefundPolicyDialog(
+                onDismissRequest = onRefundPolicyDismiss,
+            )
+        }
+
+        Column(modifier = Modifier.padding(innerPadding)) {
+            DetailReservationMap(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(230.dp),
+                onCloseClick = onCloseClick,
+            )
+
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(horizontal = 16.dp),
+            ) {
+                item {
+                    ReservationStatusHeader(
+                        modifier = Modifier.padding(vertical = 20.dp),
+                        currentReservationStatus = state.reservationStatus,
+                        onCancelClick = onCancelClick,
+                    )
+                }
+
+                item {
+                    ReservationProgressStepper(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp),
+                        currentReservationStep = state.reservationStatus.step,
+                    )
+                }
+
+                item {
+                    ReservationInfoSection(modifier = Modifier.padding(top = 28.dp, bottom = 24.dp))
+                }
+            }
+
+            DetailReservationBottomButtons(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
+                currentReservationStatus = state.reservationStatus,
+                onChatClick = onChatClick,
+                onHistoryClick = onHistoryClick,
+                onConfirmClick = onConfirmClick,
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview
+@Composable
+private fun PhotographerDetailReservationScreenPreview() {
+    PhotographerDetailReservationScreen(
+        state = PhotographerDetailReservationState(),
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+        onCancelClick = {},
+        onCancelDialogDismiss = {},
+        onCancelDialogConfirm = {},
+        onInfoClick = {},
+        onRefundPolicyDismiss = {},
+        onCloseClick = {},
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -153,7 +153,10 @@ private fun PhotographerDetailReservationScreen(
                 }
 
                 item {
-                    ReservationInfoSection(modifier = Modifier.padding(top = 28.dp, bottom = 24.dp))
+                    ReservationInfoSection(
+                        modifier = Modifier.padding(top = 28.dp, bottom = 24.dp),
+                        customerName = state.customerName,
+                    )
                 }
             }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.ui.screen.photographer_detail_reservation
+
+sealed interface PhotographerDetailReservationSideEffect {
+    data object NavigateToPrev : PhotographerDetailReservationSideEffect
+
+    data object NavigateToRejectReservationConfirm : PhotographerDetailReservationSideEffect
+
+    data object NavigateToOrderDetail : PhotographerDetailReservationSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
@@ -1,0 +1,14 @@
+package com.hm.picplz.ui.screen.photographer_detail_reservation
+
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+
+data class PhotographerDetailReservationState(
+    val orderId: String = "",
+    val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
+    val showCancelDialog: Boolean = false,
+    val shootingDateTimeMillis: Long = System.currentTimeMillis(),
+    val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
+    val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
+    val showRefundPolicyTooltip: Boolean = false,
+)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
@@ -11,4 +11,7 @@ data class PhotographerDetailReservationState(
     val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
     val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
     val showRefundPolicyTooltip: Boolean = false,
+    val customerName: String = dummyCustomerName,
 )
+
+val dummyCustomerName = "애니프사"

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -1,0 +1,125 @@
+package com.hm.picplz.ui.screen.photographer_detail_reservation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.util.DateTimeUtil
+import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel() {
+    private val _state = MutableStateFlow(PhotographerDetailReservationState())
+    val state: StateFlow<PhotographerDetailReservationState> get() = _state
+
+    private val _sideEffect = MutableSharedFlow<PhotographerDetailReservationSideEffect>()
+    val sideEffect: SharedFlow<PhotographerDetailReservationSideEffect> get() = _sideEffect
+
+    init {
+        // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
+        // 임시로 더미 데이터 설정 (촬영일: 4일 후)
+        val currentTimeMillis = System.currentTimeMillis()
+        val dummyShootingDateTimeMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
+        val dummyConfirmedDateTimeMillis = currentTimeMillis - (12 * 60 * 60 * 1000) // 12시간 전
+
+        _state.update {
+            it.copy(
+                shootingDateTimeMillis = dummyShootingDateTimeMillis,
+                confirmedDateTimeMillis = dummyConfirmedDateTimeMillis,
+            )
+        }
+    }
+
+    fun handelIntent(intent: PhotographerDetailReservationIntent) {
+        when (intent) {
+            // 상태 변경 확인 테스트를 위한 코드입니다.
+            is PhotographerDetailReservationIntent.NavigateToChat,
+            is PhotographerDetailReservationIntent.NavigateToHistory,
+            is PhotographerDetailReservationIntent.ConfirmReservation,
+            -> {
+                _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
+            }
+
+            is PhotographerDetailReservationIntent.ShowCancelDialog -> {
+                val currentState = _state.value
+                val refundCondition =
+                    RefundCondition.calculate(
+                        currentMillis = System.currentTimeMillis(),
+                        shootingMillis = currentState.shootingDateTimeMillis,
+                        confirmedMillis = currentState.confirmedDateTimeMillis,
+                    )
+
+                _state.update {
+                    it.copy(
+                        showCancelDialog = true,
+                        refundCondition = refundCondition,
+                    )
+                }
+            }
+
+            is PhotographerDetailReservationIntent.DismissCancelDialog -> {
+                _state.update { it.copy(showCancelDialog = false) }
+            }
+
+            is PhotographerDetailReservationIntent.ConfirmCancel -> {
+                _state.update { it.copy(showCancelDialog = false) }
+
+                viewModelScope.launch {
+                    when (state.value.reservationStatus) {
+                        ReservationStatus.WAITING_APPROVAL,
+                        ReservationStatus.WAITING_PAYMENT,
+                        -> {
+                            _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToRejectReservationConfirm)
+                        }
+
+                        ReservationStatus.RESERVED,
+                        ReservationStatus.COMPLETED,
+                        -> {
+                            _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToOrderDetail)
+                        }
+                    }
+                }
+            }
+
+            is PhotographerDetailReservationIntent.ShowRefundPolicyDialog -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = true,
+                        showCancelDialog = false,
+                    )
+                }
+            }
+
+            is PhotographerDetailReservationIntent.DismissRefundPolicyTooltip -> {
+                _state.update {
+                    it.copy(
+                        showRefundPolicyTooltip = false,
+                        showCancelDialog = true,
+                    )
+                }
+            }
+
+            is PhotographerDetailReservationIntent.NavigateBack -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToPrev)
+                }
+            }
+        }
+    }
+
+    // 상태 변경 확인 테스트를 위한 코드입니다.
+    private fun ReservationStatus.next(): ReservationStatus =
+        when (this) {
+            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_PAYMENT
+            ReservationStatus.WAITING_PAYMENT -> ReservationStatus.RESERVED
+            ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
+            ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
+        }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="reservation_cancel">예약 취소</string>
+    <string name="reservation_reject">예약 거절</string>
     <string name="reservation_step_waiting">예약 대기</string>
     <string name="reservation_step_in_progress">촬영 진행</string>
     <string name="reservation_step_confirmed">거래 확정</string>

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="reservation_button_chat">채팅 바로가기</string>
     <string name="reservation_button_history">내역 보기</string>
     <string name="reservation_button_confirm">거래 확정하기</string>
+    <string name="reservation_button_reservation_approve">예약 승인</string>
 
     <!-- 예약 취소 다이얼로그 -->
     <string name="reservation_cancel_dialog_title">예약을 취소하시겠습니까?</string>


### PR DESCRIPTION
## 개요
작가 입장의 예약 정보 화면(`PhotographerDetailReservationScreen`)을 신규 추가하고, 작가 채팅방의 예약 정보 배너에서 해당 화면으로 진입하도록 연결했습니다. 작가 전용 UI 차이(예약 거절 / 고객명 섹션 / 예약 승인 CTA)를 함께 적용했으며, 메시지 버튼 클릭 처리 구조도 정리했습니다.

> 본 PR은 작가 채팅방 작업(`feat/167`) PR이 선행 머지되어야 합니다. 채팅방 관련 변경사항은 해당 PR에 포함되어 있습니다.

## 변경 사항
- 작가용 예약 정보 화면 신규 추가 (`ui/screen/photographer_detail_reservation/`)
  - Screen / ViewModel / State / Intent / SideEffect 5개 파일 (옵션 B 분리 구조)
  - UI는 기존 `DetailReservationScreen`과 동일하게 시작하여 작가 전용 차이만 적용
  - `PhotographerDetailReservation` 라우트 모델 및 네비게이션 그래프 추가
- 작가 채팅방에서 작가용 예약 정보 화면으로 진입 연결
  - `PhotographerChatRoomIntent.ClickReservationDetail` / `SideEffect.NavigateToPhotographerDetailReservation` 추가
  - 메시지 버튼 클릭 시 `ButtonActionType.OpenPhotographerDetailReservation` → 작가용 예약 정보 화면 이동
- 메시지 버튼 클릭 처리 구조 정리
  - `ButtonActionType` enum → sealed interface로 변경 (`OpenUrl`은 url 데이터 보유, `OpenPhotographerDetailReservation` 추가)
  - `ChatRoomScreenContent`의 하드코딩된 분기 제거, `onMessageButtonClick(MessageButton)` 콜백으로 wrapper Screen에 위임
- 작가 전용 UI 차이 적용
  - `PhotographerReservationStatusHeader` 상태별 분기 (`WAITING_APPROVAL` → "예약 거절", `WAITING_PAYMENT`/`RESERVED` → "예약 취소")
  - 고객명 섹션 추가 (`ReservationInfoSection`)
  - `ReservationApproveButton` 컴포저블 추가, `WAITING_APPROVAL` 상태에서 "예약 승인" CTA 노출
  - 관련 문자열 자원(`reservation_button_reservation_approve` 등) 추가

[Screen_recording_20260510_211754.webm](https://github.com/user-attachments/assets/0d734b89-a640-40b1-8d86-e4ef19f90dbc)


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #172
