### PR TITLE
🔧 : 환경 분리(dev / staging / prod) productFlavors 도입

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0.4-dev"
+        versionName = "1.0.4"
 
         testInstrumentationRunner = "com.google.dagger.hilt.android.testing.HiltTestRunner"
         vectorDrawables {
@@ -60,6 +60,7 @@ android {
         create("dev") {
             dimension = "environment"
             applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
             buildConfigField("boolean", "DEV_MODE", "true")
             buildConfigField("boolean", "STAGING_MODE", "false")
             resValue("string", "app_name", "[DEV] picplz")
@@ -67,6 +68,7 @@ android {
         create("staging") {
             dimension = "environment"
             applicationIdSuffix = ".staging"
+            versionNameSuffix = "-staging"
             buildConfigField("boolean", "DEV_MODE", "false")
             buildConfigField("boolean", "STAGING_MODE", "true")
             resValue("string", "app_name", "[STG] picplz")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,13 +60,19 @@ android {
         create("dev") {
             dimension = "environment"
             applicationIdSuffix = ".dev"
+            buildConfigField("boolean", "DEV_MODE", "true")
+            buildConfigField("boolean", "STAGING_MODE", "false")
         }
         create("staging") {
             dimension = "environment"
             applicationIdSuffix = ".staging"
+            buildConfigField("boolean", "DEV_MODE", "false")
+            buildConfigField("boolean", "STAGING_MODE", "true")
         }
         create("prod") {
             dimension = "environment"
+            buildConfigField("boolean", "DEV_MODE", "false")
+            buildConfigField("boolean", "STAGING_MODE", "false")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,20 @@ android {
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = localProperties["kakao_native_app_key"] ?: ""
     }
 
+    flavorDimensions += "environment"
+
+    productFlavors {
+        create("dev") {
+            dimension = "environment"
+        }
+        create("staging") {
+            dimension = "environment"
+        }
+        create("prod") {
+            dimension = "environment"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,8 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            // TODO: prod 릴리즈 키 도입 시 교체. 현재는 Firebase Distribution용으로 debug 키 사이닝
+            signingConfig = signingConfigs.getByName("debug")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,9 +59,11 @@ android {
     productFlavors {
         create("dev") {
             dimension = "environment"
+            applicationIdSuffix = ".dev"
         }
         create("staging") {
             dimension = "environment"
+            applicationIdSuffix = ".staging"
         }
         create("prod") {
             dimension = "environment"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,17 +62,20 @@ android {
             applicationIdSuffix = ".dev"
             buildConfigField("boolean", "DEV_MODE", "true")
             buildConfigField("boolean", "STAGING_MODE", "false")
+            resValue("string", "app_name", "[DEV] picplz")
         }
         create("staging") {
             dimension = "environment"
             applicationIdSuffix = ".staging"
             buildConfigField("boolean", "DEV_MODE", "false")
             buildConfigField("boolean", "STAGING_MODE", "true")
+            resValue("string", "app_name", "[STG] picplz")
         }
         create("prod") {
             dimension = "environment"
             buildConfigField("boolean", "DEV_MODE", "false")
             buildConfigField("boolean", "STAGING_MODE", "false")
+            resValue("string", "app_name", "picplz")
         }
     }
 

--- a/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
@@ -4,10 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.hm.picplz.BuildConfig
 import com.hm.picplz.navigation.graph.authNavGraph
 import com.hm.picplz.navigation.graph.mainNavGraph
 import com.hm.picplz.navigation.graph.photographerNavGraph
 import com.hm.picplz.navigation.model.Dev
+import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.ui.main.MainActivityUiState
 
 @Composable
@@ -16,8 +18,7 @@ fun MainNavHost(
     @Suppress("UNUSED_PARAMETER") _uiState: MainActivityUiState,
     modifier: Modifier = Modifier,
 ) {
-    // TODO: 개발 완료 후 Main으로 변경
-    val startDestination: Any = Dev
+    val startDestination: Any = if (BuildConfig.DEV_MODE) Dev else Main
 
     NavHost(
         navController = navController,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">picplz</string>
 </resources>


### PR DESCRIPTION
## 개요
`:app` 모듈에 `environment` productFlavor(dev / staging / prod)를 도입하여, 개발 환경과 사용자 흐름 검증 환경을 한 코드베이스에서 빌드 단계로 분리합니다. 동시에 dev/staging/prod 빌드를 한 기기에 설치해 비교 검증 가능하며, 추후 Firebase Distribution / 운영 배포로 확장할 기반을 마련합니다.

## 변경 사항
- `environment` flavorDimension 및 dev / staging / prod productFlavors 추가
- flavor별 `applicationIdSuffix` 설정 → 같은 기기에 동시 설치 가능
  - dev: `com.hm.picplz.dev` / staging: `com.hm.picplz.staging` / prod: `com.hm.picplz`
- flavor별 `versionNameSuffix` 적용 (`1.0.4-dev` / `1.0.4-staging` / `1.0.4`)
- flavor별 런처 앱 이름 분기 (`[DEV] picplz` / `[STG] picplz` / `picplz`) — `resValue`로 정의, 기존 `app_name` string 제거
- flavor별 BuildConfig 플래그 추가 (`DEV_MODE`, `STAGING_MODE`) — 코드에서 환경 분기에 사용
- `MainNavHost` startDestination을 `BuildConfig.DEV_MODE` 기준으로 분기 (dev → `Dev` 화면, 그 외 → `Main`)
- release buildType에 debug 키 사이닝 임시 적용 — Firebase Distribution 업로드 가능. 운영 릴리즈 키 도입 시 교체 예정

<img width="535" height="800" alt="스크린샷 2026-05-24 오후 12 36 18" src="https://github.com/user-attachments/assets/dcb76ef3-bb9e-450e-a457-e620e6c754ce" />


## 참고 사항
- Firebase picplz 프로젝트에 picplz staging 앱을 추가하였고, App Distribution에 staging 빌드 APK 업로드하였습니다.


## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #187
