### PR TITLE
✨: 작가 키워드 수정 플로우 추가

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/di/ApiModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/ApiModule.kt
@@ -36,7 +36,8 @@ object NetworkModule {
     @Singleton
     fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
         return HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
+            redactHeader("Authorization")
+            level = HttpLoggingInterceptor.Level.BASIC
         }
     }
 

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -21,6 +21,7 @@ import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPageOrderSheet
 import com.hm.picplz.navigation.model.MyPagePackageEdit
 import com.hm.picplz.navigation.model.MyPagePhotographer
+import com.hm.picplz.navigation.model.MyPagePhotographerKeywordEdit
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
@@ -39,6 +40,7 @@ import com.hm.picplz.ui.screen.my_page.FollowedPhotographersScreen
 import com.hm.picplz.ui.screen.my_page.MyPageModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageOrderSheetScreen
 import com.hm.picplz.ui.screen.my_page.MyPagePackageEditRoute
+import com.hm.picplz.ui.screen.my_page.MyPagePhotographerKeywordEditRoute
 import com.hm.picplz.ui.screen.my_page.MyPagePhotographerModifyProfileScreen
 import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
@@ -113,6 +115,14 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MyPagePhotographerModifyProfile> {
         MyPagePhotographerModifyProfileScreen(navController = navController)
+    }
+
+    composable<MyPagePhotographerKeywordEdit> { backStackEntry ->
+        val args = backStackEntry.toRoute<MyPagePhotographerKeywordEdit>()
+        MyPagePhotographerKeywordEditRoute(
+            navController = navController,
+            photographerId = args.photographerId,
+        )
     }
 
     composable<MyPagePackageEdit> {

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -83,6 +83,11 @@ data class MyPagePhotographer(
 
 @Serializable object MyPagePhotographerModifyProfile : NavigationRoute
 
+@Serializable
+data class MyPagePhotographerKeywordEdit(
+    val photographerId: Long,
+) : NavigationRoute
+
 @Serializable object MyPagePackageEdit : NavigationRoute
 
 @Serializable object MyPageMyReviews : NavigationRoute

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.data.api
 import com.hm.picplz.data.model.ApiResponse
 import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
+import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerDetailDto
 import com.hm.picplz.data.model.PhotographerRatingDto
 import com.hm.picplz.data.model.PortfolioDto
@@ -11,6 +12,7 @@ import com.hm.picplz.data.model.ReviewListDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -19,6 +21,16 @@ interface PhotographerApi {
     @POST("api/v1/photographers")
     suspend fun createPhotographer(
         @Body request: CreatePhotographerRequest,
+    ): Response<Unit>
+
+    @POST("api/v1/photographers/photo-mood")
+    suspend fun addPhotoMood(
+        @Body request: PhotoMoodRequest,
+    ): Response<Unit>
+
+    @HTTP(method = "DELETE", path = "api/v1/photographers/photo-mood", hasBody = true)
+    suspend fun deletePhotoMood(
+        @Body request: PhotoMoodRequest,
     ): Response<Unit>
 
     @GET("api/v1/members/location/nearby")

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerModel.kt
@@ -16,6 +16,10 @@ data class ActiveAreaRequest(
     val priority: Int,
 )
 
+data class PhotoMoodRequest(
+    val photoMood: String,
+)
+
 data class PhotographerCameraRequest(
     val type: String?,
     val brand: String,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
@@ -46,4 +46,12 @@ class PhotographerRepositoryImpl
                     )
                 }
             }
+
+        override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+            photographerService.getPhotographerMoodKeywords(photographerId)
+
+        override suspend fun addPhotoMood(photoMood: String): Result<Unit> = photographerService.addPhotoMood(photoMood)
+
+        override suspend fun deletePhotoMood(photoMood: String): Result<Unit> =
+            photographerService.deletePhotoMood(photoMood)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -55,7 +55,9 @@ class PhotographerServiceImpl
             photographerSource.createPhotographer(request)
 
         override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
-            photographerSource.getPhotographerInfo(photographerId).map { it.photoMoods ?: emptyList() }
+            photographerSource.getPhotographerInfo(photographerId).map { detail ->
+                detail.photoMoods?.mapNotNull { it?.trim() }?.filter(String::isNotEmpty) ?: emptyList()
+            }
 
         override suspend fun addPhotoMood(photoMood: String): Result<Unit> =
             photographerSource.addPhotoMood(PhotoMoodRequest(photoMood = photoMood))

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -5,6 +5,7 @@ import com.hm.picplz.data.mapper.toPhotographerInfo
 import com.hm.picplz.data.mapper.toReviewData
 import com.hm.picplz.data.mapper.toShootingPackage
 import com.hm.picplz.data.model.CreatePhotographerRequest
+import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerRatingDto
 import com.hm.picplz.data.model.PortfolioDto
 import com.hm.picplz.data.source.PhotographerSource
@@ -16,6 +17,12 @@ import javax.inject.Inject
 
 interface PhotographerService {
     suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit>
+
+    suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>>
+
+    suspend fun addPhotoMood(photoMood: String): Result<Unit>
+
+    suspend fun deletePhotoMood(photoMood: String): Result<Unit>
 
     suspend fun getNearbyPhotographers(
         longitude: Double,
@@ -46,6 +53,15 @@ class PhotographerServiceImpl
     ) : PhotographerService {
         override suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit> =
             photographerSource.createPhotographer(request)
+
+        override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+            photographerSource.getPhotographerInfo(photographerId).map { it.photoMoods ?: emptyList() }
+
+        override suspend fun addPhotoMood(photoMood: String): Result<Unit> =
+            photographerSource.addPhotoMood(PhotoMoodRequest(photoMood = photoMood))
+
+        override suspend fun deletePhotoMood(photoMood: String): Result<Unit> =
+            photographerSource.deletePhotoMood(PhotoMoodRequest(photoMood = photoMood))
 
         override suspend fun getNearbyPhotographers(
             longitude: Double,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.data.source
 import com.hm.picplz.data.api.PhotographerApi
 import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
+import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerDetailDto
 import com.hm.picplz.data.model.PhotographerRatingDto
 import com.hm.picplz.data.model.PortfolioDto
@@ -14,6 +15,10 @@ import javax.inject.Inject
 
 interface PhotographerSource {
     suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit>
+
+    suspend fun addPhotoMood(request: PhotoMoodRequest): Result<Unit>
+
+    suspend fun deletePhotoMood(request: PhotoMoodRequest): Result<Unit>
 
     suspend fun getNearbyPhotographers(
         longitude: Double,
@@ -44,6 +49,12 @@ class PhotographerSourceImpl
     ) : PhotographerSource {
         override suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit> =
             safeApiCallUnit { photographerApi.createPhotographer(request) }
+
+        override suspend fun addPhotoMood(request: PhotoMoodRequest): Result<Unit> =
+            safeApiCallUnit { photographerApi.addPhotoMood(request) }
+
+        override suspend fun deletePhotoMood(request: PhotoMoodRequest): Result<Unit> =
+            safeApiCallUnit { photographerApi.deletePhotoMood(request) }
 
         override suspend fun getNearbyPhotographers(
             longitude: Double,

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerRepository.kt
@@ -14,4 +14,10 @@ interface PhotographerRepository {
         photographerId: Long,
         reviewSort: String = "RECOMMENDED",
     ): Result<PhotographerDetail>
+
+    suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>>
+
+    suspend fun addPhotoMood(photoMood: String): Result<Unit>
+
+    suspend fun deletePhotoMood(photoMood: String): Result<Unit>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerMoodKeywordsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerMoodKeywordsUseCase.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.repository.PhotographerRepository
+import javax.inject.Inject
+
+class GetPhotographerMoodKeywordsUseCase
+    @Inject
+    constructor(
+        private val photographerRepository: PhotographerRepository,
+    ) {
+        suspend operator fun invoke(photographerId: Long): Result<List<String>> =
+            photographerRepository.getPhotographerMoodKeywords(photographerId)
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerMoodKeywordsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerMoodKeywordsUseCase.kt
@@ -1,0 +1,34 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.domain.repository.PhotographerRepository
+import javax.inject.Inject
+
+class UpdatePhotographerMoodKeywordsUseCase
+    @Inject
+    constructor(
+        private val photographerRepository: PhotographerRepository,
+    ) {
+        suspend operator fun invoke(
+            originalKeywords: List<String>,
+            selectedKeywords: List<String>,
+        ): Result<Unit> =
+            runCatching {
+                val original =
+                    originalKeywords
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+                        .toSet()
+                val selected =
+                    selectedKeywords
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+                        .toSet()
+
+                selected.minus(original).forEach { keyword ->
+                    photographerRepository.addPhotoMood(keyword).getOrThrow()
+                }
+                original.minus(selected).forEach { keyword ->
+                    photographerRepository.deletePhotoMood(keyword).getOrThrow()
+                }
+            }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageIntent.kt
@@ -33,6 +33,10 @@ sealed interface MyPageIntent {
 
     data object NavigateToPortfolioEdit : MyPageIntent
 
+    data class ApplyPhotographerKeywordSummary(
+        val keywordSummary: String,
+    ) : MyPageIntent
+
     data class ApplyDevPhotographerPreview(
         val hasShootings: Boolean,
         val hasPackagePreview: Boolean,

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditIntent.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditIntent.kt
@@ -1,0 +1,27 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePhotographerKeywordEditIntent {
+    data class LoadKeywords(
+        val photographerId: Long,
+        val defaultKeywords: List<String>,
+    ) : MyPagePhotographerKeywordEditIntent
+
+    data object NavigateToPrev : MyPagePhotographerKeywordEditIntent
+
+    data object SaveKeywords : MyPagePhotographerKeywordEditIntent
+
+    data class AddKeywordChip(val label: String) : MyPagePhotographerKeywordEditIntent
+
+    data class DeleteKeywordChip(val chipId: String) : MyPagePhotographerKeywordEditIntent
+
+    data class UpdateKeywordChip(val chipId: String, val label: String) : MyPagePhotographerKeywordEditIntent
+
+    data class ToggleKeywordSelection(
+        val chipId: String,
+        val label: String,
+    ) : MyPagePhotographerKeywordEditIntent
+
+    data class SetEditingChipId(val chipId: String?) : MyPagePhotographerKeywordEditIntent
+
+    data object DismissToast : MyPagePhotographerKeywordEditIntent
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.my_page
 
 import ChipHeight
 import CommonChip
+import android.content.Context
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -44,6 +46,7 @@ import com.hm.picplz.ui.util.SetStatusBarStyle
 import kotlinx.coroutines.flow.collectLatest
 
 private const val ADD_KEYWORD_CHIP_ID = "ADD_KEYWORD"
+private const val KEYWORD_SUMMARY_VISIBLE_COUNT = 3
 
 @Composable
 fun MyPagePhotographerKeywordEditRoute(
@@ -54,6 +57,7 @@ fun MyPagePhotographerKeywordEditRoute(
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle().value
     val defaultKeywords = stringArrayResource(R.array.my_page_default_mood_keywords).toList()
+    val context = LocalContext.current
 
     SetStatusBarStyle()
 
@@ -70,7 +74,7 @@ fun MyPagePhotographerKeywordEditRoute(
         viewModel.sideEffect.collectLatest { sideEffect ->
             when (sideEffect) {
                 is MyPagePhotographerKeywordEditSideEffect.NavigateToPrev -> {
-                    sideEffect.keywordSummary?.let { keywordSummary ->
+                    sideEffect.selectedKeywords?.toKeywordSummary(context)?.let { keywordSummary ->
                         navController.previousBackStackEntry
                             ?.savedStateHandle
                             ?.set(KEY_PHOTOGRAPHER_KEYWORD_SUMMARY, keywordSummary)
@@ -86,6 +90,17 @@ fun MyPagePhotographerKeywordEditRoute(
         onIntent = viewModel::handleIntent,
         modifier = modifier,
     )
+}
+
+private fun List<String>.toKeywordSummary(context: Context): String {
+    val visibleKeywords = take(KEYWORD_SUMMARY_VISIBLE_COUNT).joinToString { "#$it" }
+    val hiddenCount = size - KEYWORD_SUMMARY_VISIBLE_COUNT
+
+    return if (hiddenCount > 0) {
+        context.getString(R.string.my_page_keyword_summary_with_more, visibleKeywords, hiddenCount)
+    } else {
+        visibleKeywords
+    }
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
@@ -69,7 +69,14 @@ fun MyPagePhotographerKeywordEditRoute(
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collectLatest { sideEffect ->
             when (sideEffect) {
-                is MyPagePhotographerKeywordEditSideEffect.NavigateToPrev -> navController.popBackStack()
+                is MyPagePhotographerKeywordEditSideEffect.NavigateToPrev -> {
+                    sideEffect.keywordSummary?.let { keywordSummary ->
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set(KEY_PHOTOGRAPHER_KEYWORD_SUMMARY, keywordSummary)
+                    }
+                    navController.popBackStack()
+                }
             }
         }
     }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditScreen.kt
@@ -1,0 +1,239 @@
+package com.hm.picplz.ui.screen.my_page
+
+import ChipHeight
+import CommonChip
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.hm.picplz.common.model.ChipItem
+import com.hm.picplz.common.model.ChipMode
+import com.hm.picplz.feature.mypage.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonToast
+import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.ui.util.SetStatusBarStyle
+import kotlinx.coroutines.flow.collectLatest
+
+private const val ADD_KEYWORD_CHIP_ID = "ADD_KEYWORD"
+
+@Composable
+fun MyPagePhotographerKeywordEditRoute(
+    navController: NavHostController,
+    photographerId: Long,
+    modifier: Modifier = Modifier,
+    viewModel: MyPagePhotographerKeywordEditViewModel = hiltViewModel(),
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle().value
+    val defaultKeywords = stringArrayResource(R.array.my_page_default_mood_keywords).toList()
+
+    SetStatusBarStyle()
+
+    LaunchedEffect(photographerId, defaultKeywords) {
+        viewModel.handleIntent(
+            MyPagePhotographerKeywordEditIntent.LoadKeywords(
+                photographerId = photographerId,
+                defaultKeywords = defaultKeywords,
+            ),
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            when (sideEffect) {
+                is MyPagePhotographerKeywordEditSideEffect.NavigateToPrev -> navController.popBackStack()
+            }
+        }
+    }
+
+    MyPagePhotographerKeywordEditScreen(
+        state = state,
+        onIntent = viewModel::handleIntent,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MyPagePhotographerKeywordEditScreen(
+    state: MyPagePhotographerKeywordEditState,
+    onIntent: (MyPagePhotographerKeywordEditIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                        onIntent(MyPagePhotographerKeywordEditIntent.SetEditingChipId(null))
+                    })
+                },
+        containerColor = MainThemeColor.White,
+    ) { innerPadding ->
+        Column(
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            CommonTopBar(
+                text = stringResource(R.string.my_page_keyword_edit_title),
+                onClickBack = { onIntent(MyPagePhotographerKeywordEditIntent.NavigateToPrev) },
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(horizontal = 15.dp)
+                        .imePadding()
+                        .verticalScroll(scrollState),
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Spacer(modifier = Modifier.height(80.dp))
+                    Text(
+                        text = stringResource(R.string.my_page_keyword_edit_description),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Spacer(modifier = Modifier.height(20.dp))
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                    ) {
+                        state.keywordChipList.forEach { chip ->
+                            CommonChip(
+                                id = chip.id,
+                                label = chip.label,
+                                initialMode = ChipMode.DEFAULT,
+                                isEditing = state.editingChipId == chip.id,
+                                isEditable = chip.isEditable,
+                                onClickDefaultMode = {
+                                    focusManager.clearFocus()
+                                    onIntent(MyPagePhotographerKeywordEditIntent.SetEditingChipId(null))
+                                    onIntent(
+                                        MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection(
+                                            chipId = chip.id,
+                                            label = chip.label,
+                                        ),
+                                    )
+                                },
+                                isSelected = state.selectedKeywordChipList.any { it.id == chip.id },
+                                onUpdate = { value ->
+                                    onIntent(
+                                        MyPagePhotographerKeywordEditIntent.UpdateKeywordChip(
+                                            chip.id,
+                                            value,
+                                        ),
+                                    )
+                                },
+                                onEdit = {
+                                    onIntent(
+                                        MyPagePhotographerKeywordEditIntent.SetEditingChipId(chip.id),
+                                    )
+                                },
+                                onEndEdit = {
+                                    focusManager.clearFocus()
+                                    onIntent(
+                                        MyPagePhotographerKeywordEditIntent.SetEditingChipId(null),
+                                    )
+                                },
+                                height = ChipHeight.BIG,
+                            )
+                        }
+                        CommonChip(
+                            id = ADD_KEYWORD_CHIP_ID,
+                            initialMode = ChipMode.ADD,
+                            isEditing = state.editingChipId == ADD_KEYWORD_CHIP_ID,
+                            onEdit = {
+                                onIntent(
+                                    MyPagePhotographerKeywordEditIntent.SetEditingChipId(ADD_KEYWORD_CHIP_ID),
+                                )
+                            },
+                            onAdd = { value ->
+                                onIntent(MyPagePhotographerKeywordEditIntent.AddKeywordChip(value))
+                                onIntent(MyPagePhotographerKeywordEditIntent.SetEditingChipId(null))
+                            },
+                            height = ChipHeight.BIG,
+                        )
+                    }
+                }
+            }
+            Box(
+                modifier =
+                    Modifier
+                        .height(120.dp)
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CommonBottomButton(
+                    text = stringResource(R.string.my_page_keyword_edit_save),
+                    onClick = { onIntent(MyPagePhotographerKeywordEditIntent.SaveKeywords) },
+                    enabled = state.hasChanges && !state.isSaving && !state.isLoading,
+                )
+            }
+        }
+        state.toastMessageResId?.let { messageResId ->
+            CommonToast(
+                message = stringResource(messageResId),
+                isVisible = state.showToast,
+                onDismiss = { onIntent(MyPagePhotographerKeywordEditIntent.DismissToast) },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyPagePhotographerKeywordEditScreenPreview() {
+    PicplzTheme {
+        MyPagePhotographerKeywordEditScreen(
+            state =
+                MyPagePhotographerKeywordEditState(
+                    keywordChipList =
+                        listOf(
+                            ChipItem(id = "1", label = "캐주얼"),
+                            ChipItem(id = "2", label = "심플"),
+                        ),
+                    selectedKeywordChipList =
+                        listOf(ChipItem(id = "1", label = "캐주얼")),
+                ),
+            onIntent = {},
+        )
+    }
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
@@ -2,6 +2,6 @@ package com.hm.picplz.ui.screen.my_page
 
 sealed interface MyPagePhotographerKeywordEditSideEffect {
     data class NavigateToPrev(
-        val keywordSummary: String? = null,
+        val selectedKeywords: List<String>? = null,
     ) : MyPagePhotographerKeywordEditSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.my_page
+
+sealed interface MyPagePhotographerKeywordEditSideEffect {
+    data object NavigateToPrev : MyPagePhotographerKeywordEditSideEffect
+}

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditSideEffect.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.ui.screen.my_page
 
 sealed interface MyPagePhotographerKeywordEditSideEffect {
-    data object NavigateToPrev : MyPagePhotographerKeywordEditSideEffect
+    data class NavigateToPrev(
+        val keywordSummary: String? = null,
+    ) : MyPagePhotographerKeywordEditSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditState.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditState.kt
@@ -1,0 +1,29 @@
+package com.hm.picplz.ui.screen.my_page
+
+import com.hm.picplz.common.model.ChipItem
+
+data class MyPagePhotographerKeywordEditState(
+    val photographerId: Long = 0L,
+    val keywordChipList: List<ChipItem> = emptyList(),
+    val selectedKeywordChipList: List<ChipItem> = emptyList(),
+    val originalKeywords: List<String> = emptyList(),
+    val editingChipId: String? = null,
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
+) {
+    val hasChanges: Boolean
+        get() =
+            originalKeywords.normalizedKeywordSet() !=
+                selectedKeywordChipList.map { it.label }.normalizedKeywordSet()
+
+    companion object {
+        fun idle() = MyPagePhotographerKeywordEditState()
+    }
+}
+
+internal fun List<String>.normalizedKeywordSet(): Set<String> =
+    map(String::trim)
+        .filter(String::isNotEmpty)
+        .toSet()

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
@@ -37,7 +37,7 @@ class MyPagePhotographerKeywordEditViewModel
                     )
                 is MyPagePhotographerKeywordEditIntent.NavigateToPrev ->
                     sendSideEffect(
-                        MyPagePhotographerKeywordEditSideEffect.NavigateToPrev,
+                        MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(),
                     )
                 is MyPagePhotographerKeywordEditIntent.SaveKeywords -> saveKeywords()
                 is MyPagePhotographerKeywordEditIntent.AddKeywordChip ->
@@ -205,7 +205,11 @@ class MyPagePhotographerKeywordEditViewModel
                     selectedKeywords = currentState.selectedKeywordChipList.map { it.label },
                 ).onSuccess {
                     _state.update { it.copy(isSaving = false) }
-                    sendSideEffect(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev)
+                    sendSideEffect(
+                        MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(
+                            keywordSummary = currentState.selectedKeywordChipList.toKeywordSummary(),
+                        ),
+                    )
                 }.onFailure {
                     getPhotographerMoodKeywordsUseCase(currentState.photographerId)
                         .onSuccess { keywords -> applyKeywords(keywords) }
@@ -246,7 +250,23 @@ class MyPagePhotographerKeywordEditViewModel
             }
         }
 
+        private fun List<ChipItem>.toKeywordSummary(): String {
+            val keywords = map { it.label.trim() }.filter(String::isNotEmpty).distinct()
+            val visibleKeywords = keywords.take(KEYWORD_SUMMARY_VISIBLE_COUNT).joinToString { "#$it" }
+            val hiddenCount = keywords.size - KEYWORD_SUMMARY_VISIBLE_COUNT
+
+            return if (hiddenCount > 0) {
+                "$visibleKeywords 외 ${hiddenCount}개 키워드"
+            } else {
+                visibleKeywords
+            }
+        }
+
         private fun sendSideEffect(sideEffect: MyPagePhotographerKeywordEditSideEffect) {
             viewModelScope.launch { _sideEffect.send(sideEffect) }
+        }
+
+        companion object {
+            private const val KEYWORD_SUMMARY_VISIBLE_COUNT = 3
         }
     }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
@@ -1,0 +1,252 @@
+package com.hm.picplz.ui.screen.my_page
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.model.ChipItem
+import com.hm.picplz.domain.usecase.GetPhotographerMoodKeywordsUseCase
+import com.hm.picplz.domain.usecase.UpdatePhotographerMoodKeywordsUseCase
+import com.hm.picplz.feature.mypage.R
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyPagePhotographerKeywordEditViewModel
+    @Inject
+    constructor(
+        private val getPhotographerMoodKeywordsUseCase: GetPhotographerMoodKeywordsUseCase,
+        private val updatePhotographerMoodKeywordsUseCase: UpdatePhotographerMoodKeywordsUseCase,
+    ) : ViewModel() {
+        private val _state = MutableStateFlow(MyPagePhotographerKeywordEditState.idle())
+        val state: StateFlow<MyPagePhotographerKeywordEditState> get() = _state
+
+        private val _sideEffect = Channel<MyPagePhotographerKeywordEditSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        fun handleIntent(intent: MyPagePhotographerKeywordEditIntent) {
+            when (intent) {
+                is MyPagePhotographerKeywordEditIntent.LoadKeywords ->
+                    loadKeywords(
+                        photographerId = intent.photographerId,
+                        defaultKeywords = intent.defaultKeywords,
+                    )
+                is MyPagePhotographerKeywordEditIntent.NavigateToPrev ->
+                    sendSideEffect(
+                        MyPagePhotographerKeywordEditSideEffect.NavigateToPrev,
+                    )
+                is MyPagePhotographerKeywordEditIntent.SaveKeywords -> saveKeywords()
+                is MyPagePhotographerKeywordEditIntent.AddKeywordChip ->
+                    addKeywordChip(intent.label)
+                is MyPagePhotographerKeywordEditIntent.DeleteKeywordChip ->
+                    deleteKeywordChip(intent.chipId)
+                is MyPagePhotographerKeywordEditIntent.UpdateKeywordChip ->
+                    updateKeywordChip(
+                        intent.chipId,
+                        intent.label,
+                    )
+                is MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection ->
+                    updateSelectedKeywordChipList(
+                        intent.chipId,
+                        intent.label,
+                    )
+                is MyPagePhotographerKeywordEditIntent.SetEditingChipId ->
+                    _state.update {
+                        it.copy(editingChipId = intent.chipId)
+                    }
+                is MyPagePhotographerKeywordEditIntent.DismissToast ->
+                    _state.update {
+                        it.copy(showToast = false, toastMessageResId = null)
+                    }
+            }
+        }
+
+        private fun loadKeywords(
+            photographerId: Long,
+            defaultKeywords: List<String>,
+        ) {
+            if (_state.value.photographerId == photographerId && _state.value.originalKeywords.isNotEmpty()) {
+                return
+            }
+
+            viewModelScope.launch {
+                _state.update {
+                    it.copy(
+                        photographerId = photographerId,
+                        keywordChipList = defaultKeywords.toKeywordChips(),
+                        isLoading = true,
+                    )
+                }
+                getPhotographerMoodKeywordsUseCase(photographerId)
+                    .onSuccess { keywords -> applyKeywords(keywords, defaultKeywords) }
+                    .onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                showToast = true,
+                                toastMessageResId = R.string.my_page_keyword_edit_load_failed,
+                            )
+                        }
+                    }
+            }
+        }
+
+        private fun applyKeywords(
+            keywords: List<String>,
+            defaultKeywords: List<String> = _state.value.keywordChipList.map { it.label },
+        ) {
+            val normalizedKeywords = keywords.map(String::trim).filter(String::isNotEmpty)
+            val defaultChips = defaultKeywords.toKeywordChips()
+            val defaultLabels = defaultChips.map { it.label }.toSet()
+            val customChips =
+                normalizedKeywords
+                    .filterNot { it in defaultLabels }
+                    .distinct()
+                    .mapIndexed { index, keyword ->
+                        ChipItem(id = "custom_${index + 1}", label = keyword, isEditable = true)
+                    }
+            val chips = defaultChips + customChips
+            val selected = chips.filter { chip -> normalizedKeywords.contains(chip.label) }
+
+            _state.update {
+                it.copy(
+                    keywordChipList = chips,
+                    selectedKeywordChipList = selected,
+                    originalKeywords = normalizedKeywords,
+                    editingChipId = null,
+                    isLoading = false,
+                    isSaving = false,
+                )
+            }
+        }
+
+        private fun addKeywordChip(label: String) {
+            val keyword = label.trim()
+            if (keyword.isEmpty()) return
+            if (_state.value.keywordChipList.any { it.label == keyword }) {
+                showDuplicateToast()
+                return
+            }
+
+            val newId = nextChipId()
+            val newChip = ChipItem(id = newId, label = keyword, isEditable = true)
+            _state.update {
+                it.copy(
+                    keywordChipList = it.keywordChipList + newChip,
+                    selectedKeywordChipList = it.selectedKeywordChipList + newChip,
+                )
+            }
+        }
+
+        private fun deleteKeywordChip(chipId: String) {
+            _state.update {
+                it.copy(
+                    keywordChipList = it.keywordChipList.filterNot { chip -> chip.id == chipId },
+                    selectedKeywordChipList = it.selectedKeywordChipList.filterNot { chip -> chip.id == chipId },
+                )
+            }
+        }
+
+        private fun updateKeywordChip(
+            chipId: String,
+            label: String,
+        ) {
+            val keyword = label.trim()
+            if (keyword.isEmpty()) {
+                deleteKeywordChip(chipId)
+                return
+            }
+            if (_state.value.keywordChipList.any { it.id != chipId && it.label == keyword }) {
+                showDuplicateToast()
+                return
+            }
+
+            _state.update {
+                it.copy(
+                    keywordChipList =
+                        it.keywordChipList.map { chip ->
+                            if (chip.id == chipId) chip.copy(label = keyword) else chip
+                        },
+                    selectedKeywordChipList =
+                        it.selectedKeywordChipList.map { chip ->
+                            if (chip.id == chipId) chip.copy(label = keyword) else chip
+                        },
+                )
+            }
+        }
+
+        private fun updateSelectedKeywordChipList(
+            chipId: String,
+            label: String,
+        ) {
+            _state.update {
+                val updatedSelectedChipList =
+                    if (it.selectedKeywordChipList.any { chip -> chip.id == chipId }) {
+                        it.selectedKeywordChipList.filterNot { chip -> chip.id == chipId }
+                    } else {
+                        it.selectedKeywordChipList + ChipItem(id = chipId, label = label.trim())
+                    }
+                it.copy(selectedKeywordChipList = updatedSelectedChipList)
+            }
+        }
+
+        private fun saveKeywords() {
+            val currentState = _state.value
+            if (!currentState.hasChanges || currentState.isSaving) return
+
+            viewModelScope.launch {
+                _state.update { it.copy(isSaving = true) }
+                updatePhotographerMoodKeywordsUseCase(
+                    originalKeywords = currentState.originalKeywords,
+                    selectedKeywords = currentState.selectedKeywordChipList.map { it.label },
+                ).onSuccess {
+                    _state.update { it.copy(isSaving = false) }
+                    sendSideEffect(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev)
+                }.onFailure {
+                    getPhotographerMoodKeywordsUseCase(currentState.photographerId)
+                        .onSuccess { keywords -> applyKeywords(keywords) }
+                        .onFailure { applyKeywords(currentState.originalKeywords) }
+                    _state.update {
+                        it.copy(
+                            isSaving = false,
+                            showToast = true,
+                            toastMessageResId = R.string.my_page_keyword_edit_save_failed,
+                        )
+                    }
+                }
+            }
+        }
+
+        private fun nextChipId(): String {
+            val maxId =
+                _state.value.keywordChipList
+                    .mapNotNull { it.id.removePrefix("custom_").toIntOrNull() }
+                    .maxOrNull() ?: 0
+            return "custom_${maxId + 1}"
+        }
+
+        private fun List<String>.toKeywordChips(): List<ChipItem> =
+            map(String::trim)
+                .filter(String::isNotEmpty)
+                .distinct()
+                .mapIndexed { index, keyword ->
+                    ChipItem(id = (index + 1).toString(), label = keyword)
+                }
+
+        private fun showDuplicateToast() {
+            _state.update {
+                it.copy(
+                    showToast = true,
+                    toastMessageResId = R.string.my_page_keyword_edit_duplicate,
+                )
+            }
+        }
+
+        private fun sendSideEffect(sideEffect: MyPagePhotographerKeywordEditSideEffect) {
+            viewModelScope.launch { _sideEffect.send(sideEffect) }
+        }
+    }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModel.kt
@@ -207,7 +207,7 @@ class MyPagePhotographerKeywordEditViewModel
                     _state.update { it.copy(isSaving = false) }
                     sendSideEffect(
                         MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(
-                            keywordSummary = currentState.selectedKeywordChipList.toKeywordSummary(),
+                            selectedKeywords = currentState.selectedKeywordChipList.toKeywordLabels(),
                         ),
                     )
                 }.onFailure {
@@ -250,23 +250,12 @@ class MyPagePhotographerKeywordEditViewModel
             }
         }
 
-        private fun List<ChipItem>.toKeywordSummary(): String {
-            val keywords = map { it.label.trim() }.filter(String::isNotEmpty).distinct()
-            val visibleKeywords = keywords.take(KEYWORD_SUMMARY_VISIBLE_COUNT).joinToString { "#$it" }
-            val hiddenCount = keywords.size - KEYWORD_SUMMARY_VISIBLE_COUNT
-
-            return if (hiddenCount > 0) {
-                "$visibleKeywords 외 ${hiddenCount}개 키워드"
-            } else {
-                visibleKeywords
-            }
-        }
+        private fun List<ChipItem>.toKeywordLabels(): List<String> =
+            map { it.label.trim() }
+                .filter(String::isNotEmpty)
+                .distinct()
 
         private fun sendSideEffect(sideEffect: MyPagePhotographerKeywordEditSideEffect) {
             viewModelScope.launch { _sideEffect.send(sideEffect) }
-        }
-
-        companion object {
-            private const val KEYWORD_SUMMARY_VISIBLE_COUNT = 3
         }
     }

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -71,6 +71,7 @@ import com.hm.picplz.navigation.model.MyPageFollowedPhotographers
 import com.hm.picplz.navigation.model.MyPageModifyProfile
 import com.hm.picplz.navigation.model.MyPageMyReviews
 import com.hm.picplz.navigation.model.MyPagePackageEdit
+import com.hm.picplz.navigation.model.MyPagePhotographerKeywordEdit
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.SignUpPhotographer
@@ -129,6 +130,11 @@ fun MyPageScreen(
                 }
                 is MyPageSideEffect.NavigateToPhotographerModifyProfile -> {
                     navController.navigate(MyPagePhotographerModifyProfile)
+                }
+                is MyPageSideEffect.NavigateToPhotographerKeywordEdit -> {
+                    navController.navigate(
+                        MyPagePhotographerKeywordEdit(photographerId = effect.photographerId.toLong()),
+                    )
                 }
                 is MyPageSideEffect.NavigateToPackageEdit -> {
                     navController.navigate(MyPagePackageEdit)

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageScreen.kt
@@ -87,6 +87,8 @@ import java.text.NumberFormat
 import java.util.Locale
 import com.hm.picplz.core.ui.R as CoreR
 
+internal const val KEY_PHOTOGRAPHER_KEYWORD_SUMMARY = "photographer_keyword_summary"
+
 @Composable
 fun MyPageScreen(
     modifier: Modifier = Modifier,
@@ -98,8 +100,22 @@ fun MyPageScreen(
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
+    val keywordSummaryResultFlow =
+        remember(savedStateHandle) {
+            savedStateHandle?.getStateFlow<String?>(KEY_PHOTOGRAPHER_KEYWORD_SUMMARY, null)
+        }
+    val keywordSummaryResult by keywordSummaryResultFlow?.collectAsStateWithLifecycle()
+        ?: remember { mutableStateOf(null) }
     val context = LocalContext.current
     var toastMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(keywordSummaryResult) {
+        keywordSummaryResult?.let { keywordSummary ->
+            viewModel.handleIntent(MyPageIntent.ApplyPhotographerKeywordSummary(keywordSummary))
+            savedStateHandle?.remove<String>(KEY_PHOTOGRAPHER_KEYWORD_SUMMARY)
+        }
+    }
 
     LaunchedEffect(initialHasPhotographerRole) {
         if (initialHasPhotographerRole && !state.hasPhotographerRole) {

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageSideEffect.kt
@@ -7,6 +7,8 @@ sealed interface MyPageSideEffect {
 
     data object NavigateToPhotographerModifyProfile : MyPageSideEffect
 
+    data class NavigateToPhotographerKeywordEdit(val photographerId: Int) : MyPageSideEffect
+
     data object NavigateToPackageEdit : MyPageSideEffect
 
     data object NavigateToMyReviews : MyPageSideEffect

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -87,6 +87,16 @@ class MyPageViewModel
                 is MyPageIntent.NavigateToPortfolioEdit -> {
                     sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_portfolio_edit_pending))
                 }
+                is MyPageIntent.ApplyPhotographerKeywordSummary -> {
+                    _state.update {
+                        it.copy(
+                            photographerProfile =
+                                it.photographerProfile.copy(
+                                    keywordSummary = intent.keywordSummary,
+                                ),
+                        )
+                    }
+                }
                 is MyPageIntent.ApplyDevPhotographerPreview -> {
                     _state.update {
                         it.copy(

--- a/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModel.kt
@@ -69,7 +69,11 @@ class MyPageViewModel
                     sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_region_edit_pending))
                 }
                 is MyPageIntent.NavigateToPhotographerKeywordEdit -> {
-                    sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_keyword_edit_pending))
+                    sendSideEffect(
+                        MyPageSideEffect.NavigateToPhotographerKeywordEdit(
+                            _state.value.photographerProfile.photographerId,
+                        ),
+                    )
                 }
                 is MyPageIntent.NavigateToPhotographerEquipmentEdit -> {
                     sendSideEffect(MyPageSideEffect.ShowToast(R.string.my_page_equipment_edit_pending))

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="my_page_keyword_edit_duplicate">이미 추가된 키워드입니다.</string>
     <string name="my_page_keyword_edit_load_failed">키워드를 불러오지 못했습니다.</string>
     <string name="my_page_keyword_edit_save_failed">키워드 저장에 실패했습니다.</string>
+    <string name="my_page_keyword_summary_with_more">%1$s 외 %2$d개 키워드</string>
     <string-array name="my_page_default_mood_keywords">
         <item>캐주얼</item>
         <item>고급미</item>

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -82,6 +82,25 @@
     <string name="my_page_region_edit_pending">주 촬영지 편집 기능은 준비 중입니다.</string>
     <string name="my_page_keyword_edit_pending">키워드 편집 기능은 준비 중입니다.</string>
     <string name="my_page_equipment_edit_pending">장비 편집 기능은 준비 중입니다.</string>
+    <string name="my_page_keyword_edit_title">키워드 편집</string>
+    <string name="my_page_keyword_edit_description">자신 있는 분위기 키워드를 선택해 주세요.</string>
+    <string name="my_page_keyword_edit_save">저장</string>
+    <string name="my_page_keyword_edit_duplicate">이미 추가된 키워드입니다.</string>
+    <string name="my_page_keyword_edit_load_failed">키워드를 불러오지 못했습니다.</string>
+    <string name="my_page_keyword_edit_save_failed">키워드 저장에 실패했습니다.</string>
+    <string-array name="my_page_default_mood_keywords">
+        <item>캐주얼</item>
+        <item>고급미</item>
+        <item>심플</item>
+        <item>단아</item>
+        <item>몽환적</item>
+        <item>빈티지</item>
+        <item>청량</item>
+        <item>화려</item>
+        <item>퇴폐적</item>
+        <item>키치</item>
+        <item>힙스터</item>
+    </string-array>
     <string name="my_page_settlement_pending">정산 내역 기능은 준비 중입니다.</string>
     <string name="my_page_package_edit_pending">촬영 패키지 편집 기능은 준비 중입니다.</string>
     <string name="my_page_portfolio_edit_pending">포트폴리오 편집 기능은 준비 중입니다.</string>

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
@@ -124,7 +124,10 @@ class MyPagePhotographerKeywordEditViewModelTest {
 
             assertEquals(listOf("심플"), repository.addedKeywords)
             assertEquals(listOf("캐주얼"), repository.deletedKeywords)
-            assertEquals(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev, sideEffectDeferred.await())
+            assertEquals(
+                MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(keywordSummary = "#심플"),
+                sideEffectDeferred.await(),
+            )
         }
 
     @Test
@@ -183,7 +186,7 @@ class MyPagePhotographerKeywordEditViewModelTest {
             viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.NavigateToPrev)
             advanceUntilIdle()
 
-            assertEquals(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev, sideEffectDeferred.await())
+            assertEquals(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(), sideEffectDeferred.await())
         }
 
     private fun createViewModel(

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
@@ -126,7 +126,7 @@ class MyPagePhotographerKeywordEditViewModelTest {
             assertEquals(listOf("심플"), repository.addedKeywords)
             assertEquals(listOf("캐주얼"), repository.deletedKeywords)
             assertEquals(
-                MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(keywordSummary = "#심플"),
+                MyPagePhotographerKeywordEditSideEffect.NavigateToPrev(selectedKeywords = listOf("심플")),
                 sideEffectDeferred.await(),
             )
         }

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
@@ -1,0 +1,247 @@
+package com.hm.picplz.ui.screen.my_page
+
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.usecase.GetPhotographerMoodKeywordsUseCase
+import com.hm.picplz.domain.usecase.UpdatePhotographerMoodKeywordsUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyPagePhotographerKeywordEditViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `load keywords selects existing default and custom keywords`() =
+        runTest {
+            val viewModel = createViewModel(keywords = listOf("캐주얼", "필름감성"))
+
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertFalse(state.isLoading)
+            assertTrue(state.selectedKeywordChipList.any { it.label == "캐주얼" })
+            assertTrue(state.selectedKeywordChipList.any { it.label == "필름감성" })
+            assertTrue(state.keywordChipList.any { it.label == "필름감성" && it.isEditable })
+            assertFalse(state.hasChanges)
+        }
+
+    @Test
+    fun `add duplicate keyword shows duplicate toast`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.AddKeywordChip("캐주얼"))
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.showToast)
+            assertEquals(
+                com.hm.picplz.feature.mypage.R.string.my_page_keyword_edit_duplicate,
+                viewModel.state.value.toastMessageResId,
+            )
+        }
+
+    @Test
+    fun `add custom keyword selects new editable keyword`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.AddKeywordChip("필름감성"))
+
+            assertTrue(viewModel.state.value.keywordChipList.any { it.label == "필름감성" && it.isEditable })
+            assertTrue(viewModel.state.value.selectedKeywordChipList.any { it.label == "필름감성" })
+        }
+
+    @Test
+    fun `update custom keyword updates selected keyword label`() =
+        runTest {
+            val viewModel = createViewModel(keywords = listOf("필름감성"))
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+            val customChip = viewModel.state.value.keywordChipList.first { it.label == "필름감성" }
+
+            viewModel.handleIntent(
+                MyPagePhotographerKeywordEditIntent.UpdateKeywordChip(
+                    chipId = customChip.id,
+                    label = "몽환필름",
+                ),
+            )
+
+            assertTrue(viewModel.state.value.keywordChipList.any { it.label == "몽환필름" })
+            assertTrue(viewModel.state.value.selectedKeywordChipList.any { it.label == "몽환필름" })
+        }
+
+    @Test
+    fun `load failure shows load failure toast`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    repository = FakePhotographerRepository(failsOnGet = true),
+                )
+
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+
+            assertEquals(
+                com.hm.picplz.feature.mypage.R.string.my_page_keyword_edit_load_failed,
+                viewModel.state.value.toastMessageResId,
+            )
+        }
+
+    @Test
+    fun `save keywords applies added and removed diff then navigates back`() =
+        runTest {
+            val repository = FakePhotographerRepository(keywords = listOf("캐주얼"))
+            val viewModel = createViewModel(repository = repository)
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+            val casualChip = viewModel.state.value.keywordChipList.first { it.label == "캐주얼" }
+            val simpleChip = viewModel.state.value.keywordChipList.first { it.label == "심플" }
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(
+                MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection(casualChip.id, casualChip.label),
+            )
+            viewModel.handleIntent(
+                MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection(simpleChip.id, simpleChip.label),
+            )
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.SaveKeywords)
+            advanceUntilIdle()
+
+            assertEquals(listOf("심플"), repository.addedKeywords)
+            assertEquals(listOf("캐주얼"), repository.deletedKeywords)
+            assertEquals(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev, sideEffectDeferred.await())
+        }
+
+    @Test
+    fun `save failure reloads server keywords and shows failure toast`() =
+        runTest {
+            val repository = FakePhotographerRepository(keywords = listOf("캐주얼"), failsOnAdd = true)
+            val viewModel = createViewModel(repository = repository)
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+            val simpleChip = viewModel.state.value.keywordChipList.first { it.label == "심플" }
+
+            viewModel.handleIntent(
+                MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection(simpleChip.id, simpleChip.label),
+            )
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.SaveKeywords)
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.selectedKeywordChipList.any { it.label == "캐주얼" })
+            assertFalse(viewModel.state.value.selectedKeywordChipList.any { it.label == "심플" })
+            assertEquals(
+                com.hm.picplz.feature.mypage.R.string.my_page_keyword_edit_save_failed,
+                viewModel.state.value.toastMessageResId,
+            )
+        }
+
+    @Test
+    fun `save failure with reload failure resets to original keywords`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    keywords = listOf("캐주얼"),
+                    failsOnAdd = true,
+                    failsOnSecondGet = true,
+                )
+            val viewModel = createViewModel(repository = repository)
+            viewModel.handleIntent(loadIntent())
+            advanceUntilIdle()
+            val simpleChip = viewModel.state.value.keywordChipList.first { it.label == "심플" }
+
+            viewModel.handleIntent(
+                MyPagePhotographerKeywordEditIntent.ToggleKeywordSelection(simpleChip.id, simpleChip.label),
+            )
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.SaveKeywords)
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.selectedKeywordChipList.any { it.label == "캐주얼" })
+            assertFalse(viewModel.state.value.selectedKeywordChipList.any { it.label == "심플" })
+        }
+
+    @Test
+    fun `navigate to prev emits navigation side effect`() =
+        runTest {
+            val viewModel = createViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPagePhotographerKeywordEditIntent.NavigateToPrev)
+            advanceUntilIdle()
+
+            assertEquals(MyPagePhotographerKeywordEditSideEffect.NavigateToPrev, sideEffectDeferred.await())
+        }
+
+    private fun createViewModel(
+        keywords: List<String> = emptyList(),
+        repository: FakePhotographerRepository = FakePhotographerRepository(keywords),
+    ) = MyPagePhotographerKeywordEditViewModel(
+        getPhotographerMoodKeywordsUseCase = GetPhotographerMoodKeywordsUseCase(repository),
+        updatePhotographerMoodKeywordsUseCase = UpdatePhotographerMoodKeywordsUseCase(repository),
+    )
+
+    private fun loadIntent() =
+        MyPagePhotographerKeywordEditIntent.LoadKeywords(
+            photographerId = 1L,
+            defaultKeywords = DEFAULT_KEYWORDS,
+        )
+
+    private companion object {
+        val DEFAULT_KEYWORDS = listOf("캐주얼", "고급미", "심플")
+    }
+}
+
+private class FakePhotographerRepository(
+    private val keywords: List<String> = emptyList(),
+    private val failsOnAdd: Boolean = false,
+    private val failsOnGet: Boolean = false,
+    private val failsOnSecondGet: Boolean = false,
+) : PhotographerRepository {
+    val addedKeywords = mutableListOf<String>()
+    val deletedKeywords = mutableListOf<String>()
+    private var getCallCount = 0
+
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): Result<FilteredPhotographers> =
+        Result.success(
+            FilteredPhotographers(active = emptyList(), inactive = emptyList()),
+        )
+
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+        if (failsOnGet || (failsOnSecondGet && getCallCount++ > 0)) {
+            Result.failure(IllegalStateException("get failed"))
+        } else {
+            getCallCount++
+            Result.success(keywords)
+        }
+
+    override suspend fun addPhotoMood(photoMood: String): Result<Unit> =
+        if (failsOnAdd) {
+            Result.failure(IllegalStateException("add failed"))
+        } else {
+            addedKeywords.add(photoMood)
+            Result.success(Unit)
+        }
+
+    override suspend fun deletePhotoMood(photoMood: String): Result<Unit> {
+        deletedKeywords.add(photoMood)
+        return Result.success(Unit)
+    }
+}

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.ui.screen.my_page
 
 import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.PhotographerDetail
 import com.hm.picplz.domain.repository.PhotographerRepository
 import com.hm.picplz.domain.usecase.GetPhotographerMoodKeywordsUseCase
 import com.hm.picplz.domain.usecase.UpdatePhotographerMoodKeywordsUseCase
@@ -226,6 +227,11 @@ private class FakePhotographerRepository(
         Result.success(
             FilteredPhotographers(active = emptyList(), inactive = emptyList()),
         )
+
+    override suspend fun getPhotographerDetail(
+        photographerId: Long,
+        reviewSort: String,
+    ): Result<PhotographerDetail> = Result.failure(UnsupportedOperationException())
 
     override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
         if (failsOnGet || (failsOnSecondGet && getCallCount++ > 0)) {

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
@@ -62,6 +62,20 @@ class MyPageViewModelTest {
         }
 
     @Test
+    fun `navigate to photographer keyword edit emits dedicated navigation side effect`() =
+        runTest {
+            val viewModel = MyPageViewModel()
+            val sideEffectDeferred = async { viewModel.sideEffect.first() }
+
+            viewModel.handleIntent(MyPageIntent.NavigateToPhotographerKeywordEdit)
+            advanceUntilIdle()
+
+            val sideEffect = sideEffectDeferred.await()
+            assertTrue(sideEffect is MyPageSideEffect.NavigateToPhotographerKeywordEdit)
+            assertEquals(1, (sideEffect as MyPageSideEffect.NavigateToPhotographerKeywordEdit).photographerId)
+        }
+
+    @Test
     fun `photographer preview without package emits requires package toast`() =
         runTest {
             val viewModel = MyPageViewModel()

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPageViewModelTest.kt
@@ -112,6 +112,15 @@ class MyPageViewModelTest {
         }
 
     @Test
+    fun `apply photographer keyword summary updates profile summary`() {
+        val viewModel = MyPageViewModel()
+
+        viewModel.handleIntent(MyPageIntent.ApplyPhotographerKeywordSummary("#캐주얼, #심플"))
+
+        assertEquals("#캐주얼, #심플", viewModel.state.value.photographerProfile.keywordSummary)
+    }
+
+    @Test
     fun `photographer preview availability requires package and photographer id`() {
         assertFalse(PhotographerProfile(hasPackages = false, photographerId = 1).canPreviewProfile)
         assertFalse(PhotographerProfile(hasPackages = true, photographerId = 0).canPreviewProfile)


### PR DESCRIPTION
## Summary
- 작가 마이페이지의 키워드 편집 진입점을 실제 수정 화면으로 연결했습니다.
- 기존 분위기 키워드를 불러와 기본/직접 입력 키워드 선택 상태를 표시하고 저장할 수 있게 했습니다.
- 키워드 수정 ViewModel 테스트를 추가했습니다.

## Changes

### navigation
- `MyPagePhotographerKeywordEdit` route를 추가하고 마이페이지 그래프에 연결했습니다.
- 작가 마이페이지 키워드 편집 버튼에서 키워드 수정 화면으로 이동하도록 변경했습니다.

### feature/mypage
- 작가 키워드 수정 MVI 화면, 상태, Intent, SideEffect, ViewModel을 추가했습니다.
- 기본 키워드 선택/해제, 직접 입력 키워드 추가/수정/삭제, 중복 토스트, 저장 버튼 활성화 조건을 처리했습니다.
- UI 문구를 `strings.xml`로 분리했습니다.

### core/domain, core/data
- 기존 작가 상세 정보의 `photoMoods`를 통해 저장된 키워드를 조회합니다.
- 선택 변경분을 추가/삭제 요청으로 반영하는 use case와 repository/service/source 경로를 추가했습니다.

### tests
- 키워드 로드, 중복 입력, 직접 입력, 선택 토글, 저장 성공/실패, 마이페이지 진입 SideEffect 테스트를 추가했습니다.

## 구현

<img width="400" height="867" alt="KakaoTalk_Video_2026-05-11-00-14-16" src="https://github.com/user-attachments/assets/5378ab98-aabf-42b3-b4ff-d8fe0c820ad2" />

## Verification
- 작가 마이페이지에서 키워드 편집 클릭시 페이지 이동 확인

## TODO
- OpenAPI에는 `/photographers/photo-mood` 생성/삭제 API만 확인됩니다. 키워드 전체 수정용 PUT API는 확인되지 않아 현재는 추가/삭제 diff 방식으로 반영하며, 백엔드 수정 API가 확정되면 연동 방식을 재검토해야 합니다.

Closes #171