### PR TITLE
💄: 촬영지 검색 화면 수정내용 반영 

### DIFF
--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonToast.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonToast.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
@@ -40,6 +41,7 @@ fun CommonToast(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Center,
+    bottomOffset: Dp = CommonToastDefaults.BottomOffset,
 ) {
     LaunchedEffect(isVisible) {
         if (isVisible) {
@@ -58,7 +60,7 @@ fun CommonToast(
                 modifier
                     .fillMaxSize()
                     .padding(horizontal = CommonToastDefaults.HorizontalPadding)
-                    .padding(bottom = CommonToastDefaults.BottomOffset),
+                    .padding(bottom = bottomOffset),
             contentAlignment = Alignment.BottomCenter,
         ) {
             Box(

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
@@ -43,6 +43,7 @@ data class SignUpPhotographerState(
     val selectedAreas: List<Area> = emptyList(),
     val searchError: String? = null,
     val toastMessage: String? = null,
+    val toastMessageResId: Int? = null,
     val showToast: Boolean = false,
     val availableCameraBrands: List<DeviceBrand> = emptyList(),
     val availableCameraTypes: List<String> = emptyList(),

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
@@ -183,7 +183,7 @@ class SignUpPhotographerViewModel
                 }
 
                 is SignUpPhotographerIntent.DismissToast -> {
-                    _state.update { it.copy(showToast = false, toastMessage = null) }
+                    _state.update { it.copy(showToast = false, toastMessage = null, toastMessageResId = null) }
                 }
 
                 is SignUpPhotographerIntent.Navigate -> {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/AreaSearchHandler.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/handler/AreaSearchHandler.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer.handler
 
+import com.hm.picplz.feature.auth.R
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.ClearSearchResults
 import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerIntent.RemoveSelectedArea
@@ -32,6 +33,13 @@ class AreaSearchHandler {
                 val isAlreadySelected =
                     currentState.selectedAreas.any { it.id == intent.area.id }
 
+                if (isAlreadySelected) {
+                    return currentState.copy(
+                        toastMessageResId = R.string.sign_up_main_location_already_selected,
+                        showToast = true,
+                    )
+                }
+
                 if (!isAlreadySelected && currentState.selectedAreas.size >= 5) {
                     return currentState.copy(
                         toastMessage = "활동 지역은 최대 5개까지 선택할 수 있습니다.",
@@ -39,14 +47,7 @@ class AreaSearchHandler {
                     )
                 }
 
-                val newSelectedAreas =
-                    if (isAlreadySelected) {
-                        currentState.selectedAreas.filter { it.id != intent.area.id }
-                    } else {
-                        currentState.selectedAreas + intent.area
-                    }
-
-                currentState.copy(selectedAreas = newSelectedAreas)
+                currentState.copy(selectedAreas = currentState.selectedAreas + intent.area)
             }
 
             is RemoveSelectedArea -> {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/views/SignUpMainLocationScreen.kt
@@ -1,5 +1,9 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer.views
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -11,7 +15,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -26,16 +29,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -63,6 +67,7 @@ import com.hm.picplz.ui.theme.PicplzTheme
 import com.hm.picplz.ui.theme.pretendardTypography
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.feature.auth.R as AuthR
 
 @Composable
 fun SignUpMainLocationScreen(
@@ -73,7 +78,17 @@ fun SignUpMainLocationScreen(
 ) {
     val currentState by viewModel.state.collectAsState()
     val focusManager = LocalFocusManager.current
-    var isSearchFieldFocused by remember { mutableStateOf(false) }
+    val activity = LocalContext.current.findActivity()
+
+    DisposableEffect(activity) {
+        val previousSoftInputMode = activity?.window?.attributes?.softInputMode
+        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
+        onDispose {
+            previousSoftInputMode?.let { softInputMode ->
+                activity.window.setSoftInputMode(softInputMode)
+            }
+        }
+    }
 
     LaunchedEffect(currentState.searchQuery) {
         if (currentState.searchQuery.isNotBlank()) {
@@ -91,8 +106,7 @@ fun SignUpMainLocationScreen(
     Scaffold(
         modifier =
             modifier
-                .fillMaxSize()
-                .imePadding(),
+                .fillMaxSize(),
         containerColor = MainThemeColor.White,
     ) {
             innerPadding ->
@@ -108,7 +122,7 @@ fun SignUpMainLocationScreen(
                     },
         ) {
             CommonTopBar(
-                text = "주 촬영지",
+                text = stringResource(AuthR.string.sign_up_main_location_top_bar_title),
                 onClickBack = { viewModel.handleIntent(NavigateToPrev) },
             )
             Column(
@@ -134,6 +148,7 @@ fun SignUpMainLocationScreen(
                     },
                     placeholder = "구 단위로 검색 (ex, 마포구)",
                     onSearchClick = {
+                        focusManager.clearFocus()
                         viewModel.handleIntent(
                             SignUpPhotographerIntent.SearchArea(
                                 currentState.searchQuery,
@@ -141,42 +156,17 @@ fun SignUpMainLocationScreen(
                         )
                     },
                     keyboardActions = {
+                        focusManager.clearFocus()
                         viewModel.handleIntent(
                             SignUpPhotographerIntent.SearchArea(
                                 currentState.searchQuery,
                             ),
                         )
                     },
-                    onFocusChanged = { isFocused ->
-                        isSearchFieldFocused = isFocused
-                    },
                 )
-                if (currentState.selectedAreas.isNotEmpty()) {
-                    LazyRow(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        items(currentState.selectedAreas) { area ->
-                            AreaTag(
-                                label = area.name.split(" ").lastOrNull() ?: area.name,
-                                onRemove = {
-                                    focusManager.clearFocus()
-                                    viewModel.handleIntent(
-                                        SignUpPhotographerIntent.RemoveSelectedArea(area),
-                                    )
-                                },
-                            )
-                        }
-                    }
-                }
+                Spacer(modifier = Modifier.height(20.dp))
 
-                val spacingToIconText = if (currentState.hasSearchCompleted) 40.dp else 20.dp
-                Spacer(modifier = Modifier.height(spacingToIconText))
-
-                val showIconText = !isSearchFieldFocused || currentState.hasSearchCompleted
+                val showIconText = currentState.searchQuery.isBlank() || currentState.hasSearchCompleted
 
                 if (showIconText) {
                     Row(
@@ -199,13 +189,12 @@ fun SignUpMainLocationScreen(
                             color = MainThemeColor.Black,
                         )
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(4.dp))
                 }
                 Box(
                     modifier =
                         Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 15.dp),
+                            .fillMaxWidth(),
                 ) {
                     when {
                         currentState.isSearching -> {
@@ -223,7 +212,7 @@ fun SignUpMainLocationScreen(
                         currentState.searchResults.isNotEmpty() -> {
                             Column {
                                 LazyColumn(
-                                    modifier = Modifier.padding(top = 16.dp),
+                                    modifier = Modifier.padding(top = 4.dp),
                                 ) {
                                     itemsIndexed(currentState.searchResults) { index, area ->
                                         val isSelected = currentState.selectedAreas.any { it.id == area.id }
@@ -297,13 +286,36 @@ fun SignUpMainLocationScreen(
             Box(
                 modifier =
                     Modifier
-                        .height(120.dp)
+                        .height(112.dp)
                         .fillMaxWidth()
                         .padding(horizontal = 15.dp),
-                contentAlignment = Alignment.Center,
             ) {
+                if (currentState.selectedAreas.isNotEmpty()) {
+                    LazyRow(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.BottomStart)
+                                .padding(bottom = 64.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(currentState.selectedAreas) { area ->
+                            AreaTag(
+                                label = area.name.split(" ").lastOrNull() ?: area.name,
+                                onRemove = {
+                                    focusManager.clearFocus()
+                                    viewModel.handleIntent(
+                                        SignUpPhotographerIntent.RemoveSelectedArea(area),
+                                    )
+                                },
+                            )
+                        }
+                    }
+                }
+
                 CommonBottomButton(
                     text = "다음",
+                    modifier = Modifier.align(Alignment.BottomCenter),
                     onClick = {
                         viewModel.handleIntent(Navigate(SignUpDevice))
                     },
@@ -311,10 +323,12 @@ fun SignUpMainLocationScreen(
                 )
             }
         }
-        currentState.toastMessage?.let { message ->
+        val toastMessage = currentState.toastMessageResId?.let { stringResource(it) } ?: currentState.toastMessage
+        toastMessage?.let { message ->
             CommonToast(
                 message = message,
                 isVisible = currentState.showToast,
+                bottomOffset = 120.dp,
                 onDismiss = {
                     viewModel.handleIntent(SignUpPhotographerIntent.DismissToast)
                 },
@@ -333,6 +347,14 @@ fun SignUpMainLocationScreen(
                 else -> {}
             }
         }
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? {
+    return when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
     }
 }
 

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="sign_up_profile_image_guide_photographer">이제 촬영지와 촬영 기기를\n선택할 거예요</string>
     <string name="sign_up_profile_image_skip">다음에 설정하기</string>
     <string name="sign_up_client_top_bar_title">고객 선택</string>
+    <string name="sign_up_main_location_top_bar_title">주 촬영지 선택</string>
+    <string name="sign_up_main_location_already_selected">이미 선택된 항목입니다.</string>
 </resources>


### PR DESCRIPTION
## 개요
가입화면의 촬영지 검색 화면과 같은 ui를 쓰는 작가 마이페이지>촬영지 수정 작업 중 아직 해당 페이지 ui 최신화가 안되어있어서 해당 작업 먼저 선제 작업했습니다.

## 세부사항
- 촬영지 검색 화면(`SignUpMainLocationScreen`)의 레이아웃과 검색/선택 UX를 정리했습니다.
- 기존에는 선택된 지역 태그가 검색창 아래에 표시되어 검색 결과 리스트와 섞여 보였고, 리스트 좌우 패딩과 키보드 동작 때문에 화면 사용성이 어색했습니다. 이번 PR에서는 선택 태그를 하단 `다음` 버튼 위로 옮기고, 검색 결과 영역과 하단 CTA 영역을 분리했습니다.

## 변경 사항
- 선택 태그 위치 조정
  - 기존: 검색창 아래에 선택 태그 노출
  - 변경: 하단 `다음` 버튼 바로 위에 선택 태그 노출
  - 검색 결과 리스트와 선택 태그 영역이 시각적으로 섞이지 않도록 분리
- 검색 결과 리스트 레이아웃 정리
  - 리스트 외곽 좌우 추가 패딩 제거
  - 검색창과 `인근 지역`/`검색 결과` 헤더 간격을 20dp로 고정
  - 헤더와 리스트 사이 간격을 줄여 검색 결과가 더 붙어서 보이도록 조정
- 검색창/키보드 동작 개선
  - 검색창에 포커스만 있어도 `인근 지역` 헤더가 사라지던 동작 수정
  - 검색어가 비어 있으면 `인근 지역` 헤더를 유지
  - 키보드 Search/Enter 또는 검색 아이콘 클릭 시 포커스를 해제해 키보드를 닫도록 처리
  - 주 촬영지 선택 화면 진입 중에는 하단 `다음` 버튼이 키보드 위로 밀리지 않도록 soft input mode를 조정하고, 화면 종료 시 기존 설정으로 복원
- 선택/토스트 동작 개선
  - 이미 선택된 지역을 다시 누르면 선택 해제하지 않고 `이미 선택된 항목입니다.` 토스트 표시
  - 선택 태그의 X 버튼으로만 선택 해제 가능하도록 동작 정리
  - 토스트가 하단 버튼과 겹치지 않도록 `CommonToast`에 `bottomOffset` 옵션 추가
- 문자열 리소스 정리
  - 새로 추가한 `주 촬영지 선택`, `이미 선택된 항목입니다.` 문구를 `strings.xml`로 분리

## 구현 사항

<img width="400" height="867" alt="KakaoTalk_Video_2026-05-10-23-39-04" src="https://github.com/user-attachments/assets/56257a3a-782e-43ff-aff8-543496de7717" />

## 검증
- SignUpPhotographer > 주 촬영지 선택 화면 진입 확인
- 주변지역/검색 결과 표시 확인
- 검색창 입력 중 하단 `다음` 버튼 위치 고정 확인
- 선택된 지역 재클릭 시 토스트 표시 확인

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [x] 테스트를 실행했습니다.
- [x] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #178