### PR TITLE
♻️ 앱 전역 에러 처리 구조 중앙화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,13 +190,14 @@ main ← develop ← feat/이슈번호
 
 ### Data Layer Patterns
 
-**Simple (no domain logic)**: `Api → Source (runCatching) → Service → ViewModel`
+**Simple (no domain logic)**: `Api → Source (AppResult) → Service → ViewModel`
 - Used by: MemberApi, CameraApi, S3Api
 
 **Full (with domain logic)**: `Api → Source → Service → Repository → UseCase → ViewModel`
 - Used by: AuthApi (login flow)
 
-**Source Rule**: All Sources wrap API calls in `runCatching` returning `Result<T>`
+**Source Rule**: All Sources wrap API calls in `runCatchingAppError`/`safeApiCall` returning `AppResult<T>`.
+HTTP failures must be converted to `AppError.Network.Http` with backend error-envelope fields preserved when available.
 
 **DTO/Model Boundary Rule**:
 - `core/data/model` is for backend request/response DTOs only.

--- a/core/common/src/main/kotlin/com/hm/picplz/common/error/AppError.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/error/AppError.kt
@@ -1,0 +1,82 @@
+package com.hm.picplz.common.error
+
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+sealed class AppError(
+    message: String? = null,
+    cause: Throwable? = null,
+) : Exception(message, cause) {
+    sealed class Network(
+        message: String? = null,
+        cause: Throwable? = null,
+    ) : AppError(message, cause) {
+        data object NoConnection : Network("No network connection")
+
+        data object Timeout : Network("Network timeout")
+
+        data class Http(
+            val code: Int,
+            val body: String?,
+            val statusCode: Int? = null,
+            val serverMessage: String? = null,
+            val timestamp: String? = null,
+            val data: String? = null,
+        ) : Network(serverMessage ?: "HTTP $code $body")
+
+        data object EmptyBody : Network("Response body is null")
+
+        data class Unknown(
+            val original: Throwable?,
+        ) : Network(original?.message, original)
+    }
+
+    sealed class Auth(
+        message: String? = null,
+        cause: Throwable? = null,
+    ) : AppError(message, cause) {
+        data object KakaoTokenMissing : Auth("Kakao token is null")
+
+        data object SocialInfoMissing : Auth("Social login info is missing")
+
+        data class KakaoSdk(
+            val original: Throwable?,
+        ) : Auth(original?.message, original)
+    }
+
+    sealed class Storage(
+        message: String? = null,
+        cause: Throwable? = null,
+    ) : AppError(message, cause) {
+        data class UploadFailed(
+            val original: Throwable?,
+        ) : Storage(original?.message, original)
+    }
+
+    sealed class Location(
+        message: String? = null,
+        cause: Throwable? = null,
+    ) : AppError(message, cause) {
+        data object PermissionDenied : Location("Location permission denied")
+
+        data class LookupFailed(
+            val original: Throwable?,
+        ) : Location(original?.message, original)
+    }
+
+    data class Unknown(
+        val original: Throwable?,
+    ) : AppError(original?.message, original)
+
+    companion object {
+        fun fromThrowable(throwable: Throwable): AppError =
+            when (throwable) {
+                is AppError -> throwable
+                is java.net.SocketTimeoutException,
+                is TimeoutException,
+                -> Network.Timeout
+                is IOException -> Network.NoConnection
+                else -> Unknown(throwable)
+            }
+    }
+}

--- a/core/common/src/main/kotlin/com/hm/picplz/common/result/AppResult.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/result/AppResult.kt
@@ -1,0 +1,3 @@
+package com.hm.picplz.common.result
+
+typealias AppResult<T> = Result<T>

--- a/core/common/src/main/kotlin/com/hm/picplz/common/result/AppResultExtensions.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/result/AppResultExtensions.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.common.result
+
+import com.hm.picplz.common.error.AppError
+import kotlin.coroutines.cancellation.CancellationException
+
+inline fun <T> runCatchingAppError(block: () -> T): AppResult<T> =
+    try {
+        Result.success(block())
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        Result.failure(AppError.fromThrowable(error))
+    }

--- a/core/data/AGENTS.md
+++ b/core/data/AGENTS.md
@@ -55,6 +55,6 @@ ViewModel → UseCase → Repository(Impl) → Source → Api → Network
 
 - **API Keys**: `ConfigProvider` implementation in `:app` module reads from `local.properties`
 - **Required keys**: `kakaoRestApiKey`, `devGuestToken`, `devUserToken`
-- **Error Handling**: All Sources wrap API calls in `Result<T>` using `runCatching`
+- **Error Handling**: All Sources wrap API calls in `AppResult<T>` using `runCatchingAppError` or `safeApiCall`. HTTP failures must use `toHttpAppError()` so backend error-envelope fields are preserved.
 - **Model Boundary**: `core:data/model` contains backend DTOs only. Domain/UI-facing models live in `core:domain/model` or the owning feature.
 - **Mappers**: use dedicated mapper files for DTO → domain/feature model conversion. Feature modules must not import `com.hm.picplz.data.model.*` except true DTO-only test fixtures.

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/ApiResponse.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/ApiResponse.kt
@@ -1,8 +1,17 @@
 package com.hm.picplz.data.model
 
+import com.google.gson.JsonElement
+
 data class ApiResponse<T>(
     val timestamp: String,
     val statusCode: Int,
     val message: String,
     val data: T,
+)
+
+data class ApiErrorResponseDto(
+    val timestamp: String?,
+    val statusCode: Int?,
+    val message: String?,
+    val data: JsonElement?,
 )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/AreaRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/AreaRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.service.AddressService
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.repository.AreaRepository
@@ -10,11 +11,11 @@ class AreaRepositoryImpl
     constructor(
         private val addressService: AddressService,
     ) : AreaRepository {
-        override suspend fun searchAreas(keyword: String): Result<List<Area>> = addressService.searchArea(keyword)
+        override suspend fun searchAreas(keyword: String): AppResult<List<Area>> = addressService.searchArea(keyword)
 
         override suspend fun getNearbyAreas(
             rad: Int,
             lat: Double,
             lng: Double,
-        ): Result<List<Area>> = addressService.getNearbyAreas(rad, lat, lng)
+        ): AppResult<List<Area>> = addressService.getNearbyAreas(rad, lat, lng)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/AuthRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.hm.picplz.data.repository
 
 import android.content.Context
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.provider.TokenManager
 import com.hm.picplz.data.service.AuthService
 import com.hm.picplz.data.service.KakaoAuthService
@@ -16,17 +18,19 @@ class AuthRepositoryImpl
         private val kakaoAuthService: KakaoAuthService,
         private val tokenManager: TokenManager,
     ) : AuthRepository {
-        override suspend fun loginWithKakao(context: Context): Result<KaKaoLoginResponse> {
-            return getKakaoOAuthToken(context)
-                .mapCatching { token -> authService.loginWithKaKao(token.accessToken).getOrThrow() }
-                .onSuccess { response ->
-                    response.accessToken?.let { tokenManager.saveLoginToken(it, response.refreshToken) }
-                    tokenManager.saveSocialInfo(
-                        socialCode = response.socialCode,
-                        socialEmail = response.socialEmail,
-                        socialProvider = response.socialProvider,
-                    )
-                }
+        override suspend fun loginWithKakao(context: Context): AppResult<KaKaoLoginResponse> {
+            return runCatchingAppError {
+                val token = getKakaoOAuthToken(context).getOrThrow()
+                val response = authService.loginWithKaKao(token.accessToken).getOrThrow()
+                response
+            }.onSuccess { response ->
+                response.accessToken?.let { tokenManager.saveLoginToken(it, response.refreshToken) }
+                tokenManager.saveSocialInfo(
+                    socialCode = response.socialCode,
+                    socialEmail = response.socialEmail,
+                    socialProvider = response.socialProvider,
+                )
+            }
         }
 
         private suspend fun getKakaoOAuthToken(context: Context) =
@@ -36,11 +40,11 @@ class AuthRepositoryImpl
                 kakaoAuthService.loginWithKakaoAccount(context)
             }
 
-        override suspend fun getKakaoUserInfo(): Result<KakaoUserInfo> {
+        override suspend fun getKakaoUserInfo(): AppResult<KakaoUserInfo> {
             return kakaoAuthService.getUserInfo()
         }
 
-        override suspend fun unlinkKakao(): Result<Unit> {
+        override suspend fun unlinkKakao(): AppResult<Unit> {
             return kakaoAuthService.unlink()
         }
 

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/CameraRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/CameraRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.mapper.toDomain
 import com.hm.picplz.data.service.CameraService
 import com.hm.picplz.domain.model.CameraCatalog
@@ -11,6 +12,6 @@ class CameraRepositoryImpl
     constructor(
         private val cameraService: CameraService,
     ) : CameraRepository {
-        override suspend fun getCameraCatalog(): Result<CameraCatalog> =
+        override suspend fun getCameraCatalog(): AppResult<CameraCatalog> =
             cameraService.getCameraList().map { it.toDomain() }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.toRequest
 import com.hm.picplz.data.service.MemberService
 import com.hm.picplz.domain.model.MemberProfile
@@ -12,12 +13,12 @@ class MemberRepositoryImpl
     constructor(
         private val memberService: MemberService,
     ) : MemberRepository {
-        override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> =
+        override suspend fun checkNicknameAvailable(nickname: String): AppResult<Boolean> =
             memberService.checkNicknameAvailable(nickname)
 
-        override suspend fun getMemberProfile(memberId: Long): Result<MemberProfile> =
+        override suspend fun getMemberProfile(memberId: Long): AppResult<MemberProfile> =
             memberService.getMemberInfo(memberId)
 
-        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit> =
+        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): AppResult<Unit> =
             memberService.updateMemberInfo(command.toRequest())
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.service.PhotographerService
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
@@ -18,14 +20,14 @@ class PhotographerRepositoryImpl
             longitude: Double,
             latitude: Double,
             distance: Long,
-        ): Result<FilteredPhotographers> = photographerService.getNearbyPhotographers(longitude, latitude, distance)
+        ): AppResult<FilteredPhotographers> = photographerService.getNearbyPhotographers(longitude, latitude, distance)
 
         override suspend fun getPhotographerDetail(
             photographerId: Long,
             reviewSort: String,
-        ): Result<PhotographerDetail> =
+        ): AppResult<PhotographerDetail> =
             coroutineScope {
-                runCatching {
+                runCatchingAppError {
                     val profileDeferred = async { photographerService.getPhotographerInfo(photographerId) }
                     val reviewsDeferred =
                         async {
@@ -48,17 +50,18 @@ class PhotographerRepositoryImpl
                 }
             }
 
-        override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+        override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> =
             photographerService.getPhotographerMoodKeywords(photographerId)
 
-        override suspend fun addPhotoMood(photoMood: String): Result<Unit> = photographerService.addPhotoMood(photoMood)
+        override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> =
+            photographerService.addPhotoMood(photoMood)
 
-        override suspend fun deletePhotoMood(photoMood: String): Result<Unit> =
+        override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> =
             photographerService.deletePhotoMood(photoMood)
 
-        override suspend fun getActiveAreas(photographerId: Long): Result<List<Area>> =
+        override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> =
             photographerService.getActiveAreas(photographerId)
 
-        override suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>> =
+        override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> =
             photographerService.updateActiveAreas(areas)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/ProductRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/ProductRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.mapper.toRequest
 import com.hm.picplz.data.mapper.toShootingPackage
 import com.hm.picplz.data.service.ProductService
@@ -13,11 +14,11 @@ class ProductRepositoryImpl
     constructor(
         private val productService: ProductService,
     ) : ProductRepository {
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ShootingPackage>> =
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ShootingPackage>> =
             productService.getPhotographerProducts(photographerId).map { products ->
                 products.map { it.toShootingPackage() }
             }
 
-        override suspend fun createProduct(command: CreateProductCommand): Result<Long> =
+        override suspend fun createProduct(command: CreateProductCommand): AppResult<Long> =
             productService.createProduct(command.toRequest()).map { it.id }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/S3RepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/S3RepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.data.repository
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.service.S3Service
 import com.hm.picplz.domain.repository.S3Repository
 import javax.inject.Inject
@@ -12,20 +14,20 @@ class S3RepositoryImpl
         override suspend fun uploadProfileImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> =
-            s3Service.getUploadUrl("PROFILE", filename)
-                .mapCatching { response ->
-                    s3Service.uploadImage(response.uploadUrl, imageBytes, "image/jpeg").getOrThrow()
-                    response.objectKey
-                }
+        ): AppResult<String> =
+            runCatchingAppError {
+                val response = s3Service.getUploadUrl("PROFILE", filename).getOrThrow()
+                s3Service.uploadImage(response.uploadUrl, imageBytes, "image/jpeg").getOrThrow()
+                response.objectKey
+            }
 
         override suspend fun uploadProductImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> =
-            s3Service.getUploadUrl("PORTFOLIO", filename)
-                .mapCatching { response ->
-                    s3Service.uploadImage(response.uploadUrl, imageBytes, "image/jpeg").getOrThrow()
-                    response.objectKey
-                }
+        ): AppResult<String> =
+            runCatchingAppError {
+                val response = s3Service.getUploadUrl("PORTFOLIO", filename).getOrThrow()
+                s3Service.uploadImage(response.uploadUrl, imageBytes, "image/jpeg").getOrThrow()
+                response.objectKey
+            }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/AddressService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/AddressService.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.mapper.toDomain
 import com.hm.picplz.data.model.AreaNearbyRequest
 import com.hm.picplz.data.model.AreaSearchRequest
@@ -8,13 +9,13 @@ import com.hm.picplz.domain.model.Area
 import javax.inject.Inject
 
 interface AddressService {
-    suspend fun searchArea(keyword: String): Result<List<Area>>
+    suspend fun searchArea(keyword: String): AppResult<List<Area>>
 
     suspend fun getNearbyAreas(
         rad: Int,
         lat: Double,
         lng: Double,
-    ): Result<List<Area>>
+    ): AppResult<List<Area>>
 }
 
 class AddressServiceImpl
@@ -22,7 +23,7 @@ class AddressServiceImpl
     constructor(
         private val addressSource: AddressSource,
     ) : AddressService {
-        override suspend fun searchArea(keyword: String): Result<List<Area>> {
+        override suspend fun searchArea(keyword: String): AppResult<List<Area>> {
             return addressSource.searchArea(
                 AreaSearchRequest(keyword = keyword),
             ).map { areas ->
@@ -36,7 +37,7 @@ class AddressServiceImpl
             rad: Int,
             lat: Double,
             lng: Double,
-        ): Result<List<Area>> {
+        ): AppResult<List<Area>> {
             return addressSource.getNearbyAreas(
                 AreaNearbyRequest(rad = rad, lat = lat, lng = lng),
             ).map { areas ->

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/AuthService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/AuthService.kt
@@ -1,11 +1,12 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.source.AuthSource
 import com.hm.picplz.domain.model.KaKaoLoginResponse
 import javax.inject.Inject
 
 interface AuthService {
-    suspend fun loginWithKaKao(accessToken: String): Result<KaKaoLoginResponse>
+    suspend fun loginWithKaKao(accessToken: String): AppResult<KaKaoLoginResponse>
 }
 
 class AuthServiceImpl
@@ -13,7 +14,7 @@ class AuthServiceImpl
     constructor(
         private val authSource: AuthSource,
     ) : AuthService {
-        override suspend fun loginWithKaKao(accessToken: String): Result<KaKaoLoginResponse> {
+        override suspend fun loginWithKaKao(accessToken: String): AppResult<KaKaoLoginResponse> {
             return authSource.loginWithKaKao(accessToken = accessToken)
         }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/CameraService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/CameraService.kt
@@ -1,11 +1,12 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.CameraListData
 import com.hm.picplz.data.source.CameraSource
 import javax.inject.Inject
 
 interface CameraService {
-    suspend fun getCameraList(): Result<CameraListData>
+    suspend fun getCameraList(): AppResult<CameraListData>
 }
 
 class CameraServiceImpl
@@ -13,5 +14,5 @@ class CameraServiceImpl
     constructor(
         private val cameraSource: CameraSource,
     ) : CameraService {
-        override suspend fun getCameraList(): Result<CameraListData> = cameraSource.getCameraList()
+        override suspend fun getCameraList(): AppResult<CameraListData> = cameraSource.getCameraList()
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/CustomerService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/CustomerService.kt
@@ -1,11 +1,12 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.CreateCustomerRequest
 import com.hm.picplz.data.source.CustomerSource
 import javax.inject.Inject
 
 interface CustomerService {
-    suspend fun createCustomer(request: CreateCustomerRequest): Result<Unit>
+    suspend fun createCustomer(request: CreateCustomerRequest): AppResult<Unit>
 }
 
 class CustomerServiceImpl
@@ -13,6 +14,6 @@ class CustomerServiceImpl
     constructor(
         private val customerSource: CustomerSource,
     ) : CustomerService {
-        override suspend fun createCustomer(request: CreateCustomerRequest): Result<Unit> =
+        override suspend fun createCustomer(request: CreateCustomerRequest): AppResult<Unit> =
             customerSource.createCustomer(request)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/KakaoAuthService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/KakaoAuthService.kt
@@ -1,6 +1,8 @@
 package com.hm.picplz.data.service
 
 import android.content.Context
+import com.hm.picplz.common.error.AppError
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.KakaoUserInfo
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
@@ -9,42 +11,42 @@ import javax.inject.Inject
 import kotlin.coroutines.resume
 
 interface KakaoAuthService {
-    suspend fun loginWithKakaoTalk(context: Context): Result<OAuthToken>
+    suspend fun loginWithKakaoTalk(context: Context): AppResult<OAuthToken>
 
-    suspend fun loginWithKakaoAccount(context: Context): Result<OAuthToken>
+    suspend fun loginWithKakaoAccount(context: Context): AppResult<OAuthToken>
 
     fun isKakaoTalkLoginAvailable(context: Context): Boolean
 
-    suspend fun getUserInfo(): Result<KakaoUserInfo>
+    suspend fun getUserInfo(): AppResult<KakaoUserInfo>
 
-    suspend fun unlink(): Result<Unit>
+    suspend fun unlink(): AppResult<Unit>
 }
 
 class KakaoAuthServiceImpl
     @Inject
     constructor() : KakaoAuthService {
-        override suspend fun loginWithKakaoTalk(context: Context): Result<OAuthToken> =
+        override suspend fun loginWithKakaoTalk(context: Context): AppResult<OAuthToken> =
             suspendCancellableCoroutine { cont ->
                 UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                     if (error != null) {
-                        cont.resume(Result.failure(error))
+                        cont.resume(Result.failure(AppError.Auth.KakaoSdk(error)))
                     } else if (token != null) {
                         cont.resume(Result.success(token))
                     } else {
-                        cont.resume(Result.failure(IllegalStateException("Token is null")))
+                        cont.resume(Result.failure(AppError.Auth.KakaoTokenMissing))
                     }
                 }
             }
 
-        override suspend fun loginWithKakaoAccount(context: Context): Result<OAuthToken> =
+        override suspend fun loginWithKakaoAccount(context: Context): AppResult<OAuthToken> =
             suspendCancellableCoroutine { cont ->
                 UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
                     if (error != null) {
-                        cont.resume(Result.failure(error))
+                        cont.resume(Result.failure(AppError.Auth.KakaoSdk(error)))
                     } else if (token != null) {
                         cont.resume(Result.success(token))
                     } else {
-                        cont.resume(Result.failure(IllegalStateException("Token is null")))
+                        cont.resume(Result.failure(AppError.Auth.KakaoTokenMissing))
                     }
                 }
             }
@@ -52,11 +54,11 @@ class KakaoAuthServiceImpl
         override fun isKakaoTalkLoginAvailable(context: Context): Boolean =
             UserApiClient.instance.isKakaoTalkLoginAvailable(context)
 
-        override suspend fun getUserInfo(): Result<KakaoUserInfo> =
+        override suspend fun getUserInfo(): AppResult<KakaoUserInfo> =
             suspendCancellableCoroutine { cont ->
                 UserApiClient.instance.me { user, error ->
                     if (error != null) {
-                        cont.resume(Result.failure(error))
+                        cont.resume(Result.failure(AppError.Auth.KakaoSdk(error)))
                     } else {
                         val profileImageUrl = user?.kakaoAccount?.profile?.profileImageUrl
                         cont.resume(Result.success(KakaoUserInfo(profileImageUrl = profileImageUrl)))
@@ -64,11 +66,11 @@ class KakaoAuthServiceImpl
                 }
             }
 
-        override suspend fun unlink(): Result<Unit> =
+        override suspend fun unlink(): AppResult<Unit> =
             suspendCancellableCoroutine { cont ->
                 UserApiClient.instance.unlink { error ->
                     if (error != null) {
-                        cont.resume(Result.failure(error))
+                        cont.resume(Result.failure(AppError.Auth.KakaoSdk(error)))
                     } else {
                         cont.resume(Result.success(Unit))
                     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/KakaoMapService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/KakaoMapService.kt
@@ -1,12 +1,13 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.KaKaoAddressRequest
 import com.hm.picplz.data.source.KakaoMapSource
 import com.kakao.vectormap.LatLng
 import javax.inject.Inject
 
 interface KakaoMapService {
-    suspend fun getAddressFromCoordinates(coords: LatLng): Result<String>
+    suspend fun getAddressFromCoordinates(coords: LatLng): AppResult<String>
 }
 
 class KakaoMapServiceImpl
@@ -14,7 +15,7 @@ class KakaoMapServiceImpl
     constructor(
         private val kakaoMapSource: KakaoMapSource,
     ) : KakaoMapService {
-        override suspend fun getAddressFromCoordinates(coords: LatLng): Result<String> {
+        override suspend fun getAddressFromCoordinates(coords: LatLng): AppResult<String> {
             return kakaoMapSource.getAddressFromCoords(
                 KaKaoAddressRequest(coords.longitude.toString(), coords.latitude.toString()),
             ).map { response ->

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
 import com.hm.picplz.data.model.toDomain
@@ -8,11 +9,11 @@ import com.hm.picplz.domain.model.MemberProfile
 import javax.inject.Inject
 
 interface MemberService {
-    suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+    suspend fun checkNicknameAvailable(nickname: String): AppResult<Boolean>
 
-    suspend fun getMemberInfo(memberId: Long): Result<MemberProfile>
+    suspend fun getMemberInfo(memberId: Long): AppResult<MemberProfile>
 
-    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit>
+    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit>
 }
 
 class MemberServiceImpl
@@ -20,12 +21,12 @@ class MemberServiceImpl
     constructor(
         private val memberSource: MemberSource,
     ) : MemberService {
-        override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> =
+        override suspend fun checkNicknameAvailable(nickname: String): AppResult<Boolean> =
             memberSource.checkNickname(nickname)
 
-        override suspend fun getMemberInfo(memberId: Long): Result<MemberProfile> =
+        override suspend fun getMemberInfo(memberId: Long): AppResult<MemberProfile> =
             memberSource.getMemberInfo(memberId).map(MemberInfoResponseDto::toDomain)
 
-        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit> =
+        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit> =
             memberSource.updateMemberInfo(request)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerService.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.mapper.toArea
 import com.hm.picplz.data.mapper.toDomain
 import com.hm.picplz.data.mapper.toPhotographerInfo
@@ -20,38 +21,38 @@ import com.hm.picplz.domain.model.ShootingPackage
 import javax.inject.Inject
 
 interface PhotographerService {
-    suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit>
+    suspend fun createPhotographer(request: CreatePhotographerRequest): AppResult<Unit>
 
-    suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>>
+    suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>>
 
-    suspend fun addPhotoMood(photoMood: String): Result<Unit>
+    suspend fun addPhotoMood(photoMood: String): AppResult<Unit>
 
-    suspend fun deletePhotoMood(photoMood: String): Result<Unit>
+    suspend fun deletePhotoMood(photoMood: String): AppResult<Unit>
 
-    suspend fun getActiveAreas(photographerId: Long): Result<List<Area>>
+    suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>>
 
-    suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>>
+    suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>>
 
     suspend fun getNearbyPhotographers(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<FilteredPhotographers>
+    ): AppResult<FilteredPhotographers>
 
-    suspend fun getPhotographerInfo(photographerId: Long): Result<PhotographerInfo>
+    suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerInfo>
 
-    suspend fun getPhotographerRating(photographerId: Long): Result<PhotographerRatingDto>
+    suspend fun getPhotographerRating(photographerId: Long): AppResult<PhotographerRatingDto>
 
     suspend fun getPhotographerReviews(
         photographerId: Long,
         page: Int = 0,
         size: Int = 10,
         sort: String = "RECOMMENDED",
-    ): Result<PhotographerReviewData>
+    ): AppResult<PhotographerReviewData>
 
-    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ShootingPackage>>
+    suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ShootingPackage>>
 
-    suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto>
+    suspend fun getPortfolio(portfolioId: Long): AppResult<PortfolioDto>
 }
 
 class PhotographerServiceImpl
@@ -59,21 +60,21 @@ class PhotographerServiceImpl
     constructor(
         private val photographerSource: PhotographerSource,
     ) : PhotographerService {
-        override suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit> =
+        override suspend fun createPhotographer(request: CreatePhotographerRequest): AppResult<Unit> =
             photographerSource.createPhotographer(request)
 
-        override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+        override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> =
             photographerSource.getPhotographerInfo(photographerId).map { detail ->
                 detail.photoMoods?.mapNotNull { it?.trim() }?.filter(String::isNotEmpty) ?: emptyList()
             }
 
-        override suspend fun addPhotoMood(photoMood: String): Result<Unit> =
+        override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> =
             photographerSource.addPhotoMood(PhotoMoodRequest(photoMood = photoMood))
 
-        override suspend fun deletePhotoMood(photoMood: String): Result<Unit> =
+        override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> =
             photographerSource.deletePhotoMood(PhotoMoodRequest(photoMood = photoMood))
 
-        override suspend fun getActiveAreas(photographerId: Long): Result<List<Area>> =
+        override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> =
             photographerSource.getPhotographerInfo(photographerId).map { photographer ->
                 photographer
                     .area
@@ -90,7 +91,7 @@ class PhotographerServiceImpl
                     }
             }
 
-        override suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>> =
+        override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> =
             photographerSource.updateActiveAreas(
                 UpdateActiveAreaRequest(
                     areas =
@@ -109,7 +110,7 @@ class PhotographerServiceImpl
             longitude: Double,
             latitude: Double,
             distance: Long,
-        ): Result<FilteredPhotographers> {
+        ): AppResult<FilteredPhotographers> {
             return photographerSource.getNearbyPhotographers(longitude, latitude, distance).map { cards ->
                 val photographers = cards.toDomain()
                 FilteredPhotographers(
@@ -119,10 +120,10 @@ class PhotographerServiceImpl
             }
         }
 
-        override suspend fun getPhotographerInfo(photographerId: Long): Result<PhotographerInfo> =
+        override suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerInfo> =
             photographerSource.getPhotographerInfo(photographerId).map { it.toPhotographerInfo() }
 
-        override suspend fun getPhotographerRating(photographerId: Long): Result<PhotographerRatingDto> =
+        override suspend fun getPhotographerRating(photographerId: Long): AppResult<PhotographerRatingDto> =
             photographerSource.getPhotographerRating(photographerId)
 
         override suspend fun getPhotographerReviews(
@@ -130,16 +131,16 @@ class PhotographerServiceImpl
             page: Int,
             size: Int,
             sort: String,
-        ): Result<PhotographerReviewData> =
+        ): AppResult<PhotographerReviewData> =
             photographerSource.getPhotographerReviews(photographerId, page, size, sort).map {
                 it.toReviewData()
             }
 
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ShootingPackage>> =
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ShootingPackage>> =
             photographerSource.getPhotographerProducts(photographerId).map { dtos ->
                 dtos.map { it.toShootingPackage() }
             }
 
-        override suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto> =
+        override suspend fun getPortfolio(portfolioId: Long): AppResult<PortfolioDto> =
             photographerSource.getPortfolio(portfolioId)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/ProductService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/ProductService.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.CreateProductRequest
 import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ProductIdResponse
@@ -7,9 +8,9 @@ import com.hm.picplz.data.source.ProductSource
 import javax.inject.Inject
 
 interface ProductService {
-    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>>
+    suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>>
 
-    suspend fun createProduct(request: CreateProductRequest): Result<ProductIdResponse>
+    suspend fun createProduct(request: CreateProductRequest): AppResult<ProductIdResponse>
 }
 
 class ProductServiceImpl
@@ -17,9 +18,9 @@ class ProductServiceImpl
     constructor(
         private val productSource: ProductSource,
     ) : ProductService {
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>> =
             productSource.getPhotographerProducts(photographerId)
 
-        override suspend fun createProduct(request: CreateProductRequest): Result<ProductIdResponse> =
+        override suspend fun createProduct(request: CreateProductRequest): AppResult<ProductIdResponse> =
             productSource.createProduct(request)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/S3Service.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/S3Service.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.service
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.UploadUrlResponseDto
 import com.hm.picplz.data.source.S3Source
 import javax.inject.Inject
@@ -8,13 +9,13 @@ interface S3Service {
     suspend fun getUploadUrl(
         imageType: String,
         filename: String,
-    ): Result<UploadUrlResponseDto>
+    ): AppResult<UploadUrlResponseDto>
 
     suspend fun uploadImage(
         uploadUrl: String,
         imageBytes: ByteArray,
         contentType: String,
-    ): Result<Unit>
+    ): AppResult<Unit>
 }
 
 class S3ServiceImpl
@@ -25,11 +26,11 @@ class S3ServiceImpl
         override suspend fun getUploadUrl(
             imageType: String,
             filename: String,
-        ): Result<UploadUrlResponseDto> = s3Source.getPresignedUploadUrl(imageType, filename)
+        ): AppResult<UploadUrlResponseDto> = s3Source.getPresignedUploadUrl(imageType, filename)
 
         override suspend fun uploadImage(
             uploadUrl: String,
             imageBytes: ByteArray,
             contentType: String,
-        ): Result<Unit> = s3Source.uploadImageToS3(uploadUrl, imageBytes, contentType)
+        ): AppResult<Unit> = s3Source.uploadImageToS3(uploadUrl, imageBytes, contentType)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/AddressSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/AddressSource.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.AddressApi
 import com.hm.picplz.data.model.AreaData
 import com.hm.picplz.data.model.AreaNearbyRequest
@@ -7,9 +9,9 @@ import com.hm.picplz.data.model.AreaSearchRequest
 import javax.inject.Inject
 
 interface AddressSource {
-    suspend fun searchArea(request: AreaSearchRequest): Result<List<AreaData>>
+    suspend fun searchArea(request: AreaSearchRequest): AppResult<List<AreaData>>
 
-    suspend fun getNearbyAreas(request: AreaNearbyRequest): Result<List<AreaData>>
+    suspend fun getNearbyAreas(request: AreaNearbyRequest): AppResult<List<AreaData>>
 }
 
 class AddressSourceImpl
@@ -17,13 +19,13 @@ class AddressSourceImpl
     constructor(
         private val addressApi: AddressApi,
     ) : AddressSource {
-        override suspend fun searchArea(request: AreaSearchRequest): Result<List<AreaData>> =
-            runCatching {
+        override suspend fun searchArea(request: AreaSearchRequest): AppResult<List<AreaData>> =
+            runCatchingAppError {
                 addressApi.searchAreas(request.keyword).data
             }
 
-        override suspend fun getNearbyAreas(request: AreaNearbyRequest): Result<List<AreaData>> =
-            runCatching {
+        override suspend fun getNearbyAreas(request: AreaNearbyRequest): AppResult<List<AreaData>> =
+            runCatchingAppError {
                 addressApi.getNearbyAreas(
                     rad = request.rad,
                     lat = request.lat,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/AuthSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/AuthSource.kt
@@ -1,12 +1,16 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.error.AppError
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.AuthApi
 import com.hm.picplz.data.model.KaKaoLoginRequest
+import com.hm.picplz.data.util.toHttpAppError
 import com.hm.picplz.domain.model.KaKaoLoginResponse
 import javax.inject.Inject
 
 interface AuthSource {
-    suspend fun loginWithKaKao(accessToken: String): Result<KaKaoLoginResponse>
+    suspend fun loginWithKaKao(accessToken: String): AppResult<KaKaoLoginResponse>
 }
 
 class AuthSourceImpl
@@ -14,14 +18,14 @@ class AuthSourceImpl
     constructor(
         private val authApi: AuthApi,
     ) : AuthSource {
-        override suspend fun loginWithKaKao(accessToken: String): Result<KaKaoLoginResponse> {
-            return runCatching {
+        override suspend fun loginWithKaKao(accessToken: String): AppResult<KaKaoLoginResponse> {
+            return runCatchingAppError {
                 val response = authApi.loginWithKaKao(KaKaoLoginRequest(accessToken))
                 if (response.isSuccessful) {
                     response.body()?.toDomain()
-                        ?: error("Response body is null")
+                        ?: throw AppError.Network.EmptyBody
                 } else {
-                    error("Login failed: ${response.code()} ${response.errorBody()?.string()}")
+                    throw response.toHttpAppError()
                 }
             }
         }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/CameraSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/CameraSource.kt
@@ -1,12 +1,16 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.error.AppError
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.CameraApi
 import com.hm.picplz.data.model.CameraListData
 import com.hm.picplz.data.model.DeviceBrand
+import com.hm.picplz.data.util.toHttpAppError
 import javax.inject.Inject
 
 interface CameraSource {
-    suspend fun getCameraList(): Result<CameraListData>
+    suspend fun getCameraList(): AppResult<CameraListData>
 }
 
 class CameraSourceImpl
@@ -14,13 +18,13 @@ class CameraSourceImpl
     constructor(
         private val cameraApi: CameraApi,
     ) : CameraSource {
-        override suspend fun getCameraList(): Result<CameraListData> =
-            runCatching {
+        override suspend fun getCameraList(): AppResult<CameraListData> =
+            runCatchingAppError {
                 val response = cameraApi.getAllCameras()
                 if (!response.isSuccessful) {
-                    error("Get cameras failed: ${response.code()} ${response.errorBody()?.string()}")
+                    throw response.toHttpAppError()
                 }
-                val cameras = response.body()?.data ?: error("Get cameras failed: empty body")
+                val cameras = response.body()?.data ?: throw AppError.Network.EmptyBody
                 val brands =
                     cameras
                         .groupBy { it.brand }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/CustomerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/CustomerSource.kt
@@ -1,11 +1,14 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.CustomerApi
 import com.hm.picplz.data.model.CreateCustomerRequest
+import com.hm.picplz.data.util.toHttpAppError
 import javax.inject.Inject
 
 interface CustomerSource {
-    suspend fun createCustomer(request: CreateCustomerRequest): Result<Unit>
+    suspend fun createCustomer(request: CreateCustomerRequest): AppResult<Unit>
 }
 
 class CustomerSourceImpl
@@ -13,13 +16,13 @@ class CustomerSourceImpl
     constructor(
         private val customerApi: CustomerApi,
     ) : CustomerSource {
-        override suspend fun createCustomer(request: CreateCustomerRequest): Result<Unit> =
-            runCatching {
+        override suspend fun createCustomer(request: CreateCustomerRequest): AppResult<Unit> =
+            runCatchingAppError {
                 val response = customerApi.createCustomer(request)
                 if (response.isSuccessful) {
                     Unit
                 } else {
-                    error("Create customer failed: ${response.code()} ${response.errorBody()?.string()}")
+                    throw response.toHttpAppError()
                 }
             }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/KakaoMapSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/KakaoMapSource.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.KakaoMapApi
 import com.hm.picplz.data.model.KaKaoAddressRequest
 import com.hm.picplz.data.model.KaKaoAddressResponse
@@ -7,7 +9,7 @@ import com.hm.picplz.data.provider.ConfigProvider
 import javax.inject.Inject
 
 interface KakaoMapSource {
-    suspend fun getAddressFromCoords(request: KaKaoAddressRequest): Result<KaKaoAddressResponse>
+    suspend fun getAddressFromCoords(request: KaKaoAddressRequest): AppResult<KaKaoAddressResponse>
 }
 
 class KakaoMapSourceImpl
@@ -16,8 +18,8 @@ class KakaoMapSourceImpl
         private val kakaoMapApi: KakaoMapApi,
         private val configProvider: ConfigProvider,
     ) : KakaoMapSource {
-        override suspend fun getAddressFromCoords(request: KaKaoAddressRequest): Result<KaKaoAddressResponse> =
-            runCatching {
+        override suspend fun getAddressFromCoords(request: KaKaoAddressRequest): AppResult<KaKaoAddressResponse> =
+            runCatchingAppError {
                 kakaoMapApi.getAddressFromCoords(
                     authorization = "KakaoAK ${configProvider.kakaoRestApiKey}",
                     x = request.x,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
@@ -1,18 +1,21 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.MemberApi
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
 import com.hm.picplz.data.util.safeApiCall
 import com.hm.picplz.data.util.safeApiCallUnit
+import com.hm.picplz.data.util.toHttpAppError
 import javax.inject.Inject
 
 interface MemberSource {
-    suspend fun checkNickname(nickname: String): Result<Boolean>
+    suspend fun checkNickname(nickname: String): AppResult<Boolean>
 
-    suspend fun getMemberInfo(memberId: Long): Result<MemberInfoResponseDto>
+    suspend fun getMemberInfo(memberId: Long): AppResult<MemberInfoResponseDto>
 
-    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit>
+    suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit>
 }
 
 class MemberSourceImpl
@@ -20,19 +23,19 @@ class MemberSourceImpl
     constructor(
         private val memberApi: MemberApi,
     ) : MemberSource {
-        override suspend fun checkNickname(nickname: String): Result<Boolean> =
-            runCatching {
+        override suspend fun checkNickname(nickname: String): AppResult<Boolean> =
+            runCatchingAppError {
                 val response = memberApi.checkNickname(nickname)
                 when {
                     response.isSuccessful -> true
                     response.code() == 409 -> false
-                    else -> error("Nickname check failed: ${response.code()} ${response.errorBody()?.string()}")
+                    else -> throw response.toHttpAppError()
                 }
             }
 
-        override suspend fun getMemberInfo(memberId: Long): Result<MemberInfoResponseDto> =
+        override suspend fun getMemberInfo(memberId: Long): AppResult<MemberInfoResponseDto> =
             safeApiCall { memberApi.getMemberInfo(memberId) }
 
-        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Result<Unit> =
+        override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit> =
             safeApiCallUnit { memberApi.updateMemberInfo(request) }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.api.PhotographerApi
 import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
@@ -16,34 +17,34 @@ import com.hm.picplz.data.util.safeApiCallUnit
 import javax.inject.Inject
 
 interface PhotographerSource {
-    suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit>
+    suspend fun createPhotographer(request: CreatePhotographerRequest): AppResult<Unit>
 
-    suspend fun addPhotoMood(request: PhotoMoodRequest): Result<Unit>
+    suspend fun addPhotoMood(request: PhotoMoodRequest): AppResult<Unit>
 
-    suspend fun deletePhotoMood(request: PhotoMoodRequest): Result<Unit>
+    suspend fun deletePhotoMood(request: PhotoMoodRequest): AppResult<Unit>
 
-    suspend fun updateActiveAreas(request: UpdateActiveAreaRequest): Result<UpdateActiveAreaResponse>
+    suspend fun updateActiveAreas(request: UpdateActiveAreaRequest): AppResult<UpdateActiveAreaResponse>
 
     suspend fun getNearbyPhotographers(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<List<NearbyPhotographerCard>>
+    ): AppResult<List<NearbyPhotographerCard>>
 
-    suspend fun getPhotographerInfo(photographerId: Long): Result<PhotographerDetailDto>
+    suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto>
 
-    suspend fun getPhotographerRating(photographerId: Long): Result<PhotographerRatingDto>
+    suspend fun getPhotographerRating(photographerId: Long): AppResult<PhotographerRatingDto>
 
     suspend fun getPhotographerReviews(
         photographerId: Long,
         page: Int = 0,
         size: Int = 10,
         sort: String = "RECOMMENDED",
-    ): Result<ReviewListDto>
+    ): AppResult<ReviewListDto>
 
-    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>>
+    suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>>
 
-    suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto>
+    suspend fun getPortfolio(portfolioId: Long): AppResult<PortfolioDto>
 }
 
 class PhotographerSourceImpl
@@ -51,29 +52,29 @@ class PhotographerSourceImpl
     constructor(
         private val photographerApi: PhotographerApi,
     ) : PhotographerSource {
-        override suspend fun createPhotographer(request: CreatePhotographerRequest): Result<Unit> =
+        override suspend fun createPhotographer(request: CreatePhotographerRequest): AppResult<Unit> =
             safeApiCallUnit { photographerApi.createPhotographer(request) }
 
-        override suspend fun addPhotoMood(request: PhotoMoodRequest): Result<Unit> =
+        override suspend fun addPhotoMood(request: PhotoMoodRequest): AppResult<Unit> =
             safeApiCallUnit { photographerApi.addPhotoMood(request) }
 
-        override suspend fun deletePhotoMood(request: PhotoMoodRequest): Result<Unit> =
+        override suspend fun deletePhotoMood(request: PhotoMoodRequest): AppResult<Unit> =
             safeApiCallUnit { photographerApi.deletePhotoMood(request) }
 
-        override suspend fun updateActiveAreas(request: UpdateActiveAreaRequest): Result<UpdateActiveAreaResponse> =
+        override suspend fun updateActiveAreas(request: UpdateActiveAreaRequest): AppResult<UpdateActiveAreaResponse> =
             safeApiCall { photographerApi.updateActiveAreas(request) }
 
         override suspend fun getNearbyPhotographers(
             longitude: Double,
             latitude: Double,
             distance: Long,
-        ): Result<List<NearbyPhotographerCard>> =
+        ): AppResult<List<NearbyPhotographerCard>> =
             safeApiCall { photographerApi.getNearbyPhotographers(longitude, latitude, distance) }
 
-        override suspend fun getPhotographerInfo(photographerId: Long): Result<PhotographerDetailDto> =
+        override suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto> =
             safeApiCall({ photographerApi.getPhotographerInfo(photographerId) }) { it.data }
 
-        override suspend fun getPhotographerRating(photographerId: Long): Result<PhotographerRatingDto> =
+        override suspend fun getPhotographerRating(photographerId: Long): AppResult<PhotographerRatingDto> =
             safeApiCall({ photographerApi.getPhotographerRating(photographerId) }) { it.data }
 
         override suspend fun getPhotographerReviews(
@@ -81,12 +82,12 @@ class PhotographerSourceImpl
             page: Int,
             size: Int,
             sort: String,
-        ): Result<ReviewListDto> =
+        ): AppResult<ReviewListDto> =
             safeApiCall({ photographerApi.getPhotographerReviews(photographerId, page, size, sort) }) { it.data }
 
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>> =
             safeApiCall({ photographerApi.getPhotographerProducts(photographerId) }) { it.data }
 
-        override suspend fun getPortfolio(portfolioId: Long): Result<PortfolioDto> =
+        override suspend fun getPortfolio(portfolioId: Long): AppResult<PortfolioDto> =
             safeApiCall({ photographerApi.getPortfolio(portfolioId) }) { it.data }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/ProductSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/ProductSource.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.api.ProductApi
 import com.hm.picplz.data.model.CreateProductRequest
 import com.hm.picplz.data.model.ProductDto
@@ -8,9 +9,9 @@ import com.hm.picplz.data.util.safeApiCall
 import javax.inject.Inject
 
 interface ProductSource {
-    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>>
+    suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>>
 
-    suspend fun createProduct(request: CreateProductRequest): Result<ProductIdResponse>
+    suspend fun createProduct(request: CreateProductRequest): AppResult<ProductIdResponse>
 }
 
 class ProductSourceImpl
@@ -18,9 +19,9 @@ class ProductSourceImpl
     constructor(
         private val productApi: ProductApi,
     ) : ProductSource {
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ProductDto>> =
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>> =
             safeApiCall { productApi.getPhotographerProducts(photographerId) }
 
-        override suspend fun createProduct(request: CreateProductRequest): Result<ProductIdResponse> =
+        override suspend fun createProduct(request: CreateProductRequest): AppResult<ProductIdResponse> =
             safeApiCall { productApi.createProduct(request) }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/S3Source.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/S3Source.kt
@@ -1,7 +1,11 @@
 package com.hm.picplz.data.source
 
+import com.hm.picplz.common.error.AppError
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.S3Api
 import com.hm.picplz.data.model.UploadUrlResponseDto
+import com.hm.picplz.data.util.toHttpAppError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -15,13 +19,13 @@ interface S3Source {
     suspend fun getPresignedUploadUrl(
         imageType: String,
         filename: String,
-    ): Result<UploadUrlResponseDto>
+    ): AppResult<UploadUrlResponseDto>
 
     suspend fun uploadImageToS3(
         uploadUrl: String,
         imageBytes: ByteArray,
         contentType: String,
-    ): Result<Unit>
+    ): AppResult<Unit>
 }
 
 class S3SourceImpl
@@ -34,13 +38,13 @@ class S3SourceImpl
         override suspend fun getPresignedUploadUrl(
             imageType: String,
             filename: String,
-        ): Result<UploadUrlResponseDto> =
-            runCatching {
+        ): AppResult<UploadUrlResponseDto> =
+            runCatchingAppError {
                 val response = s3Api.getPresignedUploadUrl(imageType, filename)
                 if (response.isSuccessful) {
-                    response.body()?.data ?: error("Get presigned upload url failed: empty body")
+                    response.body()?.data ?: throw AppError.Network.EmptyBody
                 } else {
-                    error("Get presigned upload url failed: ${response.code()} ${response.errorBody()?.string()}")
+                    throw response.toHttpAppError()
                 }
             }
 
@@ -48,8 +52,8 @@ class S3SourceImpl
             uploadUrl: String,
             imageBytes: ByteArray,
             contentType: String,
-        ): Result<Unit> =
-            runCatching {
+        ): AppResult<Unit> =
+            runCatchingAppError {
                 val requestBody = imageBytes.toRequestBody(contentType.toMediaType())
                 val request =
                     Request.Builder()
@@ -59,7 +63,9 @@ class S3SourceImpl
                 withContext(Dispatchers.IO) {
                     plainOkHttpClient.newCall(request).execute().use { response ->
                         if (!response.isSuccessful) {
-                            throw IOException("S3 upload failed with code: ${response.code}")
+                            throw IOException(
+                                "S3 upload failed with code: ${response.code}, body: ${response.body?.string()}",
+                            )
                         }
                     }
                 }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/util/SafeApiCall.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/util/SafeApiCall.kt
@@ -1,31 +1,32 @@
 package com.hm.picplz.data.util
 
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.hm.picplz.common.error.AppError
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
+import com.hm.picplz.data.model.ApiErrorResponseDto
 import retrofit2.Response
 
-/**
- * API 호출 실패 시 발생하는 구조화된 예외.
- * HTTP 상태 코드와 에러 바디를 보존하여 호출부에서 에러 유형별 분기 가능.
- */
-class ApiException(
-    val code: Int,
-    val errorBody: String?,
-) : Exception("API failed: $code $errorBody")
+private val errorResponseGson = Gson()
+private const val TAG = "SafeApiCall"
 
 /**
- * Retrofit Response를 안전하게 처리하여 Result<T>로 반환.
+ * Retrofit Response를 안전하게 처리하여 AppResult<T>로 반환.
  *
  * 사용 예시:
  * ```
  * safeApiCall { api.getPhotographers(lat, lng, dist) }
  * ```
  */
-suspend fun <T> safeApiCall(call: suspend () -> Response<T>): Result<T> =
-    runCatching {
+suspend fun <T> safeApiCall(call: suspend () -> Response<T>): AppResult<T> =
+    runCatchingAppError {
         val response = call()
         if (response.isSuccessful) {
-            response.body() ?: error("Response body is null")
+            response.body() ?: throw AppError.Network.EmptyBody
         } else {
-            throw ApiException(response.code(), response.errorBody()?.string())
+            throw response.toHttpAppError()
         }
     }
 
@@ -41,14 +42,14 @@ suspend fun <T> safeApiCall(call: suspend () -> Response<T>): Result<T> =
 suspend fun <T, R> safeApiCall(
     call: suspend () -> Response<T>,
     transform: (T) -> R,
-): Result<R> =
-    runCatching {
+): AppResult<R> =
+    runCatchingAppError {
         val response = call()
         if (response.isSuccessful) {
-            val body = response.body() ?: error("Response body is null")
+            val body = response.body() ?: throw AppError.Network.EmptyBody
             transform(body)
         } else {
-            throw ApiException(response.code(), response.errorBody()?.string())
+            throw response.toHttpAppError()
         }
     }
 
@@ -60,10 +61,34 @@ suspend fun <T, R> safeApiCall(
  * safeApiCallUnit { api.createPhotographer(request) }
  * ```
  */
-suspend fun safeApiCallUnit(call: suspend () -> Response<*>): Result<Unit> =
-    runCatching {
+suspend fun safeApiCallUnit(call: suspend () -> Response<*>): AppResult<Unit> =
+    runCatchingAppError {
         val response = call()
         if (!response.isSuccessful) {
-            throw ApiException(response.code(), response.errorBody()?.string())
+            throw response.toHttpAppError()
         }
+    }
+
+fun Response<*>.toHttpAppError(): AppError.Network.Http {
+    val rawBody = errorBody()?.string()
+    val serverError = rawBody?.toApiErrorResponseDtoOrNull()
+    return AppError.Network.Http(
+        code = code(),
+        body = rawBody,
+        statusCode = serverError?.statusCode,
+        serverMessage = serverError?.message,
+        timestamp = serverError?.timestamp,
+        data = serverError?.data?.toString(),
+    )
+}
+
+private fun String.toApiErrorResponseDtoOrNull(): ApiErrorResponseDto? =
+    try {
+        errorResponseGson.fromJson(this, ApiErrorResponseDto::class.java)
+    } catch (error: JsonSyntaxException) {
+        Log.d(TAG, "Failed to parse API error response", error)
+        null
+    } catch (error: IllegalStateException) {
+        Log.d(TAG, "Failed to parse API error response", error)
+        null
     }

--- a/core/domain/AGENTS.md
+++ b/core/domain/AGENTS.md
@@ -35,12 +35,12 @@ domain/src/main/kotlin/com/hm/picplz/domain/
 - **Pattern:** `{Action}{Target}UseCase`
 - **Examples:** `GetKakaoUserInfoUseCase`, `LoginWithKakaoUseCase`
 - Always use `operator fun invoke()` for single-method execution
-- Return `Result<T>` for error handling
+- Return `AppResult<T>` for error handling
 
 ### Repository Interfaces
 - Define contracts only; implementations live in `core:data`
 - Use `suspend` functions for async operations
-- Return `Result<T>` to propagate errors cleanly
+- Return `AppResult<T>` to propagate errors cleanly
 
 ### Models
 - Plain `data class` with immutable properties

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AreaRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AreaRepository.kt
@@ -1,13 +1,14 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 
 interface AreaRepository {
-    suspend fun searchAreas(keyword: String): Result<List<Area>>
+    suspend fun searchAreas(keyword: String): AppResult<List<Area>>
 
     suspend fun getNearbyAreas(
         rad: Int,
         lat: Double,
         lng: Double,
-    ): Result<List<Area>>
+    ): AppResult<List<Area>>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/AuthRepository.kt
@@ -1,15 +1,16 @@
 package com.hm.picplz.domain.repository
 
 import android.content.Context
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.KaKaoLoginResponse
 import com.hm.picplz.domain.model.KakaoUserInfo
 
 interface AuthRepository {
-    suspend fun loginWithKakao(context: Context): Result<KaKaoLoginResponse>
+    suspend fun loginWithKakao(context: Context): AppResult<KaKaoLoginResponse>
 
-    suspend fun getKakaoUserInfo(): Result<KakaoUserInfo>
+    suspend fun getKakaoUserInfo(): AppResult<KakaoUserInfo>
 
-    suspend fun unlinkKakao(): Result<Unit>
+    suspend fun unlinkKakao(): AppResult<Unit>
 
     fun isKakaoTalkLoginAvailable(context: Context): Boolean
 

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/CameraRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/CameraRepository.kt
@@ -1,7 +1,8 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CameraCatalog
 
 interface CameraRepository {
-    suspend fun getCameraCatalog(): Result<CameraCatalog>
+    suspend fun getCameraCatalog(): AppResult<CameraCatalog>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
@@ -1,12 +1,13 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.MemberProfile
 import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 
 interface MemberRepository {
-    suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+    suspend fun checkNicknameAvailable(nickname: String): AppResult<Boolean>
 
-    suspend fun getMemberProfile(memberId: Long): Result<MemberProfile>
+    suspend fun getMemberProfile(memberId: Long): AppResult<MemberProfile>
 
-    suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit>
+    suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): AppResult<Unit>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerRepository.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.domain.model.PhotographerDetail
@@ -9,20 +10,20 @@ interface PhotographerRepository {
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<FilteredPhotographers>
+    ): AppResult<FilteredPhotographers>
 
     suspend fun getPhotographerDetail(
         photographerId: Long,
         reviewSort: String = "RECOMMENDED",
-    ): Result<PhotographerDetail>
+    ): AppResult<PhotographerDetail>
 
-    suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>>
+    suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>>
 
-    suspend fun addPhotoMood(photoMood: String): Result<Unit>
+    suspend fun addPhotoMood(photoMood: String): AppResult<Unit>
 
-    suspend fun deletePhotoMood(photoMood: String): Result<Unit>
+    suspend fun deletePhotoMood(photoMood: String): AppResult<Unit>
 
-    suspend fun getActiveAreas(photographerId: Long): Result<List<Area>>
+    suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>>
 
-    suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>>
+    suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/ProductRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/ProductRepository.kt
@@ -1,10 +1,11 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CreateProductCommand
 import com.hm.picplz.domain.model.ShootingPackage
 
 interface ProductRepository {
-    suspend fun getPhotographerProducts(photographerId: Long): Result<List<ShootingPackage>>
+    suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ShootingPackage>>
 
-    suspend fun createProduct(command: CreateProductCommand): Result<Long>
+    suspend fun createProduct(command: CreateProductCommand): AppResult<Long>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/S3Repository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/S3Repository.kt
@@ -1,13 +1,15 @@
 package com.hm.picplz.domain.repository
 
+import com.hm.picplz.common.result.AppResult
+
 interface S3Repository {
     suspend fun uploadProfileImage(
         imageBytes: ByteArray,
         filename: String,
-    ): Result<String>
+    ): AppResult<String>
 
     suspend fun uploadProductImage(
         imageBytes: ByteArray,
         filename: String,
-    ): Result<String>
+    ): AppResult<String>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CheckNicknameAvailabilityUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CheckNicknameAvailabilityUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.repository.MemberRepository
 import javax.inject.Inject
 
@@ -8,6 +9,6 @@ class CheckNicknameAvailabilityUseCase
     constructor(
         private val memberRepository: MemberRepository,
     ) {
-        suspend operator fun invoke(nickname: String): Result<Boolean> =
+        suspend operator fun invoke(nickname: String): AppResult<Boolean> =
             memberRepository.checkNicknameAvailable(nickname)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CreateProductUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/CreateProductUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CreateProductCommand
 import com.hm.picplz.domain.repository.ProductRepository
 import javax.inject.Inject
@@ -9,6 +10,6 @@ class CreateProductUseCase
     constructor(
         private val productRepository: ProductRepository,
     ) {
-        suspend operator fun invoke(command: CreateProductCommand): Result<Long> =
+        suspend operator fun invoke(command: CreateProductCommand): AppResult<Long> =
             productRepository.createProduct(command)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetCameraCatalogUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetCameraCatalogUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CameraCatalog
 import com.hm.picplz.domain.repository.CameraRepository
 import javax.inject.Inject
@@ -9,5 +10,5 @@ class GetCameraCatalogUseCase
     constructor(
         private val cameraRepository: CameraRepository,
     ) {
-        suspend operator fun invoke(): Result<CameraCatalog> = cameraRepository.getCameraCatalog()
+        suspend operator fun invoke(): AppResult<CameraCatalog> = cameraRepository.getCameraCatalog()
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetKakaoUserInfoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetKakaoUserInfoUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.KakaoUserInfo
 import com.hm.picplz.domain.repository.AuthRepository
 import javax.inject.Inject
@@ -9,7 +10,7 @@ class GetKakaoUserInfoUseCase
     constructor(
         private val authRepository: AuthRepository,
     ) {
-        suspend operator fun invoke(): Result<KakaoUserInfo> {
+        suspend operator fun invoke(): AppResult<KakaoUserInfo> {
             return authRepository.getKakaoUserInfo()
         }
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetMemberProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetMemberProfileUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.MemberProfile
 import com.hm.picplz.domain.repository.MemberRepository
 import javax.inject.Inject
@@ -9,5 +10,6 @@ class GetMemberProfileUseCase
     constructor(
         private val memberRepository: MemberRepository,
     ) {
-        suspend operator fun invoke(memberId: Long): Result<MemberProfile> = memberRepository.getMemberProfile(memberId)
+        suspend operator fun invoke(memberId: Long): AppResult<MemberProfile> =
+            memberRepository.getMemberProfile(memberId)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetNearbyAreasUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetNearbyAreasUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.repository.AreaRepository
 import javax.inject.Inject
@@ -13,5 +14,5 @@ class GetNearbyAreasUseCase
             rad: Int,
             lat: Double,
             lng: Double,
-        ): Result<List<Area>> = areaRepository.getNearbyAreas(rad, lat, lng)
+        ): AppResult<List<Area>> = areaRepository.getNearbyAreas(rad, lat, lng)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerActiveAreasUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerActiveAreasUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.repository.PhotographerRepository
 import javax.inject.Inject
@@ -9,6 +10,6 @@ class GetPhotographerActiveAreasUseCase
     constructor(
         private val photographerRepository: PhotographerRepository,
     ) {
-        suspend operator fun invoke(photographerId: Long): Result<List<Area>> =
+        suspend operator fun invoke(photographerId: Long): AppResult<List<Area>> =
             photographerRepository.getActiveAreas(photographerId)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerDetailUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerDetailUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.PhotographerDetail
 import com.hm.picplz.domain.repository.PhotographerRepository
 import javax.inject.Inject
@@ -12,5 +13,5 @@ class GetPhotographerDetailUseCase
         suspend operator fun invoke(
             photographerId: Long,
             reviewSort: String = "RECOMMENDED",
-        ): Result<PhotographerDetail> = photographerRepository.getPhotographerDetail(photographerId, reviewSort)
+        ): AppResult<PhotographerDetail> = photographerRepository.getPhotographerDetail(photographerId, reviewSort)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerMoodKeywordsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerMoodKeywordsUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.repository.PhotographerRepository
 import javax.inject.Inject
 
@@ -8,6 +9,6 @@ class GetPhotographerMoodKeywordsUseCase
     constructor(
         private val photographerRepository: PhotographerRepository,
     ) {
-        suspend operator fun invoke(photographerId: Long): Result<List<String>> =
+        suspend operator fun invoke(photographerId: Long): AppResult<List<String>> =
             photographerRepository.getPhotographerMoodKeywords(photographerId)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerProductsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerProductsUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.ShootingPackage
 import com.hm.picplz.domain.repository.ProductRepository
 import javax.inject.Inject
@@ -9,6 +10,6 @@ class GetPhotographerProductsUseCase
     constructor(
         private val productRepository: ProductRepository,
     ) {
-        suspend operator fun invoke(photographerId: Long): Result<List<ShootingPackage>> =
+        suspend operator fun invoke(photographerId: Long): AppResult<List<ShootingPackage>> =
             productRepository.getPhotographerProducts(photographerId)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/LoginWithKakaoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/LoginWithKakaoUseCase.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.domain.usecase
 
 import android.content.Context
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.KaKaoLoginResponse
 import com.hm.picplz.domain.repository.AuthRepository
 import javax.inject.Inject
@@ -10,7 +11,7 @@ class LoginWithKakaoUseCase
     constructor(
         private val authRepository: AuthRepository,
     ) {
-        suspend operator fun invoke(context: Context): Result<KaKaoLoginResponse> {
+        suspend operator fun invoke(context: Context): AppResult<KaKaoLoginResponse> {
             return authRepository.loginWithKakao(context)
         }
 

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/SearchAreasUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/SearchAreasUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.repository.AreaRepository
 import javax.inject.Inject
@@ -9,5 +10,5 @@ class SearchAreasUseCase
     constructor(
         private val areaRepository: AreaRepository,
     ) {
-        suspend operator fun invoke(keyword: String): Result<List<Area>> = areaRepository.searchAreas(keyword)
+        suspend operator fun invoke(keyword: String): AppResult<List<Area>> = areaRepository.searchAreas(keyword)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UnlinkKakaoUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UnlinkKakaoUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.repository.AuthRepository
 import javax.inject.Inject
 
@@ -8,7 +9,7 @@ class UnlinkKakaoUseCase
     constructor(
         private val authRepository: AuthRepository,
     ) {
-        suspend operator fun invoke(): Result<Unit> {
+        suspend operator fun invoke(): AppResult<Unit> {
             return authRepository.unlinkKakao()
         }
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberProfileUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberProfileUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 import com.hm.picplz.domain.repository.MemberRepository
 import javax.inject.Inject
@@ -9,6 +10,6 @@ class UpdateMemberProfileUseCase
     constructor(
         private val memberRepository: MemberRepository,
     ) {
-        suspend operator fun invoke(command: UpdateMemberProfileCommand): Result<Unit> =
+        suspend operator fun invoke(command: UpdateMemberProfileCommand): AppResult<Unit> =
             memberRepository.updateMemberProfile(command)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerActiveAreasUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerActiveAreasUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.repository.PhotographerRepository
 import javax.inject.Inject
@@ -9,6 +10,6 @@ class UpdatePhotographerActiveAreasUseCase
     constructor(
         private val photographerRepository: PhotographerRepository,
     ) {
-        suspend operator fun invoke(areas: List<Area>): Result<List<Area>> =
+        suspend operator fun invoke(areas: List<Area>): AppResult<List<Area>> =
             photographerRepository.updateActiveAreas(areas)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerMoodKeywordsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdatePhotographerMoodKeywordsUseCase.kt
@@ -1,5 +1,7 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.domain.repository.PhotographerRepository
 import javax.inject.Inject
 
@@ -11,8 +13,8 @@ class UpdatePhotographerMoodKeywordsUseCase
         suspend operator fun invoke(
             originalKeywords: List<String>,
             selectedKeywords: List<String>,
-        ): Result<Unit> =
-            runCatching {
+        ): AppResult<Unit> =
+            runCatchingAppError {
                 val original =
                     originalKeywords
                         .map(String::trim)

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProductImageUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProductImageUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.repository.S3Repository
 import javax.inject.Inject
 
@@ -11,5 +12,5 @@ class UploadProductImageUseCase
         suspend operator fun invoke(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> = s3Repository.uploadProductImage(imageBytes, filename)
+        ): AppResult<String> = s3Repository.uploadProductImage(imageBytes, filename)
     }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProfileImageUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UploadProfileImageUseCase.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.domain.usecase
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.repository.S3Repository
 import javax.inject.Inject
 
@@ -11,5 +12,5 @@ class UploadProfileImageUseCase
         suspend operator fun invoke(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> = s3Repository.uploadProfileImage(imageBytes, filename)
+        ): AppResult<String> = s3Repository.uploadProfileImage(imageBytes, filename)
     }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginSideEffect.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginSideEffect.kt
@@ -1,13 +1,15 @@
 package com.hm.picplz.ui.screen.login
 
+import com.hm.picplz.common.error.AppError
+
 sealed interface LoginSideEffect {
     data object LoginSuccess : LoginSideEffect
 
-    data class LoginFailed(val error: Throwable?) : LoginSideEffect
+    data class LoginFailed(val error: AppError?) : LoginSideEffect
 
     data class NavigateToSignUp(val profileImageUrl: String?) : LoginSideEffect
 
     data object UnlinkSuccess : LoginSideEffect
 
-    data class UnlinkFailed(val error: Throwable?) : LoginSideEffect
+    data class UnlinkFailed(val error: AppError?) : LoginSideEffect
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginState.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginState.kt
@@ -1,8 +1,10 @@
 package com.hm.picplz.ui.screen.login
 
+import com.hm.picplz.common.error.AppError
+
 data class LoginState(
     val isLoading: Boolean = false,
-    val error: Throwable? = null,
+    val error: AppError? = null,
 ) {
     companion object {
         fun idle(): LoginState {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.ui.screen.login
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.error.AppError
 import com.hm.picplz.domain.usecase.GetKakaoUserInfoUseCase
 import com.hm.picplz.domain.usecase.LoginWithKakaoUseCase
 import com.hm.picplz.domain.usecase.UnlinkKakaoUseCase
@@ -47,9 +48,10 @@ class LoginViewModel
                                 }
                             }
                             .onFailure { error ->
-                                _state.update { it.copy(isLoading = false, error = error) }
+                                val appError = AppError.fromThrowable(error)
+                                _state.update { it.copy(isLoading = false, error = appError) }
                                 Log.e(TAG, "로그인 실패", error)
-                                _sideEffect.send(LoginSideEffect.LoginFailed(error))
+                                _sideEffect.send(LoginSideEffect.LoginFailed(appError))
                             }
                     }
                 }
@@ -64,8 +66,9 @@ class LoginViewModel
                                 )
                             }
                             .onFailure { error ->
+                                val appError = AppError.fromThrowable(error)
                                 Log.e(TAG, "카카오 사용자 정보 요청 실패", error)
-                                _sideEffect.send(LoginSideEffect.LoginFailed(error))
+                                _sideEffect.send(LoginSideEffect.LoginFailed(appError))
                             }
                     }
                 }
@@ -78,8 +81,9 @@ class LoginViewModel
                                 _sideEffect.send(LoginSideEffect.UnlinkSuccess)
                             }
                             .onFailure { error ->
+                                val appError = AppError.fromThrowable(error)
                                 Log.e(TAG, "연결 끊기 실패", error)
-                                _sideEffect.send(LoginSideEffect.UnlinkFailed(error))
+                                _sideEffect.send(LoginSideEffect.UnlinkFailed(appError))
                             }
                     }
                 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonIntent.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonIntent.kt
@@ -18,15 +18,28 @@ sealed interface SignUpCommonIntent {
 
     data class SetProfileImageUri(val newProfileImageUri: String?) : SignUpCommonIntent
 
-    data class UploadProfileImage(val imageBytes: ByteArray, val filename: String) : SignUpCommonIntent {
+    data class UploadProfileImage(
+        val imageBytes: ByteArray,
+        val filename: String,
+        val contentType: String,
+    ) : SignUpCommonIntent {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is UploadProfileImage) return false
-            return filename == other.filename && imageBytes.contentEquals(other.imageBytes)
+            return filename == other.filename &&
+                contentType == other.contentType &&
+                imageBytes.contentEquals(other.imageBytes)
         }
 
-        override fun hashCode(): Int = 31 * imageBytes.contentHashCode() + filename.hashCode()
+        override fun hashCode(): Int {
+            var result = imageBytes.contentHashCode()
+            result = 31 * result + filename.hashCode()
+            result = 31 * result + contentType.hashCode()
+            return result
+        }
     }
+
+    data object ProfileImageReadFailed : SignUpCommonIntent
 
     data class Navigate(val destination: NavigationRoute) : SignUpCommonIntent
 

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonSideEffect.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonSideEffect.kt
@@ -16,4 +16,6 @@ sealed interface SignUpSideEffect {
     data class Navigate(val destination: NavigationRoute) : SignUpSideEffect
 
     data object ShowFileUploadDialog : SignUpSideEffect
+
+    data class ShowToast(val messageResId: Int) : SignUpSideEffect
 }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonState.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonState.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_common
 
+import com.hm.picplz.common.error.AppError
 import com.hm.picplz.common.model.NicknameFieldError
 import com.hm.picplz.common.model.SelectionState
 import com.hm.picplz.common.model.UserType
@@ -8,7 +9,7 @@ data class SignUpCommonState(
     val currentStep: Int = 0,
     val selectedUserType: UserType? = null,
     val isLoading: Boolean = false,
-    val error: Throwable? = null,
+    val error: AppError? = null,
     val nickname: String = "",
     val profileImageUri: String? = null,
     val profileImageObjectKey: String? = null,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/SignUpCommonViewModel.kt
@@ -1,7 +1,9 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_common
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.error.AppError
 import com.hm.picplz.common.model.NicknameFieldError
 import com.hm.picplz.common.model.User
 import com.hm.picplz.common.model.UserType
@@ -10,6 +12,7 @@ import com.hm.picplz.data.provider.TokenManager
 import com.hm.picplz.data.service.CustomerService
 import com.hm.picplz.data.service.MemberService
 import com.hm.picplz.data.service.S3Service
+import com.hm.picplz.feature.auth.R
 import com.hm.picplz.navigation.model.SignUpProfile
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.handler.UserInfoHandler
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.handler.UserTypeInfoHandler
@@ -64,7 +67,7 @@ class SignUpCommonViewModel
                                         _state.update {
                                             it.copy(
                                                 isSubmitting = false,
-                                                error = IllegalStateException("소셜 로그인 정보가 없습니다"),
+                                                error = AppError.Auth.SocialInfoMissing,
                                             )
                                         }
                                         return@launch
@@ -88,10 +91,11 @@ class SignUpCommonViewModel
                                             )
                                         }
                                         .onFailure { error ->
+                                            val appError = AppError.fromThrowable(error)
                                             _state.update {
                                                 it.copy(
                                                     isSubmitting = false,
-                                                    error = error,
+                                                    error = appError,
                                                 )
                                             }
                                         }
@@ -154,10 +158,11 @@ class SignUpCommonViewModel
                                 }
                             }
                             .onFailure { error ->
+                                val appError = AppError.fromThrowable(error)
                                 _state.update {
                                     it.copy(
                                         isCheckingNickname = false,
-                                        error = error,
+                                        error = appError,
                                     )
                                 }
                             }
@@ -174,13 +179,34 @@ class SignUpCommonViewModel
                     _state.update { SignUpCommonState.idle() }
                 }
 
+                SignUpCommonIntent.ProfileImageReadFailed -> {
+                    _state.update {
+                        it.copy(
+                            profileImageUri = null,
+                            profileImageObjectKey = null,
+                            isUploadingImage = false,
+                        )
+                    }
+                    viewModelScope.launch {
+                        _sideEffect.send(
+                            SignUpSideEffect.ShowToast(R.string.sign_up_profile_image_read_failed),
+                        )
+                    }
+                }
+
                 is SignUpCommonIntent.UploadProfileImage -> {
                     viewModelScope.launch {
-                        _state.update { it.copy(isUploadingImage = true) }
+                        Log.d(
+                            TAG,
+                            "profile image upload start: filename=${intent.filename}, bytes=${intent.imageBytes.size}",
+                        )
+                        _state.update { it.copy(isUploadingImage = true, error = null) }
                         s3Service.getUploadUrl("PROFILE", intent.filename)
                             .onSuccess { response ->
-                                s3Service.uploadImage(response.uploadUrl, intent.imageBytes, "image/jpeg")
+                                Log.d(TAG, "profile image upload url issued: objectKey=${response.objectKey}")
+                                s3Service.uploadImage(response.uploadUrl, intent.imageBytes, intent.contentType)
                                     .onSuccess {
+                                        Log.d(TAG, "profile image upload success: objectKey=${response.objectKey}")
                                         _state.update {
                                             it.copy(
                                                 profileImageObjectKey = response.objectKey,
@@ -189,19 +215,23 @@ class SignUpCommonViewModel
                                         }
                                     }
                                     .onFailure { error ->
+                                        val appError = AppError.fromThrowable(error)
+                                        Log.e(TAG, "profile image S3 PUT failed", error)
                                         _state.update {
                                             it.copy(
                                                 isUploadingImage = false,
-                                                error = error,
+                                                error = appError,
                                             )
                                         }
                                     }
                             }
                             .onFailure { error ->
+                                val appError = AppError.fromThrowable(error)
+                                Log.e(TAG, "profile image presigned URL failed", error)
                                 _state.update {
                                     it.copy(
                                         isUploadingImage = false,
-                                        error = error,
+                                        error = appError,
                                     )
                                 }
                             }
@@ -234,5 +264,9 @@ class SignUpCommonViewModel
                     user,
                 ),
             )
+        }
+
+        companion object {
+            private const val TAG = "SignUpCommonViewModel"
         }
     }

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpProfileImageScreen.kt
@@ -1,6 +1,8 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_common.views
 
 import android.net.Uri
+import android.webkit.MimeTypeMap
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -46,6 +48,7 @@ import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.NavigateToPrev
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.NavigateToSelected
+import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.ProfileImageReadFailed
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.SetProfileImageUri
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.ShowFileUploadDialog
 import com.hm.picplz.ui.screen.sign_up.sign_up_common.SignUpCommonIntent.UploadProfileImage
@@ -77,8 +80,11 @@ fun SignUpProfileImageScreen(
                 viewModel.handleIntent(SetProfileImageUri(uri.toString()))
                 val imageBytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
                 if (imageBytes != null) {
-                    val filename = uri.lastPathSegment ?: "profile.jpg"
-                    viewModel.handleIntent(UploadProfileImage(imageBytes, filename))
+                    val contentType = context.contentResolver.getType(uri) ?: "image/jpeg"
+                    val filename = uri.toProfileImageFilename(contentType)
+                    viewModel.handleIntent(UploadProfileImage(imageBytes, filename, contentType))
+                } else {
+                    viewModel.handleIntent(ProfileImageReadFailed)
                 }
             }
         }
@@ -225,9 +231,18 @@ fun SignUpProfileImageScreen(
                 is SignUpSideEffect.ShowFileUploadDialog -> {
                     filePickerLauncher.launch("image/*")
                 }
+                is SignUpSideEffect.ShowToast -> {
+                    Toast.makeText(context, sideEffect.messageResId, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
+}
+
+private fun Uri.toProfileImageFilename(contentType: String): String {
+    val rawFilename = lastPathSegment?.substringAfterLast('/')?.takeIf { it.isNotBlank() } ?: "profile"
+    val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType) ?: "jpg"
+    return if (rawFilename.contains('.')) rawFilename else "$rawFilename.$extension"
 }
 
 @Preview

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerState.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.sign_up.sign_up_photographer
 
+import com.hm.picplz.common.error.AppError
 import com.hm.picplz.common.mockdata.emptyUserData
 import com.hm.picplz.common.model.ChipItem
 import com.hm.picplz.common.model.User
@@ -22,7 +23,7 @@ data class SignUpPhotographerState(
     val currentStep: Int? = 0,
     val isLoading: Boolean = false,
     val isSubmitting: Boolean = false,
-    val error: Throwable? = null,
+    val error: AppError? = null,
     val userInfo: User = emptyUserData,
     val hasPhotographyExperience: Boolean? = null,
     val selectedPhotographyExperienceId: String? = null,

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_photographer/SignUpPhotographerViewModel.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.ui.screen.sign_up.sign_up_photographer
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hm.picplz.common.error.AppError
 import com.hm.picplz.data.model.ActiveAreaRequest
 import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.PhotographerCameraRequest
@@ -205,7 +206,7 @@ class SignUpPhotographerViewModel
                             _state.update {
                                 it.copy(
                                     isSubmitting = false,
-                                    error = IllegalStateException("소셜 로그인 정보가 없습니다"),
+                                    error = AppError.Auth.SocialInfoMissing,
                                     showToast = true,
                                     toastMessage = "로그인 정보를 찾지 못했습니다. 다시 로그인해 주세요.",
                                 )
@@ -290,10 +291,11 @@ class SignUpPhotographerViewModel
                                 )
                             }
                             .onFailure { error ->
+                                val appError = AppError.fromThrowable(error)
                                 _state.update {
                                     it.copy(
                                         isSubmitting = false,
-                                        error = error,
+                                        error = appError,
                                         showToast = true,
                                         toastMessage = "가입을 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.",
                                     )

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="sign_up_profile_image_guide_required">프로필 이미지를\n설정해 주세요.</string>
     <string name="sign_up_profile_image_guide_photographer">이제 촬영지와 촬영 기기를\n선택할 거예요</string>
     <string name="sign_up_profile_image_skip">다음에 설정하기</string>
+    <string name="sign_up_profile_image_read_failed">프로필 이미지를 불러오지 못했어요. 다른 사진을 선택해 주세요.</string>
     <string name="sign_up_client_top_bar_title">고객 선택</string>
     <string name="sign_up_main_location_top_bar_title">주 촬영지 선택</string>
     <string name="sign_up_main_location_already_selected">이미 선택된 항목입니다.</string>

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainViewModelTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/photographer_main/PhotographerMainViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.photographer_main
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CameraBrand
 import com.hm.picplz.domain.model.CameraCatalog
 import com.hm.picplz.domain.model.Device
@@ -141,7 +142,7 @@ class PhotographerMainViewModelTest {
     }
 
     private class FakeCameraRepository : CameraRepository {
-        override suspend fun getCameraCatalog(): Result<CameraCatalog> =
+        override suspend fun getCameraCatalog(): AppResult<CameraCatalog> =
             Result.success(
                 CameraCatalog(
                     brands = listOf(CameraBrand("소니", listOf("a7m4"))),

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePackageEditViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.my_page
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.CreateProductCommand
 import com.hm.picplz.domain.model.ShootingPackage
 import com.hm.picplz.domain.repository.ProductRepository
@@ -259,12 +260,12 @@ class MyPagePackageEditViewModelTest {
         val createdProducts = mutableListOf<CreateProductCommand>()
         var requestedPhotographerId: Long? = null
 
-        override suspend fun getPhotographerProducts(photographerId: Long): Result<List<ShootingPackage>> {
+        override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ShootingPackage>> {
             requestedPhotographerId = photographerId
             return Result.success(products)
         }
 
-        override suspend fun createProduct(command: CreateProductCommand): Result<Long> {
+        override suspend fun createProduct(command: CreateProductCommand): AppResult<Long> {
             createdProducts += command
             return Result.success(101L)
         }
@@ -277,12 +278,12 @@ class MyPagePackageEditViewModelTest {
         override suspend fun uploadProfileImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> = error("Not needed")
+        ): AppResult<String> = error("Not needed")
 
         override suspend fun uploadProductImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> =
+        ): AppResult<String> =
             if (shouldFail) {
                 Result.failure(IllegalStateException("upload failed"))
             } else {

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerActiveAreaEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerActiveAreaEditViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.my_page
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.domain.model.LocationCoordinate
@@ -156,25 +157,25 @@ private class FakeActiveAreaPhotographerRepository(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<FilteredPhotographers> = error("Not used")
+    ): AppResult<FilteredPhotographers> = error("Not used")
 
     override suspend fun getPhotographerDetail(
         photographerId: Long,
         reviewSort: String,
-    ): Result<PhotographerDetail> = error("Not used")
+    ): AppResult<PhotographerDetail> = error("Not used")
 
-    override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> = error("Not used")
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> = error("Not used")
 
-    override suspend fun addPhotoMood(photoMood: String): Result<Unit> = error("Not used")
+    override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> = error("Not used")
 
-    override suspend fun deletePhotoMood(photoMood: String): Result<Unit> = error("Not used")
+    override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> = error("Not used")
 
-    override suspend fun getActiveAreas(photographerId: Long): Result<List<Area>> {
+    override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> {
         requestedPhotographerId = photographerId
         return Result.success(activeAreas)
     }
 
-    override suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>> {
+    override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> {
         updatedAreas = areas
         return Result.success(areas)
     }
@@ -185,13 +186,13 @@ private class FakeAreaRepository(
 ) : AreaRepository {
     var didLoadNearbyAreas: Boolean = false
 
-    override suspend fun searchAreas(keyword: String): Result<List<Area>> = Result.success(results)
+    override suspend fun searchAreas(keyword: String): AppResult<List<Area>> = Result.success(results)
 
     override suspend fun getNearbyAreas(
         rad: Int,
         lat: Double,
         lng: Double,
-    ): Result<List<Area>> {
+    ): AppResult<List<Area>> {
         didLoadNearbyAreas = true
         return Result.success(results)
     }

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerKeywordEditViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.ui.screen.my_page
 
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.domain.model.PhotographerDetail
@@ -224,7 +225,7 @@ private class FakePhotographerRepository(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<FilteredPhotographers> =
+    ): AppResult<FilteredPhotographers> =
         Result.success(
             FilteredPhotographers(active = emptyList(), inactive = emptyList()),
         )
@@ -232,9 +233,9 @@ private class FakePhotographerRepository(
     override suspend fun getPhotographerDetail(
         photographerId: Long,
         reviewSort: String,
-    ): Result<PhotographerDetail> = Result.failure(UnsupportedOperationException())
+    ): AppResult<PhotographerDetail> = Result.failure(UnsupportedOperationException())
 
-    override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> =
         if (failsOnGet || (failsOnSecondGet && getCallCount++ > 0)) {
             Result.failure(IllegalStateException("get failed"))
         } else {
@@ -242,7 +243,7 @@ private class FakePhotographerRepository(
             Result.success(keywords)
         }
 
-    override suspend fun addPhotoMood(photoMood: String): Result<Unit> =
+    override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> =
         if (failsOnAdd) {
             Result.failure(IllegalStateException("add failed"))
         } else {
@@ -250,12 +251,12 @@ private class FakePhotographerRepository(
             Result.success(Unit)
         }
 
-    override suspend fun deletePhotoMood(photoMood: String): Result<Unit> {
+    override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> {
         deletedKeywords.add(photoMood)
         return Result.success(Unit)
     }
 
-    override suspend fun getActiveAreas(photographerId: Long): Result<List<Area>> = error("Not used")
+    override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> = error("Not used")
 
-    override suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>> = error("Not used")
+    override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> = error("Not used")
 }

--- a/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
+++ b/feature/mypage/src/test/kotlin/com/hm/picplz/ui/screen/my_page/MyPagePhotographerModifyProfileViewModelTest.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.my_page
 
 import android.content.Context
 import com.hm.picplz.common.model.NicknameFieldError
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.MemberProfile
 import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 import com.hm.picplz.domain.repository.AuthRepository
@@ -269,12 +270,12 @@ class MyPagePhotographerModifyProfileViewModelTest {
         val requestedNicknames = mutableListOf<String>()
         var updatedCommand: UpdateMemberProfileCommand? = null
 
-        override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> {
+        override suspend fun checkNicknameAvailable(nickname: String): AppResult<Boolean> {
             requestedNicknames += nickname
             return Result.success(isAvailable)
         }
 
-        override suspend fun getMemberProfile(memberId: Long): Result<MemberProfile> =
+        override suspend fun getMemberProfile(memberId: Long): AppResult<MemberProfile> =
             if (loadShouldFail) {
                 Result.failure(IllegalStateException("load failed"))
             } else {
@@ -289,7 +290,7 @@ class MyPagePhotographerModifyProfileViewModelTest {
                 )
             }
 
-        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): Result<Unit> {
+        override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): AppResult<Unit> {
             updatedCommand = command
             return Result.success(Unit)
         }
@@ -310,10 +311,10 @@ class MyPagePhotographerModifyProfileViewModelTest {
     }
 
     private class FakeS3Repository : S3Repository {
-        private val uploadResults = ArrayDeque<Result<String>>()
+        private val uploadResults = ArrayDeque<AppResult<String>>()
 
         constructor(
-            uploadResults: List<Result<String>> = listOf(Result.success("profile/object-key.jpg")),
+            uploadResults: List<AppResult<String>> = listOf(Result.success("profile/object-key.jpg")),
         ) {
             this.uploadResults.addAll(uploadResults)
         }
@@ -321,7 +322,7 @@ class MyPagePhotographerModifyProfileViewModelTest {
         override suspend fun uploadProfileImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> =
+        ): AppResult<String> =
             if (uploadResults.isEmpty()) {
                 Result.success("profile/object-key.jpg")
             } else {
@@ -331,6 +332,6 @@ class MyPagePhotographerModifyProfileViewModelTest {
         override suspend fun uploadProductImage(
             imageBytes: ByteArray,
             filename: String,
-        ): Result<String> = error("unused")
+        ): AppResult<String> = error("unused")
     }
 }

--- a/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModelTest.kt
+++ b/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/detail_photographer/DetailPhotographerViewModelTest.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.detail_photographer
 
 import androidx.lifecycle.SavedStateHandle
 import com.hm.picplz.common.model.PhotoReview
+import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.domain.model.PhotographerDetail
@@ -166,7 +167,7 @@ class DetailPhotographerViewModelTest {
 }
 
 private class FakePhotographerRepository(
-    private val detailResult: Result<PhotographerDetail> = Result.failure(NotImplementedError()),
+    private val detailResult: AppResult<PhotographerDetail> = Result.failure(NotImplementedError()),
 ) : PhotographerRepository {
     var getPhotographerDetailCallCount = 0
         private set
@@ -175,27 +176,27 @@ private class FakePhotographerRepository(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Result<FilteredPhotographers> = Result.failure(NotImplementedError())
+    ): AppResult<FilteredPhotographers> = Result.failure(NotImplementedError())
 
     override suspend fun getPhotographerDetail(
         photographerId: Long,
         reviewSort: String,
-    ): Result<PhotographerDetail> {
+    ): AppResult<PhotographerDetail> {
         getPhotographerDetailCallCount += 1
         return detailResult
     }
 
-    override suspend fun getPhotographerMoodKeywords(photographerId: Long): Result<List<String>> =
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> =
         Result.failure(NotImplementedError())
 
-    override suspend fun addPhotoMood(photoMood: String): Result<Unit> = Result.failure(NotImplementedError())
+    override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> = Result.failure(NotImplementedError())
 
-    override suspend fun deletePhotoMood(photoMood: String): Result<Unit> = Result.failure(NotImplementedError())
+    override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> = Result.failure(NotImplementedError())
 
-    override suspend fun getActiveAreas(photographerId: Long): Result<List<Area>> =
+    override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> =
         Result.failure(NotImplementedError())
 
-    override suspend fun updateActiveAreas(areas: List<Area>): Result<List<Area>> =
+    override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> =
         Result.failure(NotImplementedError())
 }
 


### PR DESCRIPTION
## 요약
- `core:common`에 공통 `AppError` / `AppResult` 구조를 추가했습니다.
- data/domain 계층의 반환 계약을 raw `Result<T>`에서 `AppResult<T>`로 통일했습니다.
- Retrofit 응답 실패와 백엔드 에러 envelope 파싱을 `safeApiCall` / `toHttpAppError()`로 중앙화했습니다.
- Compose MVI 경계는 유지했습니다. 에러를 인라인 상태, 토스트, 네비게이션으로 보여줄지는 feature ViewModel/SideEffect에서 결정합니다.
- 테스트 fake와 AGENTS 문서도 새 에러 처리 계약에 맞췄습니다.

## 배경
유저플로우를 재정리하면서 API, S3, Kakao, UI 에러 처리가 여러 계층에 흩어져 있는 문제가 확인됐습니다.
디버깅 및 추후 에러 관리를 위해 에러 핸들링 구조를 정리했습니다.

기존 구조에서는 각 Source/ViewModel이 실패를 개별적으로 해석했습니다. 이러면 같은 HTTP 실패라도 화면마다 다른 방식으로 처리되고, 백엔드 에러 body의 `message`, `statusCode` 같은 계약 정보가 유실되기 쉽습니다.

이번 PR은 백엔드 계약 파싱은 `core:data`에 두고, 앱 전반에는 `AppError` / `AppResult`만 노출하도록 정리합니다.

Closes #189

## 에러 핸들링 아키텍처

### 1. 백엔드 계약 boundary: `core:data`
백엔드와의 계약은 `core:data`에서만 해석합니다.

- Retrofit `Response<T>` 성공 여부 확인
- empty body 처리
- HTTP status code 보존
- backend error envelope 파싱
- raw error body 보존

백엔드 에러 응답은 `ApiErrorResponseDto`로 파싱한 뒤 `AppError.Network.Http`에 담습니다.

```kotlin
data class ApiErrorResponseDto(
    val timestamp: String?,
    val statusCode: Int?,
    val message: String?,
    val data: JsonElement?,
)
```

즉 feature/ViewModel은 더 이상 `errorBody()?.string()`이나 Retrofit detail을 직접 알 필요가 없습니다.

### 2. 앱 내부 에러 계약: `core:common`
앱 내부에서 공유하는 에러 타입은 `AppError`로 통일했습니다.

```kotlin
sealed class AppError : Exception {
    sealed class Network : AppError
    sealed class Auth : AppError
    sealed class Storage : AppError
    sealed class Location : AppError
    data class Unknown(...) : AppError
}
```

현재 분류 기준은 다음과 같습니다.

| 분류 | 의미 |
|---|---|
| `Network.NoConnection` | 네트워크 연결 실패 |
| `Network.Timeout` | 타임아웃 |
| `Network.Http` | HTTP 실패 및 서버 에러 envelope |
| `Network.EmptyBody` | 성공 응답인데 body 없음 |
| `Auth.*` | Kakao token / social info 등 인증 흐름 실패 |
| `Storage.*` | S3 업로드 등 저장소 실패 |
| `Location.*` | 위치 권한/조회 실패 |
| `Unknown` | 아직 분류되지 않은 실패 |

### 3. 결과 타입 계약: `AppResult<T>`
data/domain/usecase 경계의 반환 타입을 `AppResult<T>`로 통일했습니다.

현재 구현은 호환성을 위해 Kotlin `Result<T>` alias입니다.

```kotlin
typealias AppResult<T> = Result<T>
```

이 선택은 전체 호출부를 한 번에 sealed result로 갈아엎지 않기 위한 과도기 전략입니다. 대신 실패 생성 경로는 `runCatchingAppError`와 `safeApiCall`로 모아 `Throwable`이 그대로 퍼지는 것을 줄였습니다.

추후 필요하면 `AppResult.Success` / `AppResult.Failure(AppError)` 형태의 sealed result로 교체할 수 있습니다. 이번 PR은 그 전 단계로 API 표면을 먼저 `AppResult<T>`로 통일합니다.

### 4. Compose/MVI UI boundary: feature ViewModel + SideEffect
웹에서 말하는 error boundary/hook/toast 역할은 Compose/MVI에서는 다음처럼 나눴습니다.

| 웹에서 익숙한 개념 | Picplz Compose/MVI 대응 |
|---|---|
| API contract parser | `core:data`의 `safeApiCall`, `toHttpAppError()` |
| 공통 error type | `core:common`의 `AppError` |
| error hook | feature ViewModel의 `onFailure` 처리 |
| inline error | feature State의 `error: AppError?` 또는 field error |
| toast/snackbar | one-off `SideEffect` (`Channel`) |
| route/auth boundary | navigation guard 또는 ViewModel side effect |

따라서 모든 화면 표시 정책을 중앙에서 강제하지 않습니다. 중앙화 대상은 “실패 원인의 해석”이고, “어떻게 보여줄지”는 화면 맥락을 아는 feature가 결정합니다.

예를 들면 같은 `Network.Http(400)`이라도:

- 회원가입에서는 “회원가입 실패” 토스트
- 이미지 업로드에서는 “이미지 업로드 URL 발급 실패” 토스트
- 필드 검증에서는 인라인 에러
- 인증 만료라면 로그인 이동

처럼 달라질 수 있습니다. 이 판단은 ViewModel/SideEffect boundary에 남기는 것이 Compose MVI 구조에 맞습니다.

### 5. 계층별 흐름

```text
Retrofit / Kakao / S3
↓
core:data Source
- safeApiCall / runCatchingAppError
- backend error envelope parsing
- Throwable → AppError 변환
↓
core:data Service / Repository
- AppResult<T> 전달
- DTO → domain model 변환
↓
core:domain UseCase
- AppResult<T> 노출
↓
feature ViewModel
- AppError를 화면 맥락에 맞게 State 또는 SideEffect로 변환
↓
Compose UI
- State 기반 inline 표시
- SideEffect 기반 Toast / Navigation 처리
```

## 설계 원칙
- DTO와 백엔드 error envelope는 `core:data/model`에 둡니다.
- feature는 Retrofit/HTTP/raw error body를 직접 다루지 않습니다.
- 사용자에게 보이는 문구는 string resource를 사용합니다.
- 일회성 UI 이벤트는 기존 MVI 규칙대로 `Channel` 기반 SideEffect를 사용합니다.
- 네트워크/서버 실패의 “원인 해석”은 중앙화하고, 화면별 “표현 방식”은 feature boundary에 둡니다.

## 이번 PR에서 하지 않은 것
- 모든 토스트 UI를 공통 컴포넌트로 강제하지 않았습니다.
- 모든 feature의 사용자 문구를 한 번에 재작성하지 않았습니다.
- `AppResult`를 sealed class로 완전히 교체하지 않았습니다. 이번 단계는 API 표면과 실패 매핑 경로를 먼저 정리하는 작업입니다.

## 검증
- [x] `./gradlew :core:common:compileDebugKotlin :core:data:compileDebugKotlin :core:domain:compileDebugKotlin :feature:auth:compileDebugKotlin --quiet --console=plain`
- [x] `./gradlew ktlintCheck --quiet --console=plain`
- [x] `./gradlew :feature:auth:testDebugUnitTest :feature:main:testDebugUnitTest :feature:mypage:testDebugUnitTest :feature:photographer:testDebugUnitTest --quiet --console=plain`
- [x] `./gradlew assembleDebug --quiet --console=plain`
- [ ] `./gradlew detekt --quiet --console=plain` - 기존 unrelated 경고로 실패합니다. 대상은 `MainNavGraph`, `feature:chat`, `PhotographerApi/Source/Service`, `TokenManager`, 예약 화면 complexity 등입니다.