### PR TITLE
✨: 작가 촬영기기 설정 화면 개선

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.navigation.graph
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -20,6 +21,7 @@ import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerReviewScree
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerScreen
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerSingleReviewScreen
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainScreen
+import com.hm.picplz.ui.screen.photographer_main.PhotographerMainViewModel
 import com.hm.picplz.ui.screen.photographer_main.composable.EquipmentSettingScreen
 import com.hm.picplz.ui.screen.quick_shoot.QuickShootScreen
 
@@ -79,6 +81,17 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     }
 
     composable<PhotographerEquipmentSetting> {
-        EquipmentSettingScreen(navController = navController)
+        val photographerMainBackStackEntry = navController.previousBackStackEntry
+        val photographerMainViewModel: PhotographerMainViewModel =
+            if (photographerMainBackStackEntry != null) {
+                hiltViewModel(photographerMainBackStackEntry)
+            } else {
+                hiltViewModel()
+            }
+
+        EquipmentSettingScreen(
+            viewModel = photographerMainViewModel,
+            navController = navController,
+        )
     }
 }

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
@@ -81,7 +81,10 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     }
 
     composable<PhotographerEquipmentSetting> {
-        val photographerMainBackStackEntry = navController.previousBackStackEntry
+        val photographerMainBackStackEntry =
+            navController.previousBackStackEntry?.takeIf { entry ->
+                entry.destination.route == PhotographerMain::class.qualifiedName
+            }
         val photographerMainViewModel: PhotographerMainViewModel =
             if (photographerMainBackStackEntry != null) {
                 hiltViewModel(photographerMainBackStackEntry)

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainViewModel.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainViewModel.kt
@@ -3,10 +3,10 @@ package com.hm.picplz.ui.screen.photographer_main
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,19 +18,19 @@ class PhotographerMainViewModel
         private val _state = MutableStateFlow(PhotographerMainState.idle())
         val state: StateFlow<PhotographerMainState> get() = _state
 
-        private val _sideEffect = MutableSharedFlow<PhotographerMainSideEffect>()
-        val sideEffect: SharedFlow<PhotographerMainSideEffect> get() = _sideEffect
+        private val _sideEffect = Channel<PhotographerMainSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
 
         fun handleIntent(intent: PhotographerMainIntent) {
             when (intent) {
                 is PhotographerMainIntent.NavigateToPrev -> {
                     viewModelScope.launch {
-                        _sideEffect.emit(PhotographerMainSideEffect.NavigateToPrev)
+                        _sideEffect.send(PhotographerMainSideEffect.NavigateToPrev)
                     }
                 }
                 is PhotographerMainIntent.Navigate -> {
                     viewModelScope.launch {
-                        _sideEffect.emit(PhotographerMainSideEffect.Navigate(intent.destination))
+                        _sideEffect.send(PhotographerMainSideEffect.Navigate(intent.destination))
                     }
                 }
                 is PhotographerMainIntent.SetIsActive -> {

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/composable/EquipmentSettingScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/composable/EquipmentSettingScreen.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.ui.screen.photographer_main.composable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,6 +55,9 @@ fun EquipmentSettingScreen(
     val enabledEquipment = currentState.equipmentList.filter { it.isEnabled }
     val phoneEquipment = enabledEquipment.filter { it.type.contains("폰") || it.type.contains("핸드폰") }
     val cameraEquipment = enabledEquipment - phoneEquipment.toSet()
+    val disabledEquipment = currentState.equipmentList.filterNot { it.isEnabled }
+    val disabledPhoneEquipment = disabledEquipment.filter { it.type.contains("폰") || it.type.contains("핸드폰") }
+    val disabledCameraEquipment = disabledEquipment - disabledPhoneEquipment.toSet()
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -103,6 +107,14 @@ fun EquipmentSettingScreen(
                         EquipmentSection(
                             title = stringResource(R.string.equipment_setting_phone_section),
                             equipment = phoneEquipment,
+                            addButtonVisible = disabledPhoneEquipment.isNotEmpty(),
+                            onAddEquipment = {
+                                disabledPhoneEquipment.firstOrNull()?.let { equipment ->
+                                    viewModel.handleIntent(
+                                        PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
+                                    )
+                                }
+                            },
                             onRemoveEquipment = { equipment ->
                                 viewModel.handleIntent(
                                     PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
@@ -112,6 +124,14 @@ fun EquipmentSettingScreen(
                         EquipmentSection(
                             title = stringResource(R.string.equipment_setting_camera_section),
                             equipment = cameraEquipment,
+                            addButtonVisible = disabledCameraEquipment.isNotEmpty(),
+                            onAddEquipment = {
+                                disabledCameraEquipment.firstOrNull()?.let { equipment ->
+                                    viewModel.handleIntent(
+                                        PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
+                                    )
+                                }
+                            },
                             onRemoveEquipment = { equipment ->
                                 viewModel.handleIntent(
                                     PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
@@ -156,6 +176,8 @@ fun EquipmentSettingScreen(
 private fun EquipmentSection(
     title: String,
     equipment: List<Equipment>,
+    addButtonVisible: Boolean,
+    onAddEquipment: () -> Unit,
     onRemoveEquipment: (Equipment) -> Unit,
 ) {
     Column(
@@ -170,6 +192,24 @@ private fun EquipmentSection(
             EquipmentSettingItem(
                 equipment = item,
                 onRemove = { onRemoveEquipment(item) },
+            )
+        }
+        if (addButtonVisible) {
+            Text(
+                text = stringResource(R.string.equipment_setting_add_button),
+                style = pretendardTypography.bodyMedium,
+                color = MainThemeColor.Gray4,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(5.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MainThemeColor.Gray2,
+                            shape = RoundedCornerShape(5.dp),
+                        )
+                        .padding(horizontal = 15.dp, vertical = 15.dp)
+                        .clickable(onClick = onAddEquipment),
             )
         }
     }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/composable/EquipmentSettingScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/photographer_main/composable/EquipmentSettingScreen.kt
@@ -1,19 +1,48 @@
 package com.hm.picplz.ui.screen.photographer_main.composable
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.hm.picplz.domain.model.Equipment
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainIntent
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainSideEffect
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainViewModel
+import com.hm.picplz.ui.theme.MainFontFamily
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.pretendardTypography
 import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.core.ui.R as CoreUiR
 
 @Composable
 fun EquipmentSettingScreen(
@@ -21,20 +50,93 @@ fun EquipmentSettingScreen(
     viewModel: PhotographerMainViewModel = hiltViewModel(),
     navController: NavHostController,
 ) {
-    Scaffold {
-            innerPadding ->
+    val currentState = viewModel.state.collectAsState().value
+    val enabledEquipment = currentState.equipmentList.filter { it.isEnabled }
+    val phoneEquipment = enabledEquipment.filter { it.type.contains("폰") || it.type.contains("핸드폰") }
+    val cameraEquipment = enabledEquipment - phoneEquipment.toSet()
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = MainThemeColor.White,
+    ) { innerPadding ->
         Column(
             modifier =
                 modifier
                     .fillMaxSize()
                     .padding(innerPadding),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             CommonTopBar(
-                text = "촬영 기기 설정",
+                text = stringResource(R.string.equipment_setting_top_bar_title),
                 onClickBack = {
                     viewModel.handleIntent(PhotographerMainIntent.NavigateToPrev)
                 },
             )
+
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp),
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(top = 16.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.equipment_setting_title),
+                        style = pretendardTypography.titleMedium,
+                    )
+                    Spacer(modifier = Modifier.height(30.dp))
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(40.dp),
+                    ) {
+                        EquipmentSection(
+                            title = stringResource(R.string.equipment_setting_phone_section),
+                            equipment = phoneEquipment,
+                            onRemoveEquipment = { equipment ->
+                                viewModel.handleIntent(
+                                    PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
+                                )
+                            },
+                        )
+                        EquipmentSection(
+                            title = stringResource(R.string.equipment_setting_camera_section),
+                            equipment = cameraEquipment,
+                            onRemoveEquipment = { equipment ->
+                                viewModel.handleIntent(
+                                    PhotographerMainIntent.ToggleEquipmentEnabled(equipment.id),
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+            Box(
+                modifier =
+                    Modifier
+                        .height(120.dp)
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CommonBottomButton(
+                    text = stringResource(R.string.equipment_setting_save_button),
+                    enabled = enabledEquipment.isNotEmpty(),
+                    onClick = {
+                        viewModel.handleIntent(PhotographerMainIntent.NavigateToPrev)
+                    },
+                )
+            }
         }
     }
 
@@ -46,6 +148,83 @@ fun EquipmentSettingScreen(
                 }
                 is PhotographerMainSideEffect.Navigate -> {}
             }
+        }
+    }
+}
+
+@Composable
+private fun EquipmentSection(
+    title: String,
+    equipment: List<Equipment>,
+    onRemoveEquipment: (Equipment) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = title,
+            style = pretendardTypography.titleSmall,
+        )
+        equipment.forEach { item ->
+            EquipmentSettingItem(
+                equipment = item,
+                onRemove = { onRemoveEquipment(item) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EquipmentSettingItem(
+    equipment: Equipment,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(5.dp))
+                .background(MainThemeColor.Gray1)
+                .border(
+                    width = 1.dp,
+                    color = MainThemeColor.Gray2,
+                    shape = RoundedCornerShape(5.dp),
+                )
+                .padding(horizontal = 15.dp, vertical = 11.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = equipment.type,
+                style = pretendardTypography.bodyMedium,
+                color = MainThemeColor.Gray4,
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                text = equipment.deviceName,
+                style = MainFontFamily.bodyBold,
+                color = MainThemeColor.Gray5,
+            )
+        }
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier.size(48.dp),
+        ) {
+            Image(
+                painter = painterResource(id = CoreUiR.drawable.close_circle),
+                contentDescription =
+                    stringResource(
+                        R.string.equipment_setting_remove_content_description,
+                        equipment.deviceName,
+                    ),
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="equipment_setting_top_bar_title">촬영 기기 설정</string>
+    <string name="equipment_setting_title">촬영 기기를 선택해 주세요.</string>
+    <string name="equipment_setting_phone_section">내 핸드폰</string>
+    <string name="equipment_setting_camera_section">내 카메라</string>
+    <string name="equipment_setting_add_button">추가하기 +</string>
+    <string name="equipment_setting_save_button">저장</string>
+    <string name="equipment_setting_remove_content_description">%1$s 삭제</string>
+</resources>


### PR DESCRIPTION
## Summary
- 작가 촬영기기 설정 화면을 가입 기기 선택 UX와 맞게 정리했습니다.
- 장비 삭제 후 다시 추가할 수 있도록 섹션별 추가 동작을 보완했습니다.
- 작가 메인 ViewModel의 일회성 이벤트를 Channel 기반으로 정리했습니다.

## Changes

### navigation
- `PhotographerEquipmentSetting` 진입 시 작가 메인에서 온 경우에만 작가 메인 ViewModel을 공유하도록 보완했습니다.

### feature/main
- 촬영기기 설정 화면에서 활성 장비만 표시하고 삭제 시 비활성 처리하도록 개선했습니다.
- 비활성 장비가 남아 있으면 `추가하기 +` 버튼으로 다시 활성화할 수 있게 했습니다.
- 저장/뒤로가기 동작을 작가 메인 상태와 연동했습니다.

### strings
- 촬영기기 설정 화면 문구와 삭제 contentDescription을 `strings.xml`에 추가했습니다.

## Verification
- `./gradlew --no-build-cache :feature:main:compileDebugKotlin :feature:main:ktlintCheck --quiet`
- `./gradlew --no-build-cache :app:compileDebugKotlin --quiet`
- `./gradlew --no-build-cache ktlintCheck --quiet`
- `./gradlew --no-build-cache :feature:main:testDebugUnitTest --quiet`

## Note
- `installDebug`는 현재 연결된 디바이스가 없어 실행하지 못했습니다. (`No connected devices!`)

Closes #175