### PR TITLE
✨ 고객 홈 및 검색 흐름 연결

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/di/ApiModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/ApiModule.kt
@@ -8,6 +8,7 @@ import com.hm.picplz.data.api.CustomerApi
 import com.hm.picplz.data.api.KakaoMapApi
 import com.hm.picplz.data.api.MemberApi
 import com.hm.picplz.data.api.PhotographerApi
+import com.hm.picplz.data.api.PortfolioApi
 import com.hm.picplz.data.api.ProductApi
 import com.hm.picplz.data.api.S3Api
 import com.hm.picplz.data.provider.AuthInterceptor
@@ -97,6 +98,14 @@ object NetworkModule {
         @PicplzApi retrofit: Retrofit,
     ): ProductApi {
         return retrofit.create(ProductApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun providePortfolioApi(
+        @PicplzApi retrofit: Retrofit,
+    ): PortfolioApi {
+        return retrofit.create(PortfolioApi::class.java)
     }
 
     @Provides

--- a/app/src/main/kotlin/com/hm/picplz/di/PortfolioModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/PortfolioModule.kt
@@ -1,0 +1,29 @@
+package com.hm.picplz.di
+
+import com.hm.picplz.data.repository.PortfolioRepositoryImpl
+import com.hm.picplz.data.service.PortfolioService
+import com.hm.picplz.data.service.PortfolioServiceImpl
+import com.hm.picplz.data.source.PortfolioSource
+import com.hm.picplz.data.source.PortfolioSourceImpl
+import com.hm.picplz.domain.repository.PortfolioRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PortfolioModule {
+    @Binds
+    @Singleton
+    abstract fun bindPortfolioRepository(portfolioRepositoryImpl: PortfolioRepositoryImpl): PortfolioRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPortfolioService(portfolioServiceImpl: PortfolioServiceImpl): PortfolioService
+
+    @Binds
+    @Singleton
+    abstract fun bindPortfolioSource(portfolioSourceImpl: PortfolioSourceImpl): PortfolioSource
+}

--- a/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.hm.picplz.common.model.UserType
 import com.hm.picplz.navigation.graph.authNavGraph
 import com.hm.picplz.navigation.graph.mainNavGraph
 import com.hm.picplz.navigation.graph.photographerNavGraph
@@ -34,6 +35,7 @@ import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
+import com.hm.picplz.navigation.model.PhotographerMainGraph
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.main.MainActivityUiState
 import kotlin.reflect.KClass
@@ -73,18 +75,23 @@ fun MainNavHost(
 ) {
     if (uiState is MainActivityUiState.Loading) return
 
-    val startDestination: Any =
-        when (uiState) {
-            is MainActivityUiState.Success -> Main
-            MainActivityUiState.Unauthenticated -> Login
-            MainActivityUiState.Loading -> Main
-        }
+    val startDestination: Any = startDestinationFor(uiState)
     val currentDestination = navController.currentBackStackEntryAsState().value?.destination
 
     LaunchedEffect(uiState, currentDestination) {
-        if (uiState == MainActivityUiState.Unauthenticated && currentDestination.requiresAuth()) {
-            navController.navigate(Login) {
-                launchSingleTop = true
+        when {
+            uiState == MainActivityUiState.Unauthenticated && currentDestination.requiresAuth() -> {
+                navController.navigate(Login) {
+                    launchSingleTop = true
+                }
+            }
+            uiState is MainActivityUiState.Success && currentDestination?.hasRoute(Login::class) == true -> {
+                navController.navigate(startDestinationFor(uiState)) {
+                    popUpTo(Login) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
             }
         }
     }
@@ -96,12 +103,21 @@ fun MainNavHost(
     ) {
         authNavGraph(
             navController = navController,
+            onLoginCompleted = refreshUserData,
             onSignupCompleted = refreshUserData,
         )
         mainNavGraph(navController)
         photographerNavGraph(navController)
     }
 }
+
+fun startDestinationFor(uiState: MainActivityUiState): Any =
+    when (uiState) {
+        is MainActivityUiState.Success ->
+            if (uiState.userData.userType == UserType.Photographer) PhotographerMainGraph else Main
+        MainActivityUiState.Unauthenticated -> Login
+        MainActivityUiState.Loading -> Main
+    }
 
 private fun NavDestination?.requiresAuth(): Boolean {
     if (this == null) return false

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/AuthNavGraph.kt
@@ -18,11 +18,13 @@ import com.hm.picplz.ui.screen.sign_up.sign_up_photographer.SignUpPhotographerSc
 
 fun NavGraphBuilder.authNavGraph(
     navController: NavHostController,
+    onLoginCompleted: () -> Unit,
     onSignupCompleted: () -> Unit,
 ) {
     composable<Login> {
         LoginIntroScreen(
             navController = navController,
+            onLoginCompleted = onLoginCompleted,
             enableDevEntry = BuildConfig.DEBUG,
         )
     }

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -21,6 +21,7 @@ import com.hm.picplz.navigation.model.Chat
 import com.hm.picplz.navigation.model.ChatRoom
 import com.hm.picplz.navigation.model.DetailReservation
 import com.hm.picplz.navigation.model.Dev
+import com.hm.picplz.navigation.model.DevMainSearchResultPreview
 import com.hm.picplz.navigation.model.DevMyPagePackageEdit
 import com.hm.picplz.navigation.model.DevMyPagePhotographerProfileAdded
 import com.hm.picplz.navigation.model.Feed
@@ -91,6 +92,15 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     composable<MainSearch> {
         MainSearchScreen(navController = navController)
+    }
+
+    if (BuildConfig.DEBUG) {
+        composable<DevMainSearchResultPreview> {
+            MainSearchScreen(
+                navController = navController,
+                devMockResults = true,
+            )
+        }
     }
 
     composable<Reservation> {

--- a/app/src/test/kotlin/com/hm/picplz/navigation/MainRouteTest.kt
+++ b/app/src/test/kotlin/com/hm/picplz/navigation/MainRouteTest.kt
@@ -1,0 +1,47 @@
+package com.hm.picplz.navigation
+
+import com.hm.picplz.common.model.User
+import com.hm.picplz.common.model.UserType
+import com.hm.picplz.navigation.model.Login
+import com.hm.picplz.navigation.model.Main
+import com.hm.picplz.navigation.model.PhotographerMainGraph
+import com.hm.picplz.ui.main.MainActivityUiState
+import com.hm.picplz.ui.screen.sign_up.sign_up_common.views.signupCompletionDestination
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class MainRouteTest {
+    @Test
+    fun `authenticated start destination is customer main`() {
+        val destination = startDestinationFor(MainActivityUiState.Success(User(id = "user-id")))
+
+        assertSame(Main, destination)
+    }
+
+    @Test
+    fun `authenticated start destination is photographer main for photographer`() {
+        val destination =
+            startDestinationFor(
+                MainActivityUiState.Success(
+                    User(
+                        id = "photographer-id",
+                        userType = UserType.Photographer,
+                    ),
+                ),
+            )
+
+        assertSame(PhotographerMainGraph, destination)
+    }
+
+    @Test
+    fun `unauthenticated start destination remains login`() {
+        val destination = startDestinationFor(MainActivityUiState.Unauthenticated)
+
+        assertSame(Login, destination)
+    }
+
+    @Test
+    fun `signup completion destination is customer main`() {
+        assertSame(Main, signupCompletionDestination())
+    }
+}

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -57,6 +57,8 @@ data class SignUpAddDevice(val category: String = "phone") : NavigationRoute
 // === Dev ===
 @Serializable object Dev : NavigationRoute
 
+@Serializable object DevMainSearchResultPreview : NavigationRoute
+
 // === Main Screens ===
 @Serializable object Main : NavigationRoute
 

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/MemberApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/MemberApi.kt
@@ -3,10 +3,12 @@ package com.hm.picplz.data.api
 import com.hm.picplz.data.model.ApiResponse
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.model.UpdateMemberLocationRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -24,5 +26,10 @@ interface MemberApi {
     @PATCH("api/v1/members/info")
     suspend fun updateMemberInfo(
         @Body request: UpdateMemberInfoRequest,
+    ): Response<Unit>
+
+    @POST("api/v1/members/location")
+    suspend fun updateMemberLocation(
+        @Body request: UpdateMemberLocationRequest,
     ): Response<Unit>
 }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
@@ -43,7 +43,7 @@ interface PhotographerApi {
         @Query("longitude") longitude: Double,
         @Query("latitude") latitude: Double,
         @Query("distance") distance: Long,
-    ): Response<List<NearbyPhotographerCard>>
+    ): Response<ApiResponse<List<NearbyPhotographerCard>>>
 
     @GET("api/v1/photographers/{photographerId}/info")
     suspend fun getPhotographerInfo(

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/PortfolioApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/PortfolioApi.kt
@@ -1,0 +1,15 @@
+package com.hm.picplz.data.api
+
+import com.hm.picplz.data.model.PortfolioListResponseDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface PortfolioApi {
+    @GET("api/v1/portfolios")
+    suspend fun getPortfoliosByPhotographer(
+        @Query("photographerId") photographerId: Long,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 9,
+    ): Response<PortfolioListResponseDto>
+}

--- a/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
@@ -23,8 +23,8 @@ fun NearbyPhotographerCard.toDomain(): Photographer {
         profileImageUri = profileImage,
         isActive = active == "Y",
         distance = distance,
-        photoMoods = photoMoods,
-        activeAreas = activeAreas,
+        photoMoods = photoMoods?.mapNotNull { it?.takeUnless(String::isBlank) } ?: emptyList(),
+        activeAreas = activeAreas ?: emptyList(),
         instagram = null,
         portfolioPhotos = emptyList(),
     )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PortfolioMapper.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PortfolioMapper.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.data.mapper
+
+import com.hm.picplz.data.model.PortfolioSummaryResponseDto
+import com.hm.picplz.domain.model.PortfolioSummary
+
+fun PortfolioSummaryResponseDto.toDomain(): PortfolioSummary =
+    PortfolioSummary(
+        id = portfolioId ?: 0L,
+        representativeImage = representativeImage,
+        photoCount = photoCount ?: 0,
+        location = location,
+        uploadDate = uploadDate,
+    )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/MemberModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/MemberModel.kt
@@ -12,6 +12,12 @@ data class UpdateMemberInfoRequest(
     val instagram: String?,
 )
 
+data class UpdateMemberLocationRequest(
+    val memberId: Long,
+    val latitude: Double,
+    val longitude: Double,
+)
+
 data class MemberInfoResponseDto(
     val id: Long,
     val nickname: String,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/NearbyPhotographerCard.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/NearbyPhotographerCard.kt
@@ -6,6 +6,6 @@ data class NearbyPhotographerCard(
     val profileImage: String?,
     val active: String,
     val distance: Long,
-    val photoMoods: List<String>,
-    val activeAreas: List<String> = emptyList(),
+    val photoMoods: List<String?>? = null,
+    val activeAreas: List<String>? = null,
 )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/PortfolioModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/PortfolioModel.kt
@@ -1,0 +1,16 @@
+package com.hm.picplz.data.model
+
+data class PortfolioListResponseDto(
+    val portfolios: List<PortfolioSummaryResponseDto>?,
+    val totalCount: Long?,
+    val totalPages: Int?,
+    val currentPage: Int?,
+)
+
+data class PortfolioSummaryResponseDto(
+    val portfolioId: Long?,
+    val representativeImage: String?,
+    val photoCount: Int?,
+    val location: String?,
+    val uploadDate: String?,
+)

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/MemberRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.hm.picplz.data.repository
 
 import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.model.UpdateMemberLocationRequest
 import com.hm.picplz.data.model.toRequest
 import com.hm.picplz.data.service.MemberService
+import com.hm.picplz.domain.model.LocationCoordinate
 import com.hm.picplz.domain.model.MemberProfile
 import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 import com.hm.picplz.domain.repository.MemberRepository
@@ -21,4 +23,16 @@ class MemberRepositoryImpl
 
         override suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): AppResult<Unit> =
             memberService.updateMemberInfo(command.toRequest())
+
+        override suspend fun updateMemberLocation(
+            memberId: Long,
+            location: LocationCoordinate,
+        ): AppResult<Unit> =
+            memberService.updateMemberLocation(
+                UpdateMemberLocationRequest(
+                    memberId = memberId,
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                ),
+            )
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/PortfolioRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/PortfolioRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.hm.picplz.data.repository
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.mapper.toDomain
+import com.hm.picplz.data.service.PortfolioService
+import com.hm.picplz.domain.model.PortfolioSummary
+import com.hm.picplz.domain.repository.PortfolioRepository
+import javax.inject.Inject
+
+class PortfolioRepositoryImpl
+    @Inject
+    constructor(
+        private val portfolioService: PortfolioService,
+    ) : PortfolioRepository {
+        override suspend fun getPhotographerPortfolios(
+            photographerId: Long,
+            page: Int,
+            size: Int,
+        ): AppResult<List<PortfolioSummary>> =
+            portfolioService.getPortfoliosByPhotographer(
+                photographerId = photographerId,
+                page = page,
+                size = size,
+            ).map { response ->
+                response.portfolios.orEmpty().map { it.toDomain() }
+            }
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/MemberService.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.data.service
 import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.model.UpdateMemberLocationRequest
 import com.hm.picplz.data.model.toDomain
 import com.hm.picplz.data.source.MemberSource
 import com.hm.picplz.domain.model.MemberProfile
@@ -14,6 +15,8 @@ interface MemberService {
     suspend fun getMemberInfo(memberId: Long): AppResult<MemberProfile>
 
     suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit>
+
+    suspend fun updateMemberLocation(request: UpdateMemberLocationRequest): AppResult<Unit>
 }
 
 class MemberServiceImpl
@@ -29,4 +32,7 @@ class MemberServiceImpl
 
         override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit> =
             memberSource.updateMemberInfo(request)
+
+        override suspend fun updateMemberLocation(request: UpdateMemberLocationRequest): AppResult<Unit> =
+            memberSource.updateMemberLocation(request)
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PortfolioService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PortfolioService.kt
@@ -1,0 +1,31 @@
+package com.hm.picplz.data.service
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.model.PortfolioListResponseDto
+import com.hm.picplz.data.source.PortfolioSource
+import javax.inject.Inject
+
+interface PortfolioService {
+    suspend fun getPortfoliosByPhotographer(
+        photographerId: Long,
+        page: Int = 0,
+        size: Int = 9,
+    ): AppResult<PortfolioListResponseDto>
+}
+
+class PortfolioServiceImpl
+    @Inject
+    constructor(
+        private val portfolioSource: PortfolioSource,
+    ) : PortfolioService {
+        override suspend fun getPortfoliosByPhotographer(
+            photographerId: Long,
+            page: Int,
+            size: Int,
+        ): AppResult<PortfolioListResponseDto> =
+            portfolioSource.getPortfoliosByPhotographer(
+                photographerId = photographerId,
+                page = page,
+                size = size,
+            )
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/MemberSource.kt
@@ -5,6 +5,7 @@ import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.api.MemberApi
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.model.UpdateMemberLocationRequest
 import com.hm.picplz.data.util.safeApiCall
 import com.hm.picplz.data.util.safeApiCallUnit
 import com.hm.picplz.data.util.toHttpAppError
@@ -16,6 +17,8 @@ interface MemberSource {
     suspend fun getMemberInfo(memberId: Long): AppResult<MemberInfoResponseDto>
 
     suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit>
+
+    suspend fun updateMemberLocation(request: UpdateMemberLocationRequest): AppResult<Unit>
 }
 
 class MemberSourceImpl
@@ -38,4 +41,7 @@ class MemberSourceImpl
 
         override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): AppResult<Unit> =
             safeApiCallUnit { memberApi.updateMemberInfo(request) }
+
+        override suspend fun updateMemberLocation(request: UpdateMemberLocationRequest): AppResult<Unit> =
+            safeApiCallUnit { memberApi.updateMemberLocation(request) }
     }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
@@ -60,7 +60,7 @@ class PhotographerSourceImpl
             latitude: Double,
             distance: Long,
         ): AppResult<List<NearbyPhotographerCard>> =
-            safeApiCall { photographerApi.getNearbyPhotographers(longitude, latitude, distance) }
+            safeApiCall({ photographerApi.getNearbyPhotographers(longitude, latitude, distance) }) { it.data }
 
         override suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto> =
             safeApiCall({ photographerApi.getPhotographerInfo(photographerId) }) { it.data }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PortfolioSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PortfolioSource.kt
@@ -1,0 +1,34 @@
+package com.hm.picplz.data.source
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.api.PortfolioApi
+import com.hm.picplz.data.model.PortfolioListResponseDto
+import com.hm.picplz.data.util.safeApiCall
+import javax.inject.Inject
+
+interface PortfolioSource {
+    suspend fun getPortfoliosByPhotographer(
+        photographerId: Long,
+        page: Int = 0,
+        size: Int = 9,
+    ): AppResult<PortfolioListResponseDto>
+}
+
+class PortfolioSourceImpl
+    @Inject
+    constructor(
+        private val portfolioApi: PortfolioApi,
+    ) : PortfolioSource {
+        override suspend fun getPortfoliosByPhotographer(
+            photographerId: Long,
+            page: Int,
+            size: Int,
+        ): AppResult<PortfolioListResponseDto> =
+            safeApiCall {
+                portfolioApi.getPortfoliosByPhotographer(
+                    photographerId = photographerId,
+                    page = page,
+                    size = size,
+                )
+            }
+    }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/source/MemberSourceTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/source/MemberSourceTest.kt
@@ -6,6 +6,7 @@ import com.hm.picplz.data.api.MemberApi
 import com.hm.picplz.data.model.ApiResponse
 import com.hm.picplz.data.model.MemberInfoResponseDto
 import com.hm.picplz.data.model.UpdateMemberInfoRequest
+import com.hm.picplz.data.model.UpdateMemberLocationRequest
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
@@ -151,9 +152,27 @@ class MemberSourceTest {
             assertEquals("member not found", error.serverMessage)
         }
 
+    @Test
+    fun `updateMemberLocation treats successful raw response as unit`() =
+        runTest {
+            val source = MemberSourceImpl(FakeMemberApi(updateLocationResponse = Response.success(Unit)))
+
+            val result =
+                source.updateMemberLocation(
+                    UpdateMemberLocationRequest(
+                        memberId = 3L,
+                        latitude = 37.5665,
+                        longitude = 126.978,
+                    ),
+                )
+
+            assertTrue(result.isSuccess)
+        }
+
     private class FakeMemberApi(
         private val checkNicknameResponse: Response<Unit> = Response.success(Unit),
         private val memberInfoResponse: Response<ApiResponse<MemberInfoResponseDto>>? = null,
+        private val updateLocationResponse: Response<Unit> = Response.success(Unit),
     ) : MemberApi {
         override suspend fun checkNickname(nickname: String): Response<Unit> = checkNicknameResponse
 
@@ -163,5 +182,8 @@ class MemberSourceTest {
         override suspend fun updateMemberInfo(request: UpdateMemberInfoRequest): Response<Unit> {
             throw NotImplementedError("Not used in test")
         }
+
+        override suspend fun updateMemberLocation(request: UpdateMemberLocationRequest): Response<Unit> =
+            updateLocationResponse
     }
 }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/source/PhotographerSourceTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/source/PhotographerSourceTest.kt
@@ -1,0 +1,86 @@
+package com.hm.picplz.data.source
+
+import com.hm.picplz.data.api.PhotographerApi
+import com.hm.picplz.data.model.ApiResponse
+import com.hm.picplz.data.model.CreatePhotographerRequest
+import com.hm.picplz.data.model.NearbyPhotographerCard
+import com.hm.picplz.data.model.PhotoMoodRequest
+import com.hm.picplz.data.model.PhotographerDetailDto
+import com.hm.picplz.data.model.ReviewListDto
+import com.hm.picplz.data.model.UpdateActiveAreaRequest
+import com.hm.picplz.data.model.UpdateActiveAreaResponse
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class PhotographerSourceTest {
+    @Test
+    fun `nearby photographers unwraps runtime ApiResponse data`() =
+        runTest {
+            val api =
+                FakePhotographerApi(
+                    nearbyResponse =
+                        Response.success(
+                            ApiResponse(
+                                timestamp = "2026-07-06T22:18:38",
+                                statusCode = 200,
+                                message = "success",
+                                data =
+                                    listOf(
+                                        NearbyPhotographerCard(
+                                            photographerId = 7L,
+                                            nickname = "유가영 작가",
+                                            profileImage = "profile.jpg",
+                                            active = "Y",
+                                            distance = 120L,
+                                            photoMoods = listOf("필름", null),
+                                        ),
+                                    ),
+                            ),
+                        ),
+                )
+            val source = PhotographerSourceImpl(api)
+
+            val cards =
+                source.getNearbyPhotographers(
+                    longitude = 126.978,
+                    latitude = 37.5665,
+                    distance = 2_000L,
+                ).getOrThrow()
+
+            assertEquals(1, cards.size)
+            assertEquals(7L, cards.first().photographerId)
+            assertEquals("유가영 작가", cards.first().nickname)
+        }
+}
+
+private class FakePhotographerApi(
+    private val nearbyResponse: Response<ApiResponse<List<NearbyPhotographerCard>>>,
+) : PhotographerApi {
+    override suspend fun createPhotographer(request: CreatePhotographerRequest): Response<Unit> = error("Not used")
+
+    override suspend fun addPhotoMood(request: PhotoMoodRequest): Response<Unit> = error("Not used")
+
+    override suspend fun deletePhotoMood(request: PhotoMoodRequest): Response<Unit> = error("Not used")
+
+    override suspend fun updateActiveAreas(request: UpdateActiveAreaRequest): Response<UpdateActiveAreaResponse> =
+        error("Not used")
+
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): Response<ApiResponse<List<NearbyPhotographerCard>>> = nearbyResponse
+
+    override suspend fun getPhotographerInfo(
+        photographerId: Long,
+    ): Response<com.hm.picplz.data.model.ApiResponse<PhotographerDetailDto>> = error("Not used")
+
+    override suspend fun getPhotographerReviews(
+        photographerId: Long,
+        page: Int,
+        size: Int,
+        sort: String,
+    ): Response<com.hm.picplz.data.model.ApiResponse<ReviewListDto>> = error("Not used")
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/PortfolioSummary.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/PortfolioSummary.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.domain.model
+
+data class PortfolioSummary(
+    val id: Long,
+    val representativeImage: String?,
+    val photoCount: Int,
+    val location: String?,
+    val uploadDate: String?,
+)

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.domain.repository
 
 import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.LocationCoordinate
 import com.hm.picplz.domain.model.MemberProfile
 import com.hm.picplz.domain.model.UpdateMemberProfileCommand
 
@@ -10,4 +11,9 @@ interface MemberRepository {
     suspend fun getMemberProfile(memberId: Long): AppResult<MemberProfile>
 
     suspend fun updateMemberProfile(command: UpdateMemberProfileCommand): AppResult<Unit>
+
+    suspend fun updateMemberLocation(
+        memberId: Long,
+        location: LocationCoordinate,
+    ): AppResult<Unit>
 }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PortfolioRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PortfolioRepository.kt
@@ -1,0 +1,12 @@
+package com.hm.picplz.domain.repository
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.PortfolioSummary
+
+interface PortfolioRepository {
+    suspend fun getPhotographerPortfolios(
+        photographerId: Long,
+        page: Int = 0,
+        size: Int = 9,
+    ): AppResult<List<PortfolioSummary>>
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetNearbyPhotographersUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetNearbyPhotographersUseCase.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.repository.PhotographerRepository
+import javax.inject.Inject
+
+class GetNearbyPhotographersUseCase
+    @Inject
+    constructor(
+        private val photographerRepository: PhotographerRepository,
+    ) {
+        suspend operator fun invoke(
+            longitude: Double,
+            latitude: Double,
+            distance: Long,
+        ): AppResult<FilteredPhotographers> =
+            photographerRepository.getNearbyPhotographers(
+                longitude = longitude,
+                latitude = latitude,
+                distance = distance,
+            )
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerPortfoliosUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/GetPhotographerPortfoliosUseCase.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.PortfolioSummary
+import com.hm.picplz.domain.repository.PortfolioRepository
+import javax.inject.Inject
+
+class GetPhotographerPortfoliosUseCase
+    @Inject
+    constructor(
+        private val portfolioRepository: PortfolioRepository,
+    ) {
+        suspend operator fun invoke(
+            photographerId: Long,
+            page: Int = 0,
+            size: Int = 9,
+        ): AppResult<List<PortfolioSummary>> =
+            portfolioRepository.getPhotographerPortfolios(
+                photographerId = photographerId,
+                page = page,
+                size = size,
+            )
+    }

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberLocationUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/UpdateMemberLocationUseCase.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.LocationCoordinate
+import com.hm.picplz.domain.repository.MemberRepository
+import javax.inject.Inject
+
+class UpdateMemberLocationUseCase
+    @Inject
+    constructor(
+        private val memberRepository: MemberRepository,
+    ) {
+        suspend operator fun invoke(
+            memberId: Long,
+            location: LocationCoordinate,
+        ): AppResult<Unit> =
+            memberRepository.updateMemberLocation(
+                memberId = memberId,
+                location = location,
+            )
+    }

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonLocationPermissionContent.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonLocationPermissionContent.kt
@@ -1,0 +1,162 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun CommonLocationPermissionRationale(
+    titlePrefix: String,
+    highlightedTitle: String,
+    titleSuffix: String,
+    description: String,
+    buttonText: String,
+    iconContentDescription: String,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(MainThemeColor.White),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 162.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_location_permission),
+                contentDescription = iconContentDescription,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = titlePrefix,
+                style = MainThemeFont.Title,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text =
+                    buildAnnotatedString {
+                        withStyle(SpanStyle(color = MainThemeColor.Green120)) {
+                            append(highlightedTitle)
+                        }
+                        withStyle(SpanStyle(color = MainThemeColor.Black)) {
+                            append(titleSuffix)
+                        }
+                    },
+                style = MainThemeFont.Title,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = description,
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        CommonBottomButton(
+            text = buttonText,
+            onClick = onNextClick,
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(start = 20.dp, end = 20.dp, bottom = 47.dp),
+            enabled = true,
+        )
+    }
+}
+
+@Composable
+fun CommonLocationPermissionDeniedContent(
+    title: String,
+    subtitle: String,
+    guidePrefix: String,
+    guideSuffix: String,
+    imageContentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = title,
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = subtitle,
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Image(
+            painter = painterResource(id = R.drawable.no_place),
+            contentDescription = imageContentDescription,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = guidePrefix,
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = guideSuffix,
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CommonLocationPermissionRationalePreview() {
+    PicplzTheme {
+        CommonLocationPermissionRationale(
+            titlePrefix = "주변 작가를 찾으려면",
+            highlightedTitle = "위치 권한",
+            titleSuffix = "이 필요해요",
+            description = "현재 위치를 기준으로 가까운 작가를 보여드려요",
+            buttonText = "다음",
+            iconContentDescription = "위치 권한",
+            onNextClick = {},
+        )
+    }
+}

--- a/core/ui/src/main/res/drawable/region_arrow_down.xml
+++ b/core/ui/src/main/res/drawable/region_arrow_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="10dp"
+    android:viewportWidth="12"
+    android:viewportHeight="10">
+  <path
+      android:pathData="M6.736,9.6C6.409,10.133 5.591,10.133 5.264,9.6L0.115,1.2C-0.212,0.667 0.197,0 0.851,0L11.149,0C11.803,0 12.212,0.667 11.885,1.2L6.736,9.6Z"
+      android:fillColor="#0E0E0F"/>
+</vector>

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginIntroScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/login/LoginIntroScreen.kt
@@ -36,7 +36,6 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.hm.picplz.core.ui.R
 import com.hm.picplz.navigation.model.Dev
-import com.hm.picplz.navigation.model.Main
 import com.hm.picplz.navigation.model.SignUpIntro
 import com.hm.picplz.ui.screen.common.CommonHorizontalPager
 import com.hm.picplz.ui.screen.common.KakaoLoginButton
@@ -68,6 +67,7 @@ private const val DEV_ENTRY_TAP_COUNT = 5
 fun LoginIntroScreen(
     navController: NavController,
     viewModel: LoginViewModel = hiltViewModel(),
+    onLoginCompleted: () -> Unit = {},
     enableDevEntry: Boolean = false,
 ) {
     val context = LocalContext.current
@@ -128,13 +128,7 @@ fun LoginIntroScreen(
 
                 LoginSideEffect.LoginSuccess -> {
                     Toast.makeText(context, "로그인 성공", Toast.LENGTH_SHORT).show()
-                    navController.navigate(Main) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    onLoginCompleted()
                 }
 
                 is LoginSideEffect.NavigateToSignUp -> {

--- a/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hm/picplz/ui/screen/sign_up/sign_up_common/views/SignUpCompletionScreen.kt
@@ -156,7 +156,7 @@ fun SignUpCompletionScreen(
 
                 is SignUpSideEffect.SignupCompleted -> {
                     onSignupCompleted()
-                    mainNavController.navigate(Main) {
+                    mainNavController.navigate(signupCompletionDestination()) {
                         popUpTo(Login) { inclusive = true }
                         launchSingleTop = true
                     }
@@ -171,6 +171,8 @@ fun SignUpCompletionScreen(
         }
     }
 }
+
+fun signupCompletionDestination(): Any = Main
 
 @Composable
 private fun CompletionProfileImage(profileImageUri: String?) {

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -37,6 +37,7 @@ import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.navigation.model.DetailPhotographerPhotoPortfolios
 import com.hm.picplz.navigation.model.DetailPhotographerPhotoReviews
 import com.hm.picplz.navigation.model.DetailReservation
+import com.hm.picplz.navigation.model.DevMainSearchResultPreview
 import com.hm.picplz.navigation.model.DevMyPagePackageEdit
 import com.hm.picplz.navigation.model.DevMyPagePhotographerProfileAdded
 import com.hm.picplz.navigation.model.Feed
@@ -188,6 +189,8 @@ fun DevScreen(
             // === Main Tabs ===
             SectionTitle("Main Tabs")
             DevButton("Main (홈)") { navController.navigate(Main) }
+            DevButton("MainSearch (검색)") { navController.navigate(MainSearch) }
+            DevButton("MainSearch (검색완료 카드 목업)") { navController.navigate(DevMainSearchResultPreview) }
             DevButton("Feed (피드)") { navController.navigate(Feed) }
             DevButton("Reservation (예약)") { navController.navigate(Reservation) }
             DevButton("Chat (채팅)") { navController.navigate(Chat) }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainIntent.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainIntent.kt
@@ -1,0 +1,19 @@
+package com.hm.picplz.ui.screen.main
+
+sealed interface MainIntent {
+    data class EnterScreen(val hasLocationPermission: Boolean) : MainIntent
+
+    data object RequestLocationPermission : MainIntent
+
+    data class LocationPermissionResult(val granted: Boolean) : MainIntent
+
+    data object RetryLoad : MainIntent
+
+    data object SearchClicked : MainIntent
+
+    data class PhotographerClicked(val photographerId: Long) : MainIntent
+
+    data object DevEntryClicked : MainIntent
+
+    data class RegionSelected(val region: String) : MainIntent
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainScreen.kt
@@ -1,25 +1,38 @@
 package com.hm.picplz.ui.screen.main
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,287 +40,134 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
+import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.hm.picplz.core.ui.R
+import coil.compose.AsyncImage
 import com.hm.picplz.feature.main.BuildConfig
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.navigation.model.Dev
 import com.hm.picplz.navigation.model.MainSearch
 import com.hm.picplz.ui.navigation.BottomNavigationBar
-import com.hm.picplz.ui.screen.common.PhotographerStatus
-import com.hm.picplz.ui.screen.common.card.PhotographerCard
-import com.hm.picplz.ui.screen.common.card.PortfolioCard
-import com.hm.picplz.ui.screen.common.card.ScheduleCardNone
-import com.hm.picplz.ui.screen.main.modalBottomSheet.DeviceModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.MoodKeywordModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.RegionModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.SortFilterModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonLocationPermissionDeniedContent
+import com.hm.picplz.ui.screen.common.CommonLocationPermissionRationale
+import com.hm.picplz.ui.screen.main.modalBottomSheet.RegionExploreBottomSheet
 import com.hm.picplz.ui.screen.main.search.SearchNavigateButton
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
-
-private val DISTRICTS =
-    listOf(
-        "연남동", "성수동", "한남동", "망원동",
-        "상수동", "이태원동", "청담동", "삼청동",
-        "북촌동", "신사동", "서교동", "합정동",
-        "논현동", "잠실동",
-    )
-private val TodayDistrict: String by lazy { DISTRICTS.random() }
-private const val DEV_ENTRY_TAP_COUNT = 5
-
-@Composable
-fun SearchBanner(navController: NavHostController) {
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(159.dp)
-                .background(
-                    brush =
-                        Brush.verticalGradient(
-                            colors = listOf(MainThemeColor.Black, Color(0xFF242529)),
-                        ),
-                ),
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp),
-        ) {
-            Spacer(Modifier.height(10.dp))
-
-            SearchNavigateButton(
-                placeholder = "촬영을 하고 싶은 장소 또는 동을 검색해보세요",
-                onClick = { navController.navigate(MainSearch) },
-            )
-
-            Spacer(Modifier.height(20.dp))
-
-            Text(
-                text = "오늘은 $TodayDistrict 나들이 어때요?",
-                style = MainThemeFont.TitleSmall,
-                color = MainThemeColor.White,
-            )
-
-            Spacer(Modifier.height(4.dp))
-
-            Box(
-                modifier =
-                    Modifier
-                        .clip(RoundedCornerShape(5.dp))
-                        .background(MainThemeColor.Gray6)
-                        .padding(5.dp),
-            ) {
-                // TODO: 작가 수 연동
-                Text(
-                    text = "N명의 작가가 픽플즈에서 활동하고 있어요",
-                    style = MainThemeFont.Caption,
-                    color = MainThemeColor.White,
-                )
-            }
-        }
-
-        Image(
-            painter = painterResource(id = R.drawable.mask_group),
-            contentDescription = "banner-image",
-            modifier =
-                Modifier
-                    .align(Alignment.BottomEnd)
-                    .zIndex(1f),
-        )
-    }
-}
-
-@Composable
-fun ReservationSection() {
-    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-        Text(text = "진행중인 촬영", style = MainThemeFont.TitleSmall)
-        Spacer(modifier = Modifier.height(10.dp))
-//        TODO: 예약 있을 때 없을 때 분기처리
-//        ScheduleCard(
-//            userName = "합정동 불주먹",
-//            userProfile = R.drawable.edit_grey4,
-//            status = ReservationStatus.INPROGRESS,
-//            type = ReservationType.ASAP,
-//            packageType = PackageType.KAKAO,
-//            date = "5월 26일 오전 9시 30분",
-//            location = "종로구 효자로 33",
-//            onClick = {}
-//        )
-        ScheduleCardNone(
-            mainText = "진행중인 촬영이 없어요",
-            subText = "촬영지를 검색하고 작가들을 둘러보세요",
-            onClick = { /* TODO */ },
-        )
-    }
-}
-
-@Composable
-fun AdSection() {
-    Column {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(70.dp)
-                    .background(MainThemeColor.Olive),
-        ) {
-            Text(text = "광고!")
-        }
-    }
-}
-
-@Composable
-fun PopularPortfolioSection() {
-    Column(modifier = Modifier.padding(start = 16.dp)) {
-        Text(text = "인기 포트폴리오", style = MainThemeFont.TitleSmall)
-        Spacer(modifier = Modifier.height(12.dp))
-        LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(11.dp),
-            contentPadding = PaddingValues(end = 16.dp),
-        ) {
-//            TODO: 포트폴리오 데이터 연동
-            item {
-                PortfolioCard(
-                    portfolioImage = R.drawable.logo,
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    location = "무대륙",
-                    bookmarkCnt = 23,
-                    isBookMarked = false,
-                    bookmarkClick = {},
-                    onClick = {},
-                )
-            }
-            item {
-                PortfolioCard(
-                    portfolioImage = R.drawable.logo,
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    location = "무대륙",
-                    bookmarkCnt = 23,
-                    isBookMarked = false,
-                    bookmarkClick = {},
-                    onClick = {},
-                )
-            }
-            item {
-                PortfolioCard(
-                    portfolioImage = R.drawable.logo,
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    location = "무대륙",
-                    bookmarkCnt = 23,
-                    isBookMarked = false,
-                    bookmarkClick = {},
-                    onClick = {},
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun PopularPhotographerSection() {
-    Column(modifier = Modifier.padding(start = 16.dp)) {
-        Text(text = "인기 작가", style = MainThemeFont.TitleSmall)
-        Spacer(modifier = Modifier.height(20.dp))
-        LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(30.dp),
-            contentPadding = PaddingValues(end = 16.dp),
-        ) {
-//            TODO: 작가 데이터 연동
-            item {
-                PhotographerCard(
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    status = PhotographerStatus.ENABLED,
-                    onClick = {},
-                )
-            }
-            item {
-                PhotographerCard(
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    status = PhotographerStatus.ENABLED,
-                    onClick = {},
-                )
-            }
-            item {
-                PhotographerCard(
-                    profileImage = R.drawable.user_undefined,
-                    username = "유가영",
-                    status = PhotographerStatus.DISABLED,
-                    onClick = {},
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun PopularReviewSection() {
-    Column(modifier = Modifier.padding(start = 16.dp)) {
-        Text(text = "인기 리뷰", style = MainThemeFont.TitleSmall)
-        Spacer(modifier = Modifier.height(10.dp))
-//        TODO: 리뷰 데이터 연동
-    }
-}
+import kotlinx.coroutines.flow.collectLatest
+import com.hm.picplz.core.ui.R as CoreR
 
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController,
+    viewModel: MainViewModel = hiltViewModel(),
 ) {
-    var visible by remember { mutableStateOf(false) }
-    var visibleDevice by remember { mutableStateOf(false) }
-    var visibleDeviceMood by remember { mutableStateOf(false) }
-    var visibleSortFilter by remember { mutableStateOf(false) }
-    var selectedSortType by remember { mutableStateOf(SortType.POPULAR) }
-    var devEntryTapCount by remember { mutableStateOf(0) }
+    val context = LocalContext.current
+    val state by viewModel.state.collectAsState()
+    val selectedRegion = state.selectedRegion.ifBlank { stringResource(R.string.main_region_all_seoul) }
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            val granted =
+                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) ||
+                    permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false)
+            viewModel.handleIntent(MainIntent.LocationPermissionResult(granted = granted))
+        }
 
+    LaunchedEffect(Unit) {
+        val hasLocationPermission =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                ) == PackageManager.PERMISSION_GRANTED
+        viewModel.handleIntent(MainIntent.EnterScreen(hasLocationPermission = hasLocationPermission))
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            when (sideEffect) {
+                MainSideEffect.RequestLocationPermission -> {
+                    launcher.launch(
+                        arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                        ),
+                    )
+                }
+                MainSideEffect.NavigateToSearch -> {
+                    navController.navigate(MainSearch)
+                }
+                is MainSideEffect.NavigateToPhotographerDetail -> {
+                    navController.navigate(DetailPhotographer(sideEffect.photographerId.toInt()))
+                }
+                MainSideEffect.NavigateToDev -> {
+                    navController.navigate(Dev)
+                }
+            }
+        }
+    }
+
+    when {
+        !state.locationPermissionGranted && !state.hasRequestedPermission -> {
+            CommonLocationPermissionRationale(
+                titlePrefix = stringResource(R.string.main_location_rationale_title_prefix),
+                highlightedTitle = stringResource(R.string.main_location_rationale_title_permission),
+                titleSuffix = stringResource(R.string.main_location_rationale_title_suffix),
+                description = stringResource(R.string.main_location_rationale_description),
+                buttonText = stringResource(R.string.main_location_rationale_button),
+                iconContentDescription = stringResource(R.string.main_location_rationale_icon_desc),
+                onNextClick = { viewModel.handleIntent(MainIntent.RequestLocationPermission) },
+                modifier = modifier,
+            )
+        }
+
+        else -> {
+            MainContent(
+                modifier = modifier,
+                navController = navController,
+                state = state.copy(selectedRegion = selectedRegion),
+                onRetry = { viewModel.handleIntent(MainIntent.RetryLoad) },
+                onSearchClick = { viewModel.handleIntent(MainIntent.SearchClicked) },
+                onPhotographerClick = { viewModel.handleIntent(MainIntent.PhotographerClicked(it)) },
+                onDevEntryClick = { viewModel.handleIntent(MainIntent.DevEntryClicked) },
+                onRegionSelected = { viewModel.handleIntent(MainIntent.RegionSelected(it)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MainContent(
+    modifier: Modifier,
+    navController: NavHostController,
+    state: MainState,
+    onRetry: () -> Unit,
+    onSearchClick: () -> Unit,
+    onPhotographerClick: (Long) -> Unit,
+    onDevEntryClick: () -> Unit,
+    onRegionSelected: (String) -> Unit,
+) {
     Scaffold(
         containerColor = MainThemeColor.White,
-        topBar = {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .background(MainThemeColor.Black)
-                        .clickable(
-                            enabled = BuildConfig.DEBUG,
-                            indication = null,
-                            interactionSource = null,
-                        ) {
-                            devEntryTapCount += 1
-                            if (devEntryTapCount >= DEV_ENTRY_TAP_COUNT) {
-                                devEntryTapCount = 0
-                                navController.navigate(Dev)
-                            }
-                        }
-                        .padding(16.dp, 11.dp),
-            ) {
-                Text(
-                    text = "홈",
-                    style = MainThemeFont.BodySmallButton2,
-                    color = MainThemeColor.White,
-                )
-            }
-        },
         bottomBar = {
-            BottomNavigationBar(
-                navController = navController,
-            )
+            BottomNavigationBar(navController = navController)
         },
         modifier =
             modifier
@@ -317,63 +177,288 @@ fun MainScreen(
         Column(
             modifier =
                 Modifier
-                    .padding(innerPadding)
-                    .verticalScroll(rememberScrollState()),
+                    .fillMaxSize()
+                    .padding(innerPadding),
         ) {
-            SearchBanner(navController = navController)
-
-            Spacer(modifier = Modifier.height(30.dp))
-
-            ReservationSection()
-
-            Spacer(modifier = Modifier.height(30.dp))
-
-            AdSection()
-
-            Spacer(modifier = Modifier.height(30.dp))
-
-//            PopularPortfolioSection()
-//
-//            Spacer(modifier = Modifier.height(30.dp))
-
-            PopularPhotographerSection()
-
-            Spacer(modifier = Modifier.height(30.dp))
-
-            PopularReviewSection()
-
-            RegionModalBottomSheet(
-                onDismiss = { visible = false },
-                visible = visible,
+            HomeSearchHeader(
+                selectedRegion = state.selectedRegion,
+                onSearchClick = onSearchClick,
+                onDevEntryClick = onDevEntryClick,
+                onRegionSelected = onRegionSelected,
             )
 
-            DeviceModalBottomSheet(
-                onDismiss = { visibleDevice = false },
-                visible = visibleDevice,
-            )
+            when {
+                state.isLoading -> MainLoadingContent()
+                !state.locationPermissionGranted -> MainPermissionDeniedContent(onRetry = onRetry)
+                state.homeItems.isEmpty() -> MainEmptyContent(onRetry = onRetry)
+                else -> MainHomeFeed(items = state.homeItems, onPhotographerClick = onPhotographerClick)
+            }
+        }
+    }
+}
 
-            MoodKeywordModalBottomSheet(
-                onDismiss = { visibleDeviceMood = false },
-                visible = visibleDeviceMood,
-            )
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HomeSearchHeader(
+    selectedRegion: String,
+    onSearchClick: () -> Unit,
+    onDevEntryClick: () -> Unit,
+    onRegionSelected: (String) -> Unit,
+) {
+    var showRegionSheet by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
 
-            SortFilterModalBottomSheet(
-                onDismiss = { visibleSortFilter = false },
-                visible = visibleSortFilter,
-                onSelect = { selectedType ->
-                    selectedSortType = selectedType
-                },
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+                    .combinedClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = { showRegionSheet = true },
+                        onLongClick = if (BuildConfig.DEBUG) onDevEntryClick else null,
+                    ),
+        ) {
+            Text(
+                text = selectedRegion,
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Black,
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Image(
+                painter = painterResource(CoreR.drawable.region_arrow_down),
+                contentDescription = stringResource(R.string.main_region_select_content_description),
+                modifier =
+                    Modifier
+                        .size(width = 12.dp, height = 10.dp)
+                        .rotate(if (showRegionSheet) 180f else 0f),
+            )
+        }
+
+        SearchNavigateButton(
+            placeholder = stringResource(R.string.main_search_placeholder),
+            onClick = onSearchClick,
+        )
+    }
+
+    RegionExploreBottomSheet(
+        visible = showRegionSheet,
+        currentRegion = selectedRegion,
+        onDismiss = { showRegionSheet = false },
+        onApply = onRegionSelected,
+    )
+}
+
+@Composable
+private fun MainHomeFeed(
+    items: List<CustomerHomeItem>,
+    onPhotographerClick: (Long) -> Unit,
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        items(
+            items = items,
+            key = { it.photographerId },
+        ) { item ->
+            CustomerHomeCard(
+                item = item,
+                onClick = { onPhotographerClick(item.photographerId) },
             )
         }
     }
 }
 
+@Composable
+private fun CustomerHomeCard(
+    item: CustomerHomeItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable { onClick() },
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AsyncImage(
+                model = item.profileImageUri,
+                placeholder = painterResource(CoreR.drawable.user_undefined),
+                error = painterResource(CoreR.drawable.user_undefined),
+                contentDescription =
+                    stringResource(
+                        R.string.main_photographer_profile_content_description,
+                        item.photographerName,
+                    ),
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .size(42.dp)
+                        .clip(CircleShape),
+            )
+            Spacer(modifier = Modifier.size(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.photographerName,
+                    style = MainThemeFont.TitleSmall,
+                    color = MainThemeColor.Black,
+                )
+                Text(
+                    text = item.moodTags.take(2).joinToString(" · "),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Gray4,
+                )
+            }
+            Text(
+                text =
+                    if (item.isActive) {
+                        stringResource(R.string.main_photographer_active)
+                    } else {
+                        stringResource(R.string.main_photographer_inactive)
+                    },
+                style = MainThemeFont.InnerTag,
+                color = if (item.isActive) MainThemeColor.Green120 else MainThemeColor.Gray4,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        AsyncImage(
+            model = item.portfolioImageUri,
+            placeholder = painterResource(CoreR.drawable.logo),
+            error = painterResource(CoreR.drawable.logo),
+            contentDescription = stringResource(R.string.main_portfolio_image_content_description),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(420.dp)
+                    .clip(RoundedCornerShape(2.dp)),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = item.location.ifBlank { stringResource(R.string.main_location_unknown) },
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+        )
+        Text(
+            text = stringResource(R.string.main_distance_format, item.distance),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray3,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider(color = MainThemeColor.Gray2)
+    }
+}
+
+@Composable
+private fun MainLoadingContent() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(color = MainThemeColor.Black)
+    }
+}
+
+@Composable
+private fun MainPermissionDeniedContent(onRetry: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(top = 88.dp, start = 20.dp, end = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CommonLocationPermissionDeniedContent(
+            title = stringResource(R.string.main_location_denied_title),
+            subtitle = stringResource(R.string.main_location_denied_subtitle),
+            guidePrefix = stringResource(R.string.main_location_denied_guide_prefix),
+            guideSuffix = stringResource(R.string.main_location_denied_guide_suffix),
+            imageContentDescription = stringResource(R.string.main_location_denied_image_desc),
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        CommonBottomButton(
+            text = stringResource(R.string.main_retry_button),
+            onClick = onRetry,
+        )
+    }
+}
+
+@Composable
+private fun MainEmptyContent(onRetry: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.main_empty_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.main_empty_subtitle),
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        CommonBottomButton(
+            text = stringResource(R.string.main_retry_button),
+            onClick = onRetry,
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
-fun MainScreenPreview() {
-    val navController = rememberNavController()
-
+private fun MainScreenPreview() {
     PicplzTheme {
-        MainScreen(navController = navController)
+        MainContent(
+            modifier = Modifier,
+            navController = rememberNavController(),
+            state =
+                MainState(
+                    locationPermissionGranted = true,
+                    homeItems =
+                        listOf(
+                            CustomerHomeItem(
+                                photographerId = 1L,
+                                photographerName = "유가영 작가",
+                                profileImageUri = null,
+                                portfolioImageUri = null,
+                                location = "서울 마포구",
+                                uploadDate = "2026-06-11",
+                                photoCount = 4,
+                                isActive = true,
+                                distance = 340,
+                                moodTags = listOf("무드", "필름"),
+                            ),
+                        ),
+                ),
+            onRetry = {},
+            onSearchClick = {},
+            onPhotographerClick = {},
+            onDevEntryClick = {},
+            onRegionSelected = {},
+        )
     }
 }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchDevFixtures.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchDevFixtures.kt
@@ -1,0 +1,58 @@
+package com.hm.picplz.ui.screen.main
+
+internal fun devMainSearchPreviewState(): MainSearchState =
+    MainSearchState.idle().copy(
+        query = "유가영",
+        hasSearched = true,
+        results = devSearchPreviewPhotographers(),
+        nearbyPhotographers = devSearchPreviewPhotographers(),
+    )
+
+internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
+    listOf(
+        MainSearchPhotographerItem(
+            id = "dev-search-active",
+            name = "유가영 작가",
+            profileImageUri = "https://picsum.photos/seed/picplz-search-1/240",
+            areaSummary = "마포구, 서대문구",
+            isAvailableNow = true,
+            moodTags = listOf("을지로 감성", "MZ 감성", "필름 감성", "자연광", "빈티지"),
+            distance = 100,
+        ),
+        MainSearchPhotographerItem(
+            id = "dev-search-yeongdeungpo",
+            name = "유가영 작가",
+            profileImageUri = "https://picsum.photos/seed/picplz-search-2/240",
+            areaSummary = "동작구, 영등포구",
+            isAvailableNow = false,
+            moodTags = listOf("을지로 감성", "MZ 감성", "MZ 감성"),
+            distance = 200,
+        ),
+        MainSearchPhotographerItem(
+            id = "dev-search-default",
+            name = "유가영 작가",
+            profileImageUri = null,
+            areaSummary = "마포구, 망구",
+            isAvailableNow = false,
+            moodTags = listOf("을지로 감성", "MZ 감성", "MZ 감성"),
+            distance = 300,
+        ),
+        MainSearchPhotographerItem(
+            id = "dev-search-gangnam",
+            name = "유가영 작가",
+            profileImageUri = "https://picsum.photos/seed/picplz-search-4/240",
+            areaSummary = "강남구, 강북구, 동대문구 외 3개",
+            isAvailableNow = false,
+            moodTags = listOf("을지로 감성", "MZ 감성", "MZ 감성"),
+            distance = 400,
+        ),
+        MainSearchPhotographerItem(
+            id = "dev-search-gangdong",
+            name = "유가영 작가",
+            profileImageUri = "https://picsum.photos/seed/picplz-search-5/240",
+            areaSummary = "강동구",
+            isAvailableNow = false,
+            moodTags = listOf("을지로 감성", "MZ 감성", "MZ 감성"),
+            distance = 500,
+        ),
+    )

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchIntent.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchIntent.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.ui.screen.main
+
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+
+sealed interface MainSearchIntent {
+    data class QueryChanged(val query: String) : MainSearchIntent
+
+    data class FocusChanged(val isFocused: Boolean) : MainSearchIntent
+
+    data class SearchSubmitted(val query: String) : MainSearchIntent
+
+    data class NearbyPhotographersLoaded(val photographers: List<MainSearchPhotographerItem>) : MainSearchIntent
+
+    data object SearchLoadFailed : MainSearchIntent
+
+    data class SortSelected(val sortType: SortType) : MainSearchIntent
+
+    data class RecentSearchRemoved(val query: String) : MainSearchIntent
+
+    data object RecentSearchCleared : MainSearchIntent
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchPhotographerListItem.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchPhotographerListItem.kt
@@ -1,0 +1,214 @@
+package com.hm.picplz.ui.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.core.ui.R as CoreR
+
+private object PhotographerListItemDefaults {
+    val ItemVerticalPadding = 16.dp
+    val ItemStartPadding = 16.dp
+    val HeaderEndPadding = 16.dp
+    val ThumbnailSize = 88.dp
+    val ThumbnailRadius = 5.dp
+    val ThumbnailTextGap = 10.dp
+    val TitleAreaGap = 0.dp
+    val TagHorizontalGap = 4.dp
+    val TagListEndPadding = 16.dp
+    val TagHorizontalPadding = 12.dp
+    val TagVerticalPadding = 4.dp
+    val TagRadius = 5.dp
+    val ActiveDotSize = 10.dp
+    val ActiveTextGap = 4.dp
+    val HeaderActiveGap = 8.dp
+}
+
+@Composable
+internal fun PhotographerListItem(
+    item: MainSearchPhotographerItem,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(
+                    start = PhotographerListItemDefaults.ItemStartPadding,
+                    top = PhotographerListItemDefaults.ItemVerticalPadding,
+                    bottom = PhotographerListItemDefaults.ItemVerticalPadding,
+                ),
+        verticalAlignment = Alignment.Top,
+    ) {
+        PhotographerThumbnail(item = item)
+
+        Spacer(modifier = Modifier.width(PhotographerListItemDefaults.ThumbnailTextGap))
+
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .height(PhotographerListItemDefaults.ThumbnailSize),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                modifier = Modifier.padding(end = PhotographerListItemDefaults.HeaderEndPadding),
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(PhotographerListItemDefaults.HeaderActiveGap),
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(PhotographerListItemDefaults.TitleAreaGap),
+                ) {
+                    Text(
+                        text = item.name,
+                        style = MainThemeFont.BodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                        color = MainThemeColor.Black,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    if (item.areaSummary.isNotBlank()) {
+                        Text(
+                            text = item.areaSummary,
+                            style = MainThemeFont.Body,
+                            color = MainThemeColor.Gray4,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+
+                if (item.isAvailableNow) {
+                    ActiveStatus()
+                }
+            }
+
+            PhotographerMoodTags(tags = item.moodTags)
+        }
+    }
+}
+
+@Composable
+private fun PhotographerThumbnail(item: MainSearchPhotographerItem) {
+    val shape = RoundedCornerShape(PhotographerListItemDefaults.ThumbnailRadius)
+
+    Box(
+        modifier =
+            Modifier
+                .size(PhotographerListItemDefaults.ThumbnailSize)
+                .clip(shape)
+                .background(MainThemeColor.Gray2, shape)
+                .border(
+                    width = 1.dp,
+                    color = MainThemeColor.Gray2,
+                    shape = shape,
+                ),
+    ) {
+        AsyncImage(
+            model = item.profileImageUri,
+            placeholder = painterResource(id = CoreR.drawable.user_undefined),
+            error = painterResource(id = CoreR.drawable.user_undefined),
+            fallback = painterResource(id = CoreR.drawable.user_undefined),
+            contentScale = ContentScale.Crop,
+            contentDescription =
+                stringResource(
+                    R.string.main_search_photographer_profile_content_description,
+                    item.name,
+                ),
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun PhotographerMoodTags(tags: List<String>) {
+    val displayTags =
+        tags.mapNotNull { rawTag ->
+            rawTag
+                .trim()
+                .takeUnless(String::isBlank)
+                ?.let { tag -> if (tag.startsWith("#")) tag else "#$tag" }
+        }.distinct()
+
+    if (displayTags.isEmpty()) return
+
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(PhotographerListItemDefaults.TagHorizontalGap),
+        contentPadding = PaddingValues(end = PhotographerListItemDefaults.TagListEndPadding),
+    ) {
+        items(displayTags) { tag ->
+            Text(
+                text = tag,
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray4,
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(PhotographerListItemDefaults.TagRadius))
+                        .background(MainThemeColor.Gray1)
+                        .border(
+                            width = 1.dp,
+                            color = MainThemeColor.Gray1,
+                            shape = RoundedCornerShape(PhotographerListItemDefaults.TagRadius),
+                        )
+                        .padding(
+                            horizontal = PhotographerListItemDefaults.TagHorizontalPadding,
+                            vertical = PhotographerListItemDefaults.TagVerticalPadding,
+                        ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveStatus(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(PhotographerListItemDefaults.ActiveDotSize)
+                    .clip(CircleShape)
+                    .background(MainThemeColor.Green120),
+        )
+        Spacer(modifier = Modifier.width(PhotographerListItemDefaults.ActiveTextGap))
+        Text(
+            text = stringResource(R.string.main_search_result_active_status),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Green120,
+        )
+    }
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducer.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducer.kt
@@ -1,0 +1,97 @@
+package com.hm.picplz.ui.screen.main
+
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+
+object MainSearchReducer {
+    fun reduce(
+        state: MainSearchState,
+        intent: MainSearchIntent,
+    ): MainSearchState =
+        when (intent) {
+            is MainSearchIntent.QueryChanged -> {
+                state.copy(
+                    query = intent.query,
+                    hasSearched = false,
+                    results = emptyList(),
+                )
+            }
+
+            is MainSearchIntent.FocusChanged -> {
+                state.copy(isFocused = intent.isFocused)
+            }
+
+            is MainSearchIntent.SearchSubmitted -> {
+                val submittedQuery = intent.query.trim()
+                state.copy(
+                    query = submittedQuery,
+                    isFocused = false,
+                    hasSearched = true,
+                    isLoading = submittedQuery.isNotBlank(),
+                    recentSearchQueries = state.recentSearchQueries.withSubmittedQuery(submittedQuery),
+                    results = state.nearbyPhotographers.searchResultsFor(submittedQuery, state.selectedSortType),
+                )
+            }
+
+            is MainSearchIntent.NearbyPhotographersLoaded -> {
+                val nearbyPhotographers = intent.photographers
+                state.copy(
+                    isLoading = false,
+                    nearbyPhotographers = nearbyPhotographers,
+                    results = nearbyPhotographers.searchResultsFor(state.query, state.selectedSortType),
+                )
+            }
+
+            MainSearchIntent.SearchLoadFailed -> {
+                state.copy(
+                    isLoading = false,
+                    results = emptyList(),
+                )
+            }
+
+            is MainSearchIntent.SortSelected -> {
+                state.copy(
+                    selectedSortType = intent.sortType,
+                    results = state.results.sortedBy(intent.sortType),
+                )
+            }
+
+            is MainSearchIntent.RecentSearchRemoved -> {
+                state.copy(recentSearchQueries = state.recentSearchQueries - intent.query)
+            }
+
+            MainSearchIntent.RecentSearchCleared -> {
+                state.copy(recentSearchQueries = emptyList())
+            }
+        }
+
+    private fun List<String>.withSubmittedQuery(query: String): List<String> {
+        if (query.isBlank() || query in this) return this
+        return listOf(query) + this
+    }
+
+    private fun List<MainSearchPhotographerItem>.searchResultsFor(
+        query: String,
+        sortType: SortType,
+    ): List<MainSearchPhotographerItem> {
+        if (query.isBlank()) return emptyList()
+
+        val normalizedQuery = query.lowercase()
+        return filter { item ->
+            item.id.lowercase().contains(normalizedQuery) ||
+                item.areaSummary.lowercase().contains(normalizedQuery) ||
+                item.name.lowercase().contains(normalizedQuery) ||
+                item.moodTags.any { it.lowercase().contains(normalizedQuery) }
+        }.sortedBy(sortType)
+    }
+
+    private fun List<MainSearchPhotographerItem>.sortedBy(sortType: SortType): List<MainSearchPhotographerItem> =
+        when (sortType) {
+            SortType.POPULAR ->
+                sortedWith(
+                    compareByDescending<MainSearchPhotographerItem> { it.isAvailableNow }
+                        .thenBy { it.distance },
+                )
+            SortType.RATING -> sortedByDescending { it.moodTags.size }
+            SortType.FOLLOWER -> sortedBy { it.distance }
+        }
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchResultSection.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchResultSection.kt
@@ -1,0 +1,166 @@
+package com.hm.picplz.ui.screen.main
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortFilterModalBottomSheet
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.core.ui.R as CoreR
+
+private object SearchResultDefaults {
+    val HorizontalPadding = 16.dp
+    val SortTextIconGap = 4.dp
+    val SortIconSize = 8.dp
+}
+
+@Composable
+fun SearchResultSection(
+    results: List<MainSearchPhotographerItem>,
+    isLoading: Boolean,
+    selectedSortType: SortType,
+    onSortSelected: (SortType) -> Unit,
+    onPhotographerClick: (MainSearchPhotographerItem) -> Unit,
+) {
+    var visibleSortFilter by remember { mutableStateOf(false) }
+    val selectedSortLabel = stringResource(selectedSortType.labelResId)
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        SortButton(
+            label = selectedSortLabel,
+            onClick = { visibleSortFilter = true },
+            modifier = Modifier.padding(horizontal = SearchResultDefaults.HorizontalPadding),
+        )
+
+        if (isLoading) {
+            SearchLoadingResult()
+        } else if (results.isEmpty()) {
+            SearchEmptyResult()
+        } else {
+            LazyColumn {
+                itemsIndexed(
+                    items = results,
+                    key = { _, item -> item.id },
+                ) { index, item ->
+                    PhotographerListItem(
+                        item = item,
+                        onClick = { onPhotographerClick(item) },
+                    )
+                    if (index < results.lastIndex) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = SearchResultDefaults.HorizontalPadding),
+                            color = MainThemeColor.Gray2,
+                            thickness = 1.dp,
+                        )
+                    }
+                }
+            }
+        }
+
+        SortFilterModalBottomSheet(
+            onDismiss = { visibleSortFilter = false },
+            visible = visibleSortFilter,
+            onSelect = onSortSelected,
+        )
+    }
+}
+
+@Composable
+private fun SortButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SearchResultDefaults.SortTextIconGap),
+    ) {
+        Text(
+            text = label,
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray5,
+        )
+        Icon(
+            painter = painterResource(id = CoreR.drawable.arrow_down),
+            contentDescription = null,
+            tint = MainThemeColor.Gray4,
+            modifier = Modifier.size(SearchResultDefaults.SortIconSize),
+        )
+    }
+}
+
+@Composable
+private fun SearchLoadingResult() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(top = 163.dp),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        CircularProgressIndicator(color = MainThemeColor.Black)
+    }
+}
+
+private val SortType.labelResId: Int
+    @StringRes
+    get() =
+        when (this) {
+            SortType.POPULAR -> R.string.main_search_sort_popular
+            SortType.RATING -> R.string.main_search_sort_rating
+            SortType.FOLLOWER -> R.string.main_search_sort_follower
+        }
+
+@Composable
+private fun SearchEmptyResult() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(top = 163.dp),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.main_search_no_result),
+                style = MainThemeFont.TitleSmall,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Image(
+                painter = painterResource(id = CoreR.drawable.user_undefined),
+                contentDescription = stringResource(R.string.main_search_empty_image_content_description),
+            )
+        }
+    }
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchScreen.kt
@@ -1,7 +1,6 @@
 package com.hm.picplz.ui.screen.main
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +19,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
@@ -28,58 +28,39 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.hm.picplz.core.ui.R
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.ui.screen.common.AreaTag
-import com.hm.picplz.ui.screen.common.CommonIconButton
-import com.hm.picplz.ui.screen.main.modalBottomSheet.DeviceModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.MoodKeywordModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.RegionModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.SortFilterModalBottomSheet
-import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
 import com.hm.picplz.ui.screen.main.search.SearchField
-import com.hm.picplz.ui.screen.main.search.SearchFilterButton
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
-
-// 3가지 상태를 표현하는 sealed class
-sealed class SearchUiState {
-    object Empty : SearchUiState() // 아무 입력도 없는 초기 상태
-
-    object Typing : SearchUiState() // 포커스가 있고 입력 중인 상태
-
-    data class Complete(
-        val query: String,
-    ) : SearchUiState()
-}
+import com.hm.picplz.core.ui.R as CoreR
 
 @Composable
 fun Header(
     navController: NavHostController,
-    uiState: SearchUiState,
     query: String,
     onQueryChange: (String) -> Unit,
     onSearchClick: () -> Unit,
     onFocusChanged: (Boolean) -> Unit,
 ) {
-    var visibleRegion by remember { mutableStateOf(false) }
-    var visibleDevice by remember { mutableStateOf(false) }
-    var visibleDeviceMood by remember { mutableStateOf(false) }
+    val canNavigateBack = navController.previousBackStackEntry != null
 
     Box(
         modifier =
@@ -93,73 +74,31 @@ fun Header(
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
-                        .padding(top = 8.dp),
+                        .padding(top = 8.dp)
+                        .padding(vertical = 2.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    painter = painterResource(R.drawable.triangle_left),
-                    contentDescription = "arrow left",
-                    modifier =
-                        Modifier
-                            .size(18.dp)
-                            .clickable { navController.popBackStack() },
-                )
-                Spacer(modifier = Modifier.width(17.dp))
+                if (canNavigateBack) {
+                    Icon(
+                        painter = painterResource(CoreR.drawable.triangle_left),
+                        contentDescription = stringResource(R.string.main_search_back_content_description),
+                        modifier =
+                            Modifier
+                                .size(18.dp)
+                                .clickable { navController.popBackStack() },
+                    )
+                    Spacer(modifier = Modifier.width(17.dp))
+                }
                 SearchField(
                     value = query,
                     onValueChange = onQueryChange,
-                    placeholder = "촬영을 하고 싶은 장소 또는 동을 검색해보세요",
-                    modifier = Modifier.height(46.dp),
+                    placeholder = stringResource(R.string.main_search_placeholder),
                     onSearchClick = onSearchClick,
                     keyboardActions = {
                         onSearchClick()
                     },
                     onFocusChanged = onFocusChanged,
-                )
-            }
-
-            if (uiState is SearchUiState.Complete) {
-                LazyRow(
-                    modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    contentPadding = PaddingValues(end = 16.dp),
-                ) {
-                    item {
-                        SearchFilterButton(
-                            label = "촬영 지역",
-                            isSelected = false,
-                            onClick = { visibleRegion = true },
-                        )
-                    }
-                    item {
-                        SearchFilterButton(
-                            label = "촬영 기기",
-                            isSelected = false,
-                            onClick = { visibleDevice = true },
-                        )
-                    }
-                    item {
-                        SearchFilterButton(
-                            label = "분위기 태그",
-                            isSelected = false,
-                            onClick = { visibleDeviceMood = true },
-                        )
-                    }
-                }
-
-                RegionModalBottomSheet(
-                    onDismiss = { visibleRegion = false },
-                    visible = visibleRegion,
-                )
-
-                DeviceModalBottomSheet(
-                    onDismiss = { visibleDevice = false },
-                    visible = visibleDevice,
-                )
-
-                MoodKeywordModalBottomSheet(
-                    onDismiss = { visibleDeviceMood = false },
-                    visible = visibleDeviceMood,
+                    autoFocus = true,
                 )
             }
         }
@@ -168,7 +107,7 @@ fun Header(
 
 @Composable
 fun RecentSearchSection(
-    recentSearchQueries: SnapshotStateList<String>,
+    recentSearchQueries: List<String>,
     onRemove: (String) -> Unit,
     onClearAll: () -> Unit,
 ) {
@@ -198,12 +137,12 @@ fun RecentSearchSection(
                     .padding(horizontal = 16.dp),
         ) {
             Text(
-                text = "최근 검색어",
+                text = stringResource(R.string.main_search_recent_title),
                 style = MainThemeFont.ButtonDefault,
             )
             Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = "모두 삭제",
+                text = stringResource(R.string.main_search_recent_clear_all),
                 style = MainThemeFont.InnerTag,
                 color = MainThemeColor.Gray4,
                 textDecoration = TextDecoration.Underline,
@@ -262,12 +201,12 @@ fun PopularSpotSection(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = "인기 촬영지",
+                text = stringResource(R.string.main_search_popular_spot_title),
                 style = MainThemeFont.ButtonDefault,
             )
             Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = "04.22 12:00 기준",
+                text = stringResource(R.string.main_search_popular_spot_updated_at),
                 style = MainThemeFont.Caption,
                 color = MainThemeColor.Gray3,
             )
@@ -300,113 +239,21 @@ fun PopularSpotSection(
 }
 
 @Composable
-fun PhotographerListItem() {
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(50.dp)
-                .background(MainThemeColor.Olive),
-    ) {
-    }
-}
+fun TypingResultSection(
+    query: String,
+    onSuggestionClick: (String) -> Unit,
+) {
+    val trimmedQuery = query.trim()
+    if (trimmedQuery.isBlank()) return
 
-@Composable
-fun SearchResultSection() {
-    var visibleSortFilter by remember { mutableStateOf(false) }
-    var selectedSortType by remember { mutableStateOf(SortType.POPULAR) }
-
-    Column(
-        modifier =
-            Modifier
-                .padding(horizontal = 16.dp),
-    ) {
-        // TODO: 폰트시스템 추가
-        CommonIconButton(
-            label = selectedSortType.label,
-            backgroundColor = MainThemeColor.Transparent,
-            textColor = MainThemeColor.Gray5,
-            iconResId = R.drawable.arrow_down,
-            horizontalPadding = 0.dp,
-            location = "right",
-            onClick = { visibleSortFilter = true },
-        )
-
-        // 검색 결과가 있을 때
-        Spacer(modifier = Modifier.height(10.dp))
-        LazyColumn {
-//            TODO: 리스트 연결
-            item {
-                PhotographerListItem()
-                HorizontalDivider(
-                    color = MainThemeColor.Gray2,
-                    thickness = 1.dp,
-                )
-            }
-            item {
-                PhotographerListItem()
-                HorizontalDivider(
-                    color = MainThemeColor.Gray2,
-                    thickness = 1.dp,
-                )
-            }
-            item {
-                PhotographerListItem()
-                HorizontalDivider(
-                    color = MainThemeColor.Gray2,
-                    thickness = 1.dp,
-                )
-            }
-            item {
-                PhotographerListItem()
-                HorizontalDivider(
-                    color = MainThemeColor.Gray2,
-                    thickness = 1.dp,
-                )
-            }
-        }
-
-        // 검색 결과가 없을 때
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(top = 163.dp),
-            contentAlignment = Alignment.TopCenter,
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(text = "검색 결과가 없습니다", style = MainThemeFont.TitleSmall)
-                Spacer(modifier = Modifier.height(12.dp))
-                Image(
-                    painter = painterResource(id = R.drawable.user_undefined),
-                    contentDescription = "user-undefined",
-                )
-            }
-        }
-
-        SortFilterModalBottomSheet(
-            onDismiss = { visibleSortFilter = false },
-            visible = visibleSortFilter,
-            onSelect = { selectedType ->
-                selectedSortType = selectedType
-            },
-        )
-    }
-}
-
-@Composable
-fun TypingResultSection(onSuggestionClick: (String) -> Unit) {
-    // 더미 데이터
-    val dummyList =
+    val photographerSuggestions =
         listOf(
-            mapOf("type" to "location", "label" to "서울 강남구 도곡동"),
-            mapOf("type" to "location", "label" to "서울 강남구 도곡1동"),
-            mapOf("type" to "location", "label" to "서울 강남구 도곡2동"),
-            mapOf("type" to "photographer", "profileImage" to R.drawable.logo, "label" to "강주은 작가"),
-            mapOf("type" to "photographer", "profileImage" to R.drawable.logo, "label" to "강아지 작가"),
-            mapOf("type" to "tag", "label" to "강아지랑 촬영"),
-            mapOf("type" to "tag", "label" to "강한 컨셉"),
-        )
+            stringResource(R.string.main_search_suggestion_photographer_kang_jueun),
+            stringResource(R.string.main_search_suggestion_photographer_dog),
+            stringResource(R.string.main_search_suggestion_photographer_dog),
+            stringResource(R.string.main_search_suggestion_photographer_dog),
+            stringResource(R.string.main_search_suggestion_photographer_dog),
+        ).filter { it.contains(trimmedQuery, ignoreCase = true) }
 
     LazyColumn(
         modifier =
@@ -414,54 +261,32 @@ fun TypingResultSection(onSuggestionClick: (String) -> Unit) {
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
     ) {
-        items(dummyList) { item ->
+        itemsIndexed(photographerSuggestions) { index, photographer ->
             Row(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .clickable { onSuggestionClick(item["label"].toString()) }
+                        .clickable { onSuggestionClick(photographer) }
                         .padding(vertical = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                when (item["type"]) {
-                    "location" -> {
-                        Icon(
-                            painter = painterResource(id = R.drawable.marker_map_gray),
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp),
-                            tint = MainThemeColor.Gray3,
-                        )
-                        Text(
-                            text = item["label"].toString(),
-                            style = MainThemeFont.Body,
-                        )
-                    }
-
-                    "photographer" -> {
-                        Image(
-                            painter = painterResource(id = R.drawable.user_undefined),
-                            contentDescription = null,
-                            modifier =
-                                Modifier
-                                    .size(20.dp)
-                                    .clip(CircleShape),
-                        )
-                        Text(
-                            text = item["label"].toString(),
-                            style = MainThemeFont.BodyBold,
-                        )
-                    }
-
-                    "tag" -> {
-                        Text(
-                            text = item["label"].toString(),
-                            style = MainThemeFont.Body,
-                        )
-                    }
-                }
+                Image(
+                    painter = painterResource(id = CoreR.drawable.user_undefined),
+                    contentDescription = null,
+                    modifier =
+                        Modifier
+                            .size(20.dp)
+                            .clip(CircleShape),
+                )
+                Text(
+                    text = photographer,
+                    style = MainThemeFont.BodyBold,
+                )
             }
-            HorizontalDivider(thickness = 0.96.dp, color = MainThemeColor.Gray2)
+            if (index < photographerSuggestions.lastIndex) {
+                HorizontalDivider(thickness = 1.dp, color = MainThemeColor.Gray2)
+            }
         }
     }
 }
@@ -470,30 +295,29 @@ fun TypingResultSection(onSuggestionClick: (String) -> Unit) {
 fun MainSearchScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController,
+    devMockResults: Boolean = false,
+    viewModel: MainSearchViewModel = hiltViewModel(),
 ) {
-    var query by rememberSaveable { mutableStateOf("") }
-    var isFocused by remember { mutableStateOf(false) }
-    var hasSearched by remember { mutableStateOf(false) }
-
-    val recentSearchQueries = remember { mutableStateListOf("연희동", "성수", "홍익대", "연남동", "송파구") }
-    val popularSpots = listOf("성수동", "연남동", "서교동", "합정동", "망원동")
+    val viewModelState by viewModel.state.collectAsState()
+    var devPreviewState by remember { mutableStateOf(devMainSearchPreviewState()) }
+    val state = if (devMockResults) devPreviewState else viewModelState
     val focusManager = LocalFocusManager.current
 
     val doSearch: (String) -> Unit = { newQuery ->
-        query = newQuery
-        hasSearched = true
+        if (devMockResults) {
+            devPreviewState =
+                devPreviewState.copy(
+                    query = newQuery.trim(),
+                    isFocused = false,
+                    hasSearched = true,
+                    isLoading = false,
+                    results = devSearchPreviewPhotographers(),
+                )
+        } else {
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted(newQuery))
+        }
         focusManager.clearFocus()
-        if (newQuery.isNotBlank() && !recentSearchQueries.contains(newQuery)) {
-            recentSearchQueries.add(0, newQuery)
-        }
     }
-
-    val uiState: SearchUiState =
-        when {
-            hasSearched -> SearchUiState.Complete(query)
-            isFocused && query.isNotEmpty() -> SearchUiState.Typing
-            else -> SearchUiState.Empty
-        }
 
     Scaffold(
         containerColor = MainThemeColor.White,
@@ -510,48 +334,58 @@ fun MainSearchScreen(
         ) {
             Header(
                 navController = navController,
-                uiState = uiState,
-                query = query,
+                query = state.query,
                 onQueryChange = {
-                    query = it
-                    hasSearched = false
+                    if (devMockResults) {
+                        devPreviewState = devPreviewState.copy(query = it)
+                    } else {
+                        viewModel.handleIntent(MainSearchIntent.QueryChanged(it))
+                    }
                 },
-                onSearchClick = { doSearch(query) },
-                onFocusChanged = { isFocused = it },
+                onSearchClick = { doSearch(state.query) },
+                onFocusChanged = {
+                    if (devMockResults) {
+                        devPreviewState = devPreviewState.copy(isFocused = it)
+                    } else {
+                        viewModel.handleIntent(MainSearchIntent.FocusChanged(it))
+                    }
+                },
             )
 
-            when (uiState) {
-                is SearchUiState.Empty -> {
-                    Spacer(modifier = Modifier.height(20.dp))
-
-                    RecentSearchSection(
-                        recentSearchQueries = recentSearchQueries,
-                        onRemove = { area ->
-                            focusManager.clearFocus()
-                            recentSearchQueries.remove(area)
-                        },
-                        onClearAll = {
-                            focusManager.clearFocus()
-                            recentSearchQueries.clear()
-                        },
-                    )
-
-                    PopularSpotSection(
-                        popularSpots = popularSpots,
-                        onSpotClick = { spot -> doSearch(spot) },
-                    )
-                }
+            when (state.uiState) {
+                is SearchUiState.Empty -> Unit
 
                 is SearchUiState.Complete -> {
                     Spacer(modifier = Modifier.height(20.dp))
 
-                    SearchResultSection()
+                    SearchResultSection(
+                        results = state.results,
+                        isLoading = state.isLoading,
+                        selectedSortType = state.selectedSortType,
+                        onSortSelected = { sortType ->
+                            if (devMockResults) {
+                                devPreviewState =
+                                    MainSearchReducer.reduce(
+                                        devPreviewState,
+                                        MainSearchIntent.SortSelected(sortType),
+                                    )
+                            } else {
+                                viewModel.handleIntent(MainSearchIntent.SortSelected(sortType))
+                            }
+                        },
+                        onPhotographerClick = { item ->
+                            item.id.toIntOrNull()?.let { photographerId ->
+                                navController.navigate(DetailPhotographer(photographerId))
+                            }
+                        },
+                    )
                 }
 
                 SearchUiState.Typing -> {
-                    Spacer(modifier = Modifier.height(20.dp))
+                    Spacer(modifier = Modifier.height(10.dp))
 
                     TypingResultSection(
+                        query = state.query,
                         onSuggestionClick = { sug -> doSearch(sug) },
                     )
                 }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchState.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchState.kt
@@ -1,0 +1,51 @@
+package com.hm.picplz.ui.screen.main
+
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+
+data class MainSearchState(
+    val query: String = "",
+    val isFocused: Boolean = false,
+    val hasSearched: Boolean = false,
+    val isLoading: Boolean = false,
+    val recentSearchQueries: List<String> = defaultRecentSearchQueries,
+    val popularSpots: List<String> = defaultPopularSpots,
+    val selectedSortType: SortType = SortType.POPULAR,
+    val nearbyPhotographers: List<MainSearchPhotographerItem> = emptyList(),
+    val results: List<MainSearchPhotographerItem> = emptyList(),
+) {
+    val uiState: SearchUiState
+        get() =
+            when {
+                hasSearched -> SearchUiState.Complete(query = query, hasResults = results.isNotEmpty())
+                isFocused && query.isNotEmpty() -> SearchUiState.Typing
+                else -> SearchUiState.Empty
+            }
+
+    companion object {
+        private val defaultRecentSearchQueries = listOf("연희동", "성수", "홍익대", "연남동", "송파구")
+        private val defaultPopularSpots = listOf("성수동", "연남동", "서교동", "합정동", "망원동")
+
+        fun idle(): MainSearchState = MainSearchState()
+    }
+}
+
+data class MainSearchPhotographerItem(
+    val id: String,
+    val name: String,
+    val profileImageUri: String?,
+    val areaSummary: String,
+    val isAvailableNow: Boolean,
+    val moodTags: List<String>,
+    val distance: Long,
+)
+
+sealed class SearchUiState {
+    data object Empty : SearchUiState()
+
+    data object Typing : SearchUiState()
+
+    data class Complete(
+        val query: String,
+        val hasResults: Boolean,
+    ) : SearchUiState()
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
@@ -1,0 +1,92 @@
+package com.hm.picplz.ui.screen.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.LocationCoordinate
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainSearchViewModel
+    @Inject
+    constructor(
+        private val getCurrentLocationUseCase: GetCurrentLocationUseCase,
+        private val getCurrentMemberIdUseCase: GetCurrentMemberIdUseCase,
+        private val updateMemberLocationUseCase: UpdateMemberLocationUseCase,
+        private val getNearbyPhotographersUseCase: GetNearbyPhotographersUseCase,
+    ) : ViewModel() {
+        private val _state = MutableStateFlow(MainSearchState.idle())
+        val state: StateFlow<MainSearchState> = _state.asStateFlow()
+
+        fun handleIntent(intent: MainSearchIntent) {
+            _state.update { MainSearchReducer.reduce(it, intent) }
+
+            if (intent is MainSearchIntent.SearchSubmitted && intent.query.isNotBlank()) {
+                loadCurrentNearbyPhotographers()
+            }
+        }
+
+        private fun loadCurrentNearbyPhotographers() {
+            getCurrentLocationUseCase(
+                onLocationReceived = ::loadNearbyPhotographers,
+                onPermissionDenied = {
+                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
+                },
+            )
+        }
+
+        private fun loadNearbyPhotographers(location: LocationCoordinate) {
+            viewModelScope.launch {
+                val memberId = getCurrentMemberIdUseCase()
+                if (memberId == null) {
+                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
+                    return@launch
+                }
+
+                updateMemberLocationUseCase(
+                    memberId = memberId,
+                    location = location,
+                )
+
+                getNearbyPhotographersUseCase(
+                    longitude = location.longitude,
+                    latitude = location.latitude,
+                    distance = 2_000L,
+                ).onSuccess { filtered ->
+                    _state.update {
+                        MainSearchReducer.reduce(
+                            it,
+                            MainSearchIntent.NearbyPhotographersLoaded(filtered.toSearchItems()),
+                        )
+                    }
+                }.onFailure {
+                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
+                }
+            }
+        }
+
+        private fun FilteredPhotographers.toSearchItems(): List<MainSearchPhotographerItem> =
+            (active + inactive).map { it.toSearchItem() }
+
+        private fun Photographer.toSearchItem(): MainSearchPhotographerItem =
+            MainSearchPhotographerItem(
+                id = id.toString(),
+                name = name,
+                profileImageUri = profileImageUri,
+                areaSummary = activeAreas.joinToString(", "),
+                isAvailableNow = isActive,
+                moodTags = photoMoods,
+                distance = distance,
+            )
+    }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSideEffect.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSideEffect.kt
@@ -1,0 +1,11 @@
+package com.hm.picplz.ui.screen.main
+
+sealed interface MainSideEffect {
+    data object RequestLocationPermission : MainSideEffect
+
+    data object NavigateToSearch : MainSideEffect
+
+    data class NavigateToPhotographerDetail(val photographerId: Long) : MainSideEffect
+
+    data object NavigateToDev : MainSideEffect
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainState.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainState.kt
@@ -1,0 +1,32 @@
+package com.hm.picplz.ui.screen.main
+
+data class MainState(
+    val locationPermissionGranted: Boolean = false,
+    val hasRequestedPermission: Boolean = false,
+    val isLoading: Boolean = false,
+    val errorMessage: MainLoadError? = null,
+    val homeItems: List<CustomerHomeItem> = emptyList(),
+    val selectedRegion: String = "",
+) {
+    companion object {
+        fun idle(): MainState = MainState()
+    }
+}
+
+data class CustomerHomeItem(
+    val photographerId: Long,
+    val photographerName: String,
+    val profileImageUri: String?,
+    val portfolioImageUri: String?,
+    val location: String,
+    val uploadDate: String?,
+    val photoCount: Int,
+    val isActive: Boolean,
+    val distance: Long,
+    val moodTags: List<String>,
+)
+
+enum class MainLoadError {
+    LocationUnavailable,
+    NearbyPhotographers,
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainViewModel.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainViewModel.kt
@@ -1,0 +1,194 @@
+package com.hm.picplz.ui.screen.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hm.picplz.domain.model.LocationCoordinate
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerPortfoliosUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val HOME_FEED_LIMIT = 5
+private const val NEARBY_DISTANCE_METERS = 2_000L
+
+@HiltViewModel
+class MainViewModel
+    @Inject
+    constructor(
+        private val getCurrentLocationUseCase: GetCurrentLocationUseCase,
+        private val getCurrentMemberIdUseCase: GetCurrentMemberIdUseCase,
+        private val updateMemberLocationUseCase: UpdateMemberLocationUseCase,
+        private val getNearbyPhotographersUseCase: GetNearbyPhotographersUseCase,
+        private val getPhotographerPortfoliosUseCase: GetPhotographerPortfoliosUseCase,
+    ) : ViewModel() {
+        private val _state = MutableStateFlow(MainState.idle())
+        val state: StateFlow<MainState> = _state.asStateFlow()
+
+        private val _sideEffect = Channel<MainSideEffect>(Channel.BUFFERED)
+        val sideEffect = _sideEffect.receiveAsFlow()
+
+        fun handleIntent(intent: MainIntent) {
+            when (intent) {
+                is MainIntent.EnterScreen -> {
+                    _state.update { it.copy(locationPermissionGranted = intent.hasLocationPermission) }
+                    if (intent.hasLocationPermission && state.value.homeItems.isEmpty()) {
+                        loadCurrentLocation()
+                    }
+                }
+
+                MainIntent.RequestLocationPermission -> {
+                    _state.update { it.copy(hasRequestedPermission = true) }
+                    viewModelScope.launch {
+                        _sideEffect.send(MainSideEffect.RequestLocationPermission)
+                    }
+                }
+
+                is MainIntent.LocationPermissionResult -> {
+                    _state.update {
+                        it.copy(
+                            locationPermissionGranted = intent.granted,
+                            hasRequestedPermission = true,
+                            errorMessage = null,
+                        )
+                    }
+                    if (intent.granted) {
+                        loadCurrentLocation()
+                    }
+                }
+
+                MainIntent.RetryLoad -> {
+                    if (state.value.locationPermissionGranted) {
+                        loadCurrentLocation()
+                    } else {
+                        handleIntent(MainIntent.RequestLocationPermission)
+                    }
+                }
+
+                MainIntent.SearchClicked -> {
+                    sendSideEffect(MainSideEffect.NavigateToSearch)
+                }
+
+                is MainIntent.PhotographerClicked -> {
+                    sendSideEffect(MainSideEffect.NavigateToPhotographerDetail(intent.photographerId))
+                }
+
+                MainIntent.DevEntryClicked -> {
+                    sendSideEffect(MainSideEffect.NavigateToDev)
+                }
+
+                is MainIntent.RegionSelected -> {
+                    _state.update { it.copy(selectedRegion = intent.region) }
+                }
+            }
+        }
+
+        private fun sendSideEffect(sideEffect: MainSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.send(sideEffect)
+            }
+        }
+
+        private fun loadCurrentLocation() {
+            _state.update { it.copy(isLoading = true, errorMessage = null) }
+            getCurrentLocationUseCase(
+                onLocationReceived = ::loadHomeFeed,
+                onPermissionDenied = {
+                    _state.update {
+                        it.copy(
+                            locationPermissionGranted = false,
+                            hasRequestedPermission = true,
+                            isLoading = false,
+                            errorMessage = MainLoadError.LocationUnavailable,
+                        )
+                    }
+                },
+            )
+        }
+
+        private fun loadHomeFeed(location: LocationCoordinate) {
+            viewModelScope.launch {
+                val memberId = getCurrentMemberIdUseCase()
+                if (memberId == null) {
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = MainLoadError.NearbyPhotographers,
+                            homeItems = emptyList(),
+                        )
+                    }
+                    return@launch
+                }
+
+                updateMemberLocationUseCase(
+                    memberId = memberId,
+                    location = location,
+                )
+
+                getNearbyPhotographersUseCase(
+                    longitude = location.longitude,
+                    latitude = location.latitude,
+                    distance = NEARBY_DISTANCE_METERS,
+                ).onSuccess { filtered ->
+                    val photographers = (filtered.active + filtered.inactive).take(HOME_FEED_LIMIT)
+                    val homeItems = photographers.toHomeItems()
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = null,
+                            homeItems = homeItems,
+                        )
+                    }
+                }.onFailure {
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = MainLoadError.NearbyPhotographers,
+                            homeItems = emptyList(),
+                        )
+                    }
+                }
+            }
+        }
+
+        private suspend fun List<Photographer>.toHomeItems(): List<CustomerHomeItem> =
+            coroutineScope {
+                map { photographer ->
+                    async { photographer.toHomeItem() }
+                }.map { it.await() }
+            }
+
+        private suspend fun Photographer.toHomeItem(): CustomerHomeItem {
+            val portfolio =
+                getPhotographerPortfoliosUseCase(
+                    photographerId = id,
+                    page = 0,
+                    size = 1,
+                ).getOrNull()?.firstOrNull()
+            val locationText = portfolio?.location ?: activeAreas.firstOrNull().orEmpty()
+            return CustomerHomeItem(
+                photographerId = id,
+                photographerName = name,
+                profileImageUri = profileImageUri,
+                portfolioImageUri = portfolio?.representativeImage,
+                location = locationText,
+                uploadDate = portfolio?.uploadDate,
+                photoCount = portfolio?.photoCount ?: 0,
+                isActive = isActive,
+                distance = distance,
+                moodTags = photoMoods,
+            )
+        }
+    }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionExploreBottomSheet.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionExploreBottomSheet.kt
@@ -1,0 +1,250 @@
+package com.hm.picplz.ui.screen.main.modalBottomSheet
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.main.R
+import com.hm.picplz.ui.screen.common.CommonModalBottomSheet
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun canRegionExploreSheetTransitionTo(target: SheetValue): Boolean =
+    when (target) {
+        SheetValue.Hidden,
+        SheetValue.PartiallyExpanded,
+        SheetValue.Expanded,
+        -> true
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RegionExploreBottomSheet(
+    visible: Boolean,
+    currentRegion: String = "",
+    onDismiss: () -> Unit,
+    onApply: (String) -> Unit = {},
+) {
+    val regionTabs = stringArrayResource(R.array.main_region_tabs).toList()
+    val districtsByRegion =
+        listOf(
+            stringArrayResource(R.array.main_region_districts_seoul).toList(),
+            stringArrayResource(R.array.main_region_districts_gyeonggi).toList(),
+            stringArrayResource(R.array.main_region_districts_incheon).toList(),
+            stringArrayResource(R.array.main_region_districts_busan).toList(),
+            stringArrayResource(R.array.main_region_districts_jeju).toList(),
+        )
+    val allLabels = regionTabs.map { stringResource(R.string.main_region_all_format, it) }
+    val defaultRegion = stringResource(R.string.main_region_all_seoul)
+    val sheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = ::canRegionExploreSheetTransitionTo,
+        )
+    var selectedTab by remember { mutableIntStateOf(0) }
+    val region = regionTabs[selectedTab]
+    val allLabel = allLabels[selectedTab]
+    var selected by remember(defaultRegion) { mutableStateOf(defaultRegion) }
+
+    LaunchedEffect(visible, currentRegion, regionTabs, allLabels) {
+        if (visible) {
+            val effectiveRegion = currentRegion.ifBlank { defaultRegion }
+            val tab = regionTabs.indexOfFirst { effectiveRegion.startsWith(it) }.coerceAtLeast(0)
+            selectedTab = tab
+            val remainder = effectiveRegion.removePrefix("${regionTabs[tab]} ")
+            selected = if (effectiveRegion == allLabels[tab] || remainder.isBlank()) allLabels[tab] else remainder
+        }
+    }
+
+    val rows = listOf(allLabel) + districtsByRegion[selectedTab]
+    val appliedRegion =
+        if (selected == allLabel) {
+            allLabel
+        } else {
+            stringResource(R.string.main_region_selection_format, region, selected)
+        }
+
+    CommonModalBottomSheet(
+        visible = visible,
+        visibleCloseButton = true,
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp, bottom = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(width = 40.dp, height = 4.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(MainThemeColor.Gray2),
+                )
+            }
+        },
+        sheetMinHeight = 680.dp,
+        sheetMaxHeight = 680.dp,
+        expandToMaxHeight = false,
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = stringResource(R.string.main_region_explore_title),
+                style = MainThemeFont.TitleSmall,
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 12.dp, bottom = 20.dp),
+            )
+
+            val density = LocalDensity.current
+            val tabBounds = remember { mutableStateMapOf<Int, Pair<Dp, Dp>>() }
+            val target = tabBounds[selectedTab]
+            val indicatorLeft by animateDpAsState(targetValue = target?.first ?: 0.dp, label = "indicatorLeft")
+            val indicatorWidth by animateDpAsState(targetValue = target?.second ?: 0.dp, label = "indicatorWidth")
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(40.dp)
+                        .padding(horizontal = 16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalArrangement = Arrangement.spacedBy(20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    regionTabs.forEachIndexed { index, title ->
+                        val isSelected = index == selectedTab
+                        Text(
+                            text = title,
+                            style = MainThemeFont.BodyBold,
+                            color = if (isSelected) MainThemeColor.Black else MainThemeColor.Gray3,
+                            maxLines = 1,
+                            softWrap = false,
+                            modifier =
+                                Modifier
+                                    .onGloballyPositioned { coords ->
+                                        tabBounds[index] =
+                                            with(density) {
+                                                coords.positionInParent().x.toDp() to coords.size.width.toDp()
+                                            }
+                                    }
+                                    .clickable(
+                                        indication = null,
+                                        interactionSource = remember { MutableInteractionSource() },
+                                    ) {
+                                        selectedTab = index
+                                        selected = allLabels[index]
+                                    },
+                        )
+                    }
+                }
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomStart)
+                            .offset(x = indicatorLeft)
+                            .width(indicatorWidth)
+                            .height(2.dp)
+                            .background(MainThemeColor.Black),
+                )
+            }
+
+            Box(modifier = Modifier.weight(1f)) {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(rows) { row ->
+                        val isSelected = row == selected
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .height(40.dp)
+                                    .clickable { selected = row }
+                                    .background(if (isSelected) MainThemeColor.Gray1 else MainThemeColor.White)
+                                    .padding(horizontal = 16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = row,
+                                style = if (row == allLabel) MainThemeFont.BodyBold else MainThemeFont.Body,
+                                color = MainThemeColor.Gray5,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                }
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 16.dp, bottom = 45.dp),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                            .background(MainThemeColor.Black)
+                            .clickable {
+                                onApply(appliedRegion)
+                                onDismiss()
+                            },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.main_region_apply),
+                        style = MainThemeFont.BodyBold,
+                        color = MainThemeColor.White,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/search/SearchField.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/search/SearchField.kt
@@ -3,12 +3,10 @@ package com.hm.picplz.ui.screen.main.search
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -22,26 +20,40 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hm.picplz.core.ui.R
+import androidx.compose.ui.unit.sp
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.feature.main.R as FeatureMainR
+
+private object SearchFieldDefaults {
+    val HorizontalPadding = 16.dp
+    val VerticalPadding = 10.dp
+    val CornerRadius = 50.dp
+    val StrokeWidth = 1.dp
+    val TextLineHeight = 20.sp
+    val ClearButtonSize = 20.dp
+    val ClearIconSize = 13.dp
+    val IconSize = 20.dp
+    val IconGap = 10.dp
+    val TextIconGap = 8.dp
+}
 
 @Composable
 fun SearchField(
@@ -54,25 +66,31 @@ fun SearchField(
     enabled: Boolean = true,
     imeAction: ImeAction = ImeAction.Search,
     keyboardActions: (() -> Unit)? = null,
+    autoFocus: Boolean = false,
 ) {
     val focusManager = LocalFocusManager.current
-    var isFocused by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(autoFocus) {
+        if (autoFocus) {
+            focusRequester.requestFocus()
+        }
+    }
 
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(50.dp)
-                .clip(RoundedCornerShape(50.dp))
+                .clip(RoundedCornerShape(SearchFieldDefaults.CornerRadius))
                 .border(
-                    width = 1.dp,
-                    color = if (isFocused) MainThemeColor.Olive else MainThemeColor.Gray6,
-                    shape = RoundedCornerShape(50.dp),
+                    width = SearchFieldDefaults.StrokeWidth,
+                    color = MainThemeColor.Gray6,
+                    shape = RoundedCornerShape(SearchFieldDefaults.CornerRadius),
                 )
-                .pointerInput(Unit) {
-                    detectTapGestures(onTap = { focusManager.clearFocus() })
-                }
-                .padding(horizontal = 16.dp),
+                .padding(
+                    horizontal = SearchFieldDefaults.HorizontalPadding,
+                    vertical = SearchFieldDefaults.VerticalPadding,
+                ),
         contentAlignment = Alignment.Center,
     ) {
         Row(
@@ -85,13 +103,17 @@ fun SearchField(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .padding(end = 8.dp)
+                        .padding(end = SearchFieldDefaults.TextIconGap)
+                        .focusRequester(focusRequester)
                         .onFocusChanged { focusState ->
-                            isFocused = focusState.isFocused
                             onFocusChanged?.invoke(focusState.isFocused)
                         },
                 enabled = enabled,
-                textStyle = MainThemeFont.Body.copy(color = MainThemeColor.Black),
+                textStyle =
+                    MainThemeFont.Body.copy(
+                        color = MainThemeColor.Black,
+                        lineHeight = SearchFieldDefaults.TextLineHeight,
+                    ),
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Text,
@@ -114,7 +136,7 @@ fun SearchField(
                     if (value.isEmpty()) {
                         Text(
                             text = placeholder,
-                            style = MainThemeFont.Body,
+                            style = MainThemeFont.Body.copy(lineHeight = SearchFieldDefaults.TextLineHeight),
                             color = MainThemeColor.Gray3,
                         )
                     }
@@ -126,7 +148,7 @@ fun SearchField(
                 Box(
                     modifier =
                         Modifier
-                            .size(20.dp)
+                            .size(SearchFieldDefaults.ClearButtonSize)
                             .clip(CircleShape)
                             .background(MainThemeColor.Gray2)
                             .clickable {
@@ -137,27 +159,28 @@ fun SearchField(
                 ) {
                     Icon(
                         imageVector = Icons.Filled.Close,
-                        contentDescription = "clear",
-                        Modifier.size(13.dp),
+                        contentDescription =
+                            stringResource(FeatureMainR.string.main_search_clear_content_description),
+                        Modifier.size(SearchFieldDefaults.ClearIconSize),
                         tint = MainThemeColor.Gray4,
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.width(10.dp))
+            Spacer(modifier = Modifier.width(SearchFieldDefaults.IconGap))
 
             Icon(
-                painter = painterResource(id = R.drawable.search),
-                contentDescription = "검색",
+                painter = painterResource(id = FeatureMainR.drawable.main_search_icon),
+                contentDescription = stringResource(FeatureMainR.string.main_search_icon_content_description),
                 modifier =
                     Modifier
-                        .size(14.dp)
+                        .size(SearchFieldDefaults.IconSize)
                         .clickable {
                             onSearchClick?.invoke()
                                 ?: keyboardActions?.invoke()
                             focusManager.clearFocus()
                         },
-                tint = if (isFocused) MainThemeColor.Olive else MainThemeColor.Black,
+                tint = MainThemeColor.Gray6,
             )
         }
     }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/search/SearchNavigateButton.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/search/SearchNavigateButton.kt
@@ -1,12 +1,12 @@
 package com.hm.picplz.ui.screen.main.search
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,12 +17,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hm.picplz.core.ui.R
+import androidx.compose.ui.unit.sp
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.feature.main.R as FeatureMainR
+
+private object SearchNavigateButtonDefaults {
+    val HorizontalPadding = 16.dp
+    val VerticalPadding = 10.dp
+    val CornerRadius = 50.dp
+    val StrokeWidth = 1.dp
+    val Gap = 10.dp
+    val IconSize = 20.dp
+    val TextLineHeight = 20.sp
+}
 
 @Composable
 fun SearchNavigateButton(
@@ -34,23 +46,37 @@ fun SearchNavigateButton(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(46.dp)
-                .clickable { onClick() }
-                .clip(RoundedCornerShape(50.dp))
+                .clip(RoundedCornerShape(SearchNavigateButtonDefaults.CornerRadius))
                 .background(MainThemeColor.White)
-                .padding(horizontal = 18.dp, vertical = 13.dp),
+                .border(
+                    width = SearchNavigateButtonDefaults.StrokeWidth,
+                    color = MainThemeColor.Gray6,
+                    shape = RoundedCornerShape(SearchNavigateButtonDefaults.CornerRadius),
+                )
+                .clickable { onClick() }
+                .padding(
+                    horizontal = SearchNavigateButtonDefaults.HorizontalPadding,
+                    vertical = SearchNavigateButtonDefaults.VerticalPadding,
+                ),
         contentAlignment = Alignment.Center,
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(SearchNavigateButtonDefaults.Gap),
         ) {
-            Text(text = placeholder, style = MainThemeFont.Body, color = MainThemeColor.Gray3)
+            Text(
+                text = placeholder,
+                style = MainThemeFont.Body.copy(lineHeight = SearchNavigateButtonDefaults.TextLineHeight),
+                color = MainThemeColor.Gray3,
+                maxLines = 1,
+                modifier = Modifier.weight(1f),
+            )
             Icon(
-                painter = painterResource(id = R.drawable.search),
-                contentDescription = "검색",
-                modifier = Modifier.size(14.dp),
+                painter = painterResource(id = FeatureMainR.drawable.main_search_icon),
+                contentDescription = stringResource(FeatureMainR.string.main_search_icon_content_description),
+                tint = MainThemeColor.Gray6,
+                modifier = Modifier.size(SearchNavigateButtonDefaults.IconSize),
             )
         }
     }

--- a/feature/main/src/main/res/drawable/main_search_icon.xml
+++ b/feature/main/src/main/res/drawable/main_search_icon.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="19dp"
+    android:viewportWidth="19"
+    android:viewportHeight="19">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8.55,8.55m-8.05,0a8.05,8.05 0,1 1,16.1 0a8.05,8.05 0,1 1,-16.1 0"
+        android:strokeColor="#2F3139"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M14.4,14.4L18,18"
+        android:strokeColor="#2F3139"
+        android:strokeWidth="1" />
+</vector>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -24,6 +24,120 @@
     <string name="equipment_setting_duplicate_device_message">이미 추가된 기기입니다.</string>
     <string name="equipment_setting_phone_brand_apple">애플</string>
     <string name="equipment_setting_phone_brand_samsung">삼성</string>
+    <string name="main_search_no_result">검색 결과가 없습니다</string>
+    <string name="main_search_empty_image_content_description">검색 결과 없음</string>
+    <string name="main_search_photographer_profile_content_description">%1$s 프로필 이미지</string>
+    <string name="main_search_result_metric_format">리뷰 %1$d · 팔로워 %2$d</string>
+    <string name="main_search_available_now">바로 가능</string>
+    <string name="main_search_available_later">일정 문의</string>
+    <string name="main_search_back_content_description">뒤로가기</string>
+    <string name="main_search_icon_content_description">검색</string>
+    <string name="main_search_clear_content_description">검색어 지우기</string>
+    <string name="main_search_placeholder">촬영을 하고 싶은 작가를 검색해보세요</string>
+    <string name="main_search_filter_region">촬영 지역</string>
+    <string name="main_search_filter_device">촬영 기기</string>
+    <string name="main_search_filter_mood">분위기 태그</string>
+    <string name="main_search_recent_title">최근 검색어</string>
+    <string name="main_search_recent_clear_all">모두 삭제</string>
+    <string name="main_search_popular_spot_title">인기 촬영지</string>
+    <string name="main_search_popular_spot_updated_at">04.22 12:00 기준</string>
+    <string name="main_search_result_active_status">바로촬영</string>
+    <string name="main_search_result_profile_content_description">%1$s 프로필 이미지</string>
+    <string name="main_search_result_empty">검색 결과가 없습니다</string>
+    <string name="main_search_result_empty_content_description">검색 결과 없음</string>
+    <string name="main_search_suggestion_location_dogok">서울 강남구 도곡동</string>
+    <string name="main_search_suggestion_location_dogok_one">서울 강남구 도곡1동</string>
+    <string name="main_search_suggestion_location_dogok_two">서울 강남구 도곡2동</string>
+    <string name="main_search_suggestion_photographer_kang_jueun">강주은 작가</string>
+    <string name="main_search_suggestion_photographer_dog">강아지 작가</string>
+    <string name="main_search_suggestion_tag_dog">강아지랑 촬영</string>
+    <string name="main_search_suggestion_tag_strong">강한 컨셉</string>
+    <string name="main_search_sort_popular">인기순</string>
+    <string name="main_search_sort_rating">별점순</string>
+    <string name="main_search_sort_follower">팔로워순</string>
+    <string name="main_home_title">홈</string>
+    <string name="main_region_all_seoul">서울 전체</string>
+    <string name="main_region_all_format">%1$s 전체</string>
+    <string name="main_region_selection_format">%1$s %2$s</string>
+    <string name="main_region_explore_title">지역별 작가 탐색</string>
+    <string name="main_region_apply">적용하기</string>
+    <string name="main_region_select_content_description">지역 선택</string>
+    <string name="main_location_rationale_title_prefix">주변 작가를 찾으려면</string>
+    <string name="main_location_rationale_title_permission">위치 권한</string>
+    <string name="main_location_rationale_title_suffix">이 필요해요</string>
+    <string name="main_location_rationale_description">현재 위치를 기준으로 가까운 작가와 포트폴리오를 보여드려요</string>
+    <string name="main_location_rationale_button">다음</string>
+    <string name="main_location_rationale_icon_desc">위치 권한 안내</string>
+    <string name="main_location_denied_title">위치 접근 권한이</string>
+    <string name="main_location_denied_subtitle">꺼져 있어요</string>
+    <string name="main_location_denied_guide_prefix">설정 → 앱 → [픽플즈]에서</string>
+    <string name="main_location_denied_guide_suffix">위치 권한을 활성화 해주세요</string>
+    <string name="main_location_denied_image_desc">위치 권한 꺼짐 이미지</string>
+    <string name="main_retry_button">다시 시도</string>
+    <string name="main_empty_title">주변 작가를 불러오지 못했어요</string>
+    <string name="main_empty_subtitle">잠시 후 다시 시도해주세요</string>
+    <string name="main_photographer_profile_content_description">%1$s 프로필 이미지</string>
+    <string name="main_portfolio_image_content_description">포트폴리오 대표 이미지</string>
+    <string name="main_photographer_active">바로촬영</string>
+    <string name="main_photographer_inactive">일정문의</string>
+    <string name="main_location_unknown">위치 정보 없음</string>
+    <string name="main_distance_format">%1$d m 근처</string>
+
+    <string-array name="main_region_tabs">
+        <item>서울</item>
+        <item>경기</item>
+        <item>인천</item>
+        <item>부산</item>
+        <item>제주</item>
+    </string-array>
+    <string-array name="main_region_districts_seoul">
+        <item>강남구</item>
+        <item>강동구</item>
+        <item>강북구</item>
+        <item>강서구</item>
+        <item>관악구</item>
+        <item>광진구</item>
+        <item>구로구</item>
+        <item>금천구</item>
+        <item>노원구</item>
+        <item>도봉구</item>
+        <item>동대문구</item>
+        <item>동작구</item>
+        <item>마포구</item>
+        <item>서대문구</item>
+        <item>서초구</item>
+        <item>성동구</item>
+        <item>성북구</item>
+        <item>송파구</item>
+        <item>양천구</item>
+        <item>영등포구</item>
+        <item>용산구</item>
+        <item>은평구</item>
+        <item>종로구</item>
+        <item>중구</item>
+        <item>중랑구</item>
+    </string-array>
+    <string-array name="main_region_districts_gyeonggi">
+        <item>성남시</item>
+        <item>수원시</item>
+        <item>고양시</item>
+        <item>용인시</item>
+        <item>부천시</item>
+    </string-array>
+    <string-array name="main_region_districts_incheon">
+        <item>연수구</item>
+        <item>남동구</item>
+        <item>부평구</item>
+    </string-array>
+    <string-array name="main_region_districts_busan">
+        <item>해운대구</item>
+        <item>수영구</item>
+        <item>부산진구</item>
+    </string-array>
+    <string-array name="main_region_districts_jeju">
+        <item>제주시</item>
+        <item>서귀포시</item>
+    </string-array>
 
     <string-array name="equipment_setting_apple_phone_models">
         <item>아이폰 15 Pro Max</item>

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducerTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducerTest.kt
@@ -1,0 +1,174 @@
+package com.hm.picplz.ui.screen.main
+
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainSearchReducerTest {
+    @Test
+    fun `starts empty with default recent and popular data`() {
+        val state = MainSearchState.idle()
+
+        assertEquals(SearchUiState.Empty, state.uiState)
+        assertEquals(listOf("연희동", "성수", "홍익대", "연남동", "송파구"), state.recentSearchQueries)
+        assertEquals(listOf("성수동", "연남동", "서교동", "합정동", "망원동"), state.popularSpots)
+        assertFalse(state.hasSearched)
+    }
+
+    @Test
+    fun `query change with non-empty focused text moves to typing and clears prior searched state`() {
+        val searchedState =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("연남동"),
+            )
+
+        val state =
+            MainSearchReducer.reduce(
+                searchedState.copy(isFocused = true),
+                MainSearchIntent.QueryChanged("성수"),
+            )
+
+        assertEquals(SearchUiState.Typing, state.uiState)
+        assertEquals("성수", state.query)
+        assertFalse(state.hasSearched)
+    }
+
+    @Test
+    fun `search submit with non-blank query moves to complete and adds recent once`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("도곡동"),
+            )
+
+        assertEquals(SearchUiState.Complete(query = "도곡동", hasResults = true), state.uiState)
+        assertEquals("도곡동", state.query)
+        assertTrue(state.hasSearched)
+        assertEquals(
+            listOf("도곡동", "연희동", "성수", "홍익대", "연남동", "송파구"),
+            state.recentSearchQueries,
+        )
+    }
+
+    @Test
+    fun `search submit with duplicate query does not duplicate recent`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("성수"),
+            )
+
+        assertEquals(1, state.recentSearchQueries.count { it == "성수" })
+        assertEquals(listOf("연희동", "성수", "홍익대", "연남동", "송파구"), state.recentSearchQueries)
+    }
+
+    @Test
+    fun `blank search moves to no-result complete without adding blank recent`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("   "),
+            )
+
+        assertEquals(SearchUiState.Complete(query = "", hasResults = false), state.uiState)
+        assertTrue(state.hasSearched)
+        assertFalse(state.recentSearchQueries.any { it.isBlank() })
+        assertEquals(listOf("연희동", "성수", "홍익대", "연남동", "송파구"), state.recentSearchQueries)
+    }
+
+    @Test
+    fun `non-empty search exposes deterministic photographer results`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("강남"),
+            )
+
+        assertTrue(state.uiState is SearchUiState.Complete)
+        assertEquals(3, state.results.size)
+        assertTrue(state.results.all { it.name.endsWith("작가") })
+    }
+
+    @Test
+    fun `ascii gangnam search exposes deterministic photographer results for adb input`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("gangnam"),
+            )
+
+        assertEquals(SearchUiState.Complete(query = "gangnam", hasResults = true), state.uiState)
+        assertEquals(3, state.results.size)
+    }
+
+    @Test
+    fun `no-match search exposes only empty result state`() {
+        val state =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("ㅁㄴㅇㄹ없는검색어"),
+            )
+
+        assertEquals(SearchUiState.Complete(query = "ㅁㄴㅇㄹ없는검색어", hasResults = false), state.uiState)
+        assertEquals(emptyList<MainSearchPhotographerItem>(), state.results)
+    }
+
+    @Test
+    fun `sort selection changes deterministic result order`() {
+        val searchedState =
+            MainSearchReducer.reduce(
+                stateWithNearbyPhotographers(),
+                MainSearchIntent.SearchSubmitted("강남"),
+            )
+
+        val followerSortedState =
+            MainSearchReducer.reduce(
+                searchedState,
+                MainSearchIntent.SortSelected(SortType.FOLLOWER),
+            )
+
+        assertEquals(SortType.FOLLOWER, followerSortedState.selectedSortType)
+        assertEquals(
+            followerSortedState.results.minBy { it.distance }.name,
+            followerSortedState.results.first().name,
+        )
+        assertFalse(searchedState.results.first().name == followerSortedState.results.first().name)
+    }
+
+    private fun stateWithNearbyPhotographers(): MainSearchState =
+        MainSearchState.idle().copy(
+            nearbyPhotographers =
+                listOf(
+                    MainSearchPhotographerItem(
+                        id = "gangnam-studio",
+                        name = "윤서 작가",
+                        profileImageUri = null,
+                        areaSummary = "서울 강남구 도곡동",
+                        isAvailableNow = true,
+                        moodTags = listOf("도시 감성", "프로필"),
+                        distance = 300,
+                    ),
+                    MainSearchPhotographerItem(
+                        id = "gangnam-film",
+                        name = "민재 작가",
+                        profileImageUri = null,
+                        areaSummary = "서울 강남구 역삼동",
+                        isAvailableNow = false,
+                        moodTags = listOf("필름 무드", "커플"),
+                        distance = 120,
+                    ),
+                    MainSearchPhotographerItem(
+                        id = "gangnam-pet",
+                        name = "가은 작가",
+                        profileImageUri = null,
+                        areaSummary = "서울 강남구 신사동",
+                        isAvailableNow = true,
+                        moodTags = listOf("반려동물", "자연광"),
+                        distance = 520,
+                    ),
+                ),
+        )
+}

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
@@ -1,0 +1,208 @@
+package com.hm.picplz.ui.screen.main
+
+import android.content.Context
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.KaKaoLoginResponse
+import com.hm.picplz.domain.model.KakaoUserInfo
+import com.hm.picplz.domain.model.LocationCoordinate
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.repository.AuthRepository
+import com.hm.picplz.domain.repository.LocationRepository
+import com.hm.picplz.domain.repository.MemberRepository
+import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import com.hm.picplz.ui.screen.photographer_main.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainSearchViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `query change keeps typing state without area lookup`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
+            viewModel.handleIntent(MainSearchIntent.QueryChanged("강"))
+            advanceUntilIdle()
+
+            assertEquals("강", viewModel.state.value.query)
+            assertEquals(SearchUiState.Typing, viewModel.state.value.uiState)
+        }
+
+    @Test
+    fun `blank query change keeps empty state`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
+            viewModel.handleIntent(MainSearchIntent.QueryChanged(""))
+            advanceUntilIdle()
+
+            assertEquals(SearchUiState.Empty, viewModel.state.value.uiState)
+        }
+
+    @Test
+    fun `search submit loads nearby photographers and filters results`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    locationRepository = FakeSearchLocationRepository(location = LocationCoordinate(37.5, 127.0)),
+                    photographerRepository =
+                        FakeSearchPhotographerRepository(
+                            nearbyResult =
+                                Result.success(
+                                    FilteredPhotographers(
+                                        active =
+                                            listOf(
+                                                Photographer(
+                                                    id = 1L,
+                                                    name = "유가영 작가",
+                                                    profileImageUri = null,
+                                                    isActive = true,
+                                                    distance = 100,
+                                                    photoMoods = listOf("필름"),
+                                                    activeAreas = listOf("서울 강남구 도곡동"),
+                                                ),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                )
+
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("강남"))
+            advanceUntilIdle()
+
+            assertEquals(SearchUiState.Complete(query = "강남", hasResults = true), viewModel.state.value.uiState)
+            assertEquals("유가영 작가", viewModel.state.value.results.single().name)
+        }
+
+    @Test
+    fun `search submit continues nearby lookup when member location update fails`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    locationRepository = FakeSearchLocationRepository(location = LocationCoordinate(37.5, 127.0)),
+                    memberRepository =
+                        FakeSearchMemberRepository(
+                            updateLocationResult = Result.failure(IllegalStateException()),
+                        ),
+                    photographerRepository =
+                        FakeSearchPhotographerRepository(
+                            nearbyResult =
+                                Result.success(
+                                    FilteredPhotographers(
+                                        active =
+                                            listOf(
+                                                Photographer(
+                                                    id = 1L,
+                                                    name = "유가영 작가",
+                                                    profileImageUri = null,
+                                                    isActive = true,
+                                                    distance = 100,
+                                                    photoMoods = listOf("필름"),
+                                                    activeAreas = listOf("서울 강남구 도곡동"),
+                                                ),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                )
+
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("강남"))
+            advanceUntilIdle()
+
+            assertEquals(SearchUiState.Complete(query = "강남", hasResults = true), viewModel.state.value.uiState)
+            assertEquals("유가영 작가", viewModel.state.value.results.single().name)
+        }
+
+    private fun createViewModel(
+        locationRepository: LocationRepository = FakeSearchLocationRepository(),
+        authRepository: AuthRepository = FakeSearchAuthRepository(),
+        memberRepository: MemberRepository = FakeSearchMemberRepository(),
+        photographerRepository: PhotographerRepository = FakeSearchPhotographerRepository(),
+    ): MainSearchViewModel =
+        MainSearchViewModel(
+            getCurrentLocationUseCase = GetCurrentLocationUseCase(locationRepository),
+            getCurrentMemberIdUseCase = GetCurrentMemberIdUseCase(authRepository),
+            updateMemberLocationUseCase = UpdateMemberLocationUseCase(memberRepository),
+            getNearbyPhotographersUseCase = GetNearbyPhotographersUseCase(photographerRepository),
+        )
+}
+
+private class FakeSearchLocationRepository(
+    private val location: LocationCoordinate? = null,
+) : LocationRepository {
+    override fun getCurrentLocation(
+        onLocationReceived: (LocationCoordinate) -> Unit,
+        onPermissionDenied: () -> Unit,
+    ) {
+        location?.let(onLocationReceived) ?: onPermissionDenied()
+    }
+}
+
+private class FakeSearchPhotographerRepository(
+    private val nearbyResult: AppResult<FilteredPhotographers> = Result.success(FilteredPhotographers()),
+) : PhotographerRepository {
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): AppResult<FilteredPhotographers> = nearbyResult
+
+    override suspend fun getPhotographerDetail(
+        photographerId: Long,
+        reviewSort: String,
+    ) = error("Not used")
+
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long) = error("Not used")
+
+    override suspend fun addPhotoMood(photoMood: String) = error("Not used")
+
+    override suspend fun deletePhotoMood(photoMood: String) = error("Not used")
+
+    override suspend fun getActiveAreas(photographerId: Long) = error("Not used")
+
+    override suspend fun updateActiveAreas(areas: List<com.hm.picplz.domain.model.Area>) = error("Not used")
+}
+
+private class FakeSearchAuthRepository(
+    private val memberId: Long? = 3L,
+) : AuthRepository {
+    override suspend fun loginWithKakao(context: Context): AppResult<KaKaoLoginResponse> = error("Not used")
+
+    override suspend fun getKakaoUserInfo(): AppResult<KakaoUserInfo> = error("Not used")
+
+    override suspend fun unlinkKakao(): AppResult<Unit> = error("Not used")
+
+    override fun isKakaoTalkLoginAvailable(context: Context): Boolean = error("Not used")
+
+    override fun getCurrentMemberId(): Long? = memberId
+}
+
+private class FakeSearchMemberRepository(
+    private val updateLocationResult: AppResult<Unit> = Result.success(Unit),
+) : MemberRepository {
+    override suspend fun checkNicknameAvailable(nickname: String) = error("Not used")
+
+    override suspend fun getMemberProfile(memberId: Long) = error("Not used")
+
+    override suspend fun updateMemberProfile(command: com.hm.picplz.domain.model.UpdateMemberProfileCommand) =
+        error("Not used")
+
+    override suspend fun updateMemberLocation(
+        memberId: Long,
+        location: LocationCoordinate,
+    ): AppResult<Unit> = updateLocationResult
+}

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainViewModelTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainViewModelTest.kt
@@ -1,0 +1,303 @@
+package com.hm.picplz.ui.screen.main
+
+import android.content.Context
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.KaKaoLoginResponse
+import com.hm.picplz.domain.model.KakaoUserInfo
+import com.hm.picplz.domain.model.LocationCoordinate
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.model.PortfolioSummary
+import com.hm.picplz.domain.repository.AuthRepository
+import com.hm.picplz.domain.repository.LocationRepository
+import com.hm.picplz.domain.repository.MemberRepository
+import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.repository.PortfolioRepository
+import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
+import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerPortfoliosUseCase
+import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import com.hm.picplz.ui.screen.photographer_main.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `first entry without permission shows rationale`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.handleIntent(MainIntent.EnterScreen(hasLocationPermission = false))
+
+            assertFalse(viewModel.state.value.locationPermissionGranted)
+            assertFalse(viewModel.state.value.hasRequestedPermission)
+            assertTrue(viewModel.state.value.homeItems.isEmpty())
+        }
+
+    @Test
+    fun `permission granted loads nearby photographers and first portfolios`() =
+        runTest {
+            val locationRepository = FakeLocationRepository(location = LocationCoordinate(37.5, 127.0))
+            val photographerRepository =
+                FakePhotographerRepository(
+                    nearbyResult =
+                        Result.success(
+                            FilteredPhotographers(
+                                active = (1L..6L).map { photographer(it) },
+                            ),
+                        ),
+                )
+            val portfolioRepository =
+                FakePortfolioRepository(
+                    results =
+                        (1L..5L).associateWith { id ->
+                            Result.success(
+                                listOf(
+                                    PortfolioSummary(
+                                        id = id,
+                                        representativeImage = "https://image/$id.jpg",
+                                        photoCount = 4,
+                                        location = "서울 강남구",
+                                        uploadDate = "2026-06-11",
+                                    ),
+                                ),
+                            )
+                        },
+                )
+            val viewModel =
+                createViewModel(
+                    locationRepository = locationRepository,
+                    photographerRepository = photographerRepository,
+                    portfolioRepository = portfolioRepository,
+                )
+
+            viewModel.handleIntent(MainIntent.LocationPermissionResult(granted = true))
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertTrue(state.locationPermissionGranted)
+            assertFalse(state.isLoading)
+            assertNull(state.errorMessage)
+            assertEquals(5, state.homeItems.size)
+            assertEquals("https://image/1.jpg", state.homeItems.first().portfolioImageUri)
+            assertEquals(listOf(1L, 2L, 3L, 4L, 5L), portfolioRepository.requestedPhotographerIds)
+        }
+
+    @Test
+    fun `nearby failure exposes empty retry state without local fallback`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    locationRepository = FakeLocationRepository(location = LocationCoordinate(37.5, 127.0)),
+                    photographerRepository =
+                        FakePhotographerRepository(
+                            nearbyResult = Result.failure(IllegalStateException("network")),
+                        ),
+                )
+
+            viewModel.handleIntent(MainIntent.LocationPermissionResult(granted = true))
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertFalse(state.isLoading)
+            assertTrue(state.homeItems.isEmpty())
+            assertEquals(MainLoadError.NearbyPhotographers, state.errorMessage)
+        }
+
+    @Test
+    fun `member location update failure does not block nearby photographers`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    locationRepository = FakeLocationRepository(location = LocationCoordinate(37.5, 127.0)),
+                    memberRepository =
+                        FakeMemberRepository(
+                            updateLocationResult = Result.failure(IllegalStateException()),
+                        ),
+                    photographerRepository =
+                        FakePhotographerRepository(
+                            nearbyResult =
+                                Result.success(
+                                    FilteredPhotographers(active = listOf(photographer(1L))),
+                                ),
+                        ),
+                )
+
+            viewModel.handleIntent(MainIntent.LocationPermissionResult(granted = true))
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertFalse(state.isLoading)
+            assertNull(state.errorMessage)
+            assertEquals("유가영 작가", state.homeItems.single().photographerName)
+        }
+
+    @Test
+    fun `portfolio failure keeps photographer with no image`() =
+        runTest {
+            val viewModel =
+                createViewModel(
+                    locationRepository = FakeLocationRepository(location = LocationCoordinate(37.5, 127.0)),
+                    photographerRepository =
+                        FakePhotographerRepository(
+                            nearbyResult =
+                                Result.success(
+                                    FilteredPhotographers(active = listOf(photographer(1L))),
+                                ),
+                        ),
+                    portfolioRepository =
+                        FakePortfolioRepository(
+                            results = mapOf(1L to Result.failure(IllegalStateException("network"))),
+                        ),
+                )
+
+            viewModel.handleIntent(MainIntent.LocationPermissionResult(granted = true))
+            advanceUntilIdle()
+
+            val item = viewModel.state.value.homeItems.single()
+            assertEquals("유가영 작가", item.photographerName)
+            assertNull(item.portfolioImageUri)
+        }
+
+    @Test
+    fun `search click emits search navigation side effect`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.handleIntent(MainIntent.SearchClicked)
+            advanceUntilIdle()
+
+            assertEquals(MainSideEffect.NavigateToSearch, viewModel.sideEffect.first())
+        }
+
+    @Test
+    fun `photographer click emits detail navigation side effect`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.handleIntent(MainIntent.PhotographerClicked(7L))
+            advanceUntilIdle()
+
+            assertEquals(MainSideEffect.NavigateToPhotographerDetail(7L), viewModel.sideEffect.first())
+        }
+
+    private fun createViewModel(
+        locationRepository: LocationRepository = FakeLocationRepository(),
+        authRepository: AuthRepository = FakeAuthRepository(),
+        memberRepository: MemberRepository = FakeMemberRepository(),
+        photographerRepository: PhotographerRepository = FakePhotographerRepository(),
+        portfolioRepository: PortfolioRepository = FakePortfolioRepository(),
+    ): MainViewModel =
+        MainViewModel(
+            getCurrentLocationUseCase = GetCurrentLocationUseCase(locationRepository),
+            getCurrentMemberIdUseCase = GetCurrentMemberIdUseCase(authRepository),
+            updateMemberLocationUseCase = UpdateMemberLocationUseCase(memberRepository),
+            getNearbyPhotographersUseCase = GetNearbyPhotographersUseCase(photographerRepository),
+            getPhotographerPortfoliosUseCase = GetPhotographerPortfoliosUseCase(portfolioRepository),
+        )
+}
+
+private class FakeLocationRepository(
+    private val location: LocationCoordinate? = null,
+) : LocationRepository {
+    override fun getCurrentLocation(
+        onLocationReceived: (LocationCoordinate) -> Unit,
+        onPermissionDenied: () -> Unit,
+    ) {
+        location?.let(onLocationReceived) ?: onPermissionDenied()
+    }
+}
+
+private class FakePhotographerRepository(
+    private val nearbyResult: AppResult<FilteredPhotographers> = Result.success(FilteredPhotographers()),
+) : PhotographerRepository {
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): AppResult<FilteredPhotographers> = nearbyResult
+
+    override suspend fun getPhotographerDetail(
+        photographerId: Long,
+        reviewSort: String,
+    ) = error("Not used")
+
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long) = error("Not used")
+
+    override suspend fun addPhotoMood(photoMood: String) = error("Not used")
+
+    override suspend fun deletePhotoMood(photoMood: String) = error("Not used")
+
+    override suspend fun getActiveAreas(photographerId: Long) = error("Not used")
+
+    override suspend fun updateActiveAreas(areas: List<com.hm.picplz.domain.model.Area>) = error("Not used")
+}
+
+private class FakeAuthRepository(
+    private val memberId: Long? = 3L,
+) : AuthRepository {
+    override suspend fun loginWithKakao(context: Context): AppResult<KaKaoLoginResponse> = error("Not used")
+
+    override suspend fun getKakaoUserInfo(): AppResult<KakaoUserInfo> = error("Not used")
+
+    override suspend fun unlinkKakao(): AppResult<Unit> = error("Not used")
+
+    override fun isKakaoTalkLoginAvailable(context: Context): Boolean = error("Not used")
+
+    override fun getCurrentMemberId(): Long? = memberId
+}
+
+private class FakeMemberRepository(
+    private val updateLocationResult: AppResult<Unit> = Result.success(Unit),
+) : MemberRepository {
+    override suspend fun checkNicknameAvailable(nickname: String) = error("Not used")
+
+    override suspend fun getMemberProfile(memberId: Long) = error("Not used")
+
+    override suspend fun updateMemberProfile(command: com.hm.picplz.domain.model.UpdateMemberProfileCommand) =
+        error("Not used")
+
+    override suspend fun updateMemberLocation(
+        memberId: Long,
+        location: LocationCoordinate,
+    ): AppResult<Unit> = updateLocationResult
+}
+
+private class FakePortfolioRepository(
+    private val results: Map<Long, AppResult<List<PortfolioSummary>>> = emptyMap(),
+) : PortfolioRepository {
+    val requestedPhotographerIds = mutableListOf<Long>()
+
+    override suspend fun getPhotographerPortfolios(
+        photographerId: Long,
+        page: Int,
+        size: Int,
+    ): AppResult<List<PortfolioSummary>> {
+        requestedPhotographerIds += photographerId
+        return results[photographerId] ?: Result.success(emptyList())
+    }
+}
+
+private fun photographer(id: Long): Photographer =
+    Photographer(
+        id = id,
+        name = "유가영 작가",
+        profileImageUri = null,
+        isActive = true,
+        distance = 120,
+        photoMoods = listOf("무드"),
+        activeAreas = listOf("서울 강남구"),
+    )

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionExploreBottomSheetStateTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/modalBottomSheet/RegionExploreBottomSheetStateTest.kt
@@ -1,0 +1,14 @@
+package com.hm.picplz.ui.screen.main.modalBottomSheet
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RegionExploreBottomSheetStateTest {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun `hidden transition is allowed so scrim tap and drag can dismiss sheet`() {
+        assertTrue(canRegionExploreSheetTransitionTo(SheetValue.Hidden))
+    }
+}


### PR DESCRIPTION
## Summary

- 로그인 및 고객 가입 완료 후 `MainActivity`의 사용자 정보를 갱신하고 고객 홈으로 진입하도록 랜딩 흐름을 정리했습니다.
- 고객 홈을 최신 Figma 기준의 지역 선택, 작가 검색 진입, 주변 작가 포트폴리오 피드 구조로 개편했습니다.
- 검색 입력, 입력 중 추천, 검색 완료, 결과 없음, 정렬 상태를 MVI로 분리하고 검색 결과 카드 UI를 구현했습니다.
- 위치 업데이트, 주변 작가, 작가별 포트폴리오 API를 data-domain-feature 경계에 맞춰 연결했습니다.
- Debug 빌드에서 검색 결과 목업을 직접 확인할 수 있는 Dev route를 추가했습니다.

## Background

로그인/회원가입 이후 고객이 진입하는 기존 홈과 검색 화면은 최신 디자인과 실제 사용자 흐름이 이어지지 않았습니다.
이번 PR은 고객 랜딩부터 홈 진입, 검색 입력, 검색 결과 확인까지 하나의 흐름으로 연결하고, 현재 백엔드에서 제공하는 주변 작가 API를 이용해 실제 데이터를 표시할 수 있도록 정리합니다.

Closes #192

## Changes

### app / navigation

- 로그인 성공 시 화면에서 `Main`으로 직접 이동하지 않고 사용자 정보를 갱신한 뒤 역할에 맞는 시작 화면을 결정합니다.
- 고객은 `Main`, 작가는 `PhotographerMainGraph`를 시작 화면으로 사용합니다.
- 고객 가입 완료 후 로그인 백스택을 제거하고 고객 홈으로 이동합니다.
- Debug 전용 `DevMainSearchResultPreview` route를 추가했습니다.

### customer home

- 위치 권한 안내, 권한 거부, 로딩, 결과 없음, 홈 피드 상태를 `MainState`로 분리했습니다.
- `MainViewModel`을 추가하고 사용자 액션을 `MainIntent`, 일회성 이동/권한 요청을 `Channel` 기반 `MainSideEffect`로 처리합니다.
- 현재 위치 기준 주변 작가를 조회하고 최대 5명의 대표 포트폴리오를 병렬로 불러옵니다.
- 홈 상단 지역 선택 및 검색바, 작가 프로필/대표 이미지/위치/업로드 날짜를 표시하는 고객 홈 카드를 구현했습니다.
- 지역 선택 바텀시트의 scrim 탭과 drag dismiss가 정상 동작하도록 sheet transition을 허용했습니다.
- 위치 권한 안내 UI를 `core:ui` 공통 컴포넌트로 분리했습니다.

### search flow

- `MainSearchState`, `MainSearchIntent`, `MainSearchReducer`, `MainSearchViewModel`로 검색 상태 전이를 분리했습니다.
- 검색창 포커스 및 입력 중에는 추천 목록을 표시하고, submit 이후에는 로딩/검색 결과/결과 없음 상태를 표시합니다.
- 검색 결과 카드에 88dp 썸네일, 작가명, 활동 지역, 바로촬영 상태, 가로 스크롤 분위기 태그를 적용했습니다.
- 태그는 오른쪽 패딩에 잘리지 않고 전체 목록을 가로 스크롤할 수 있습니다.
- 인기순/별점순/팔로워순 정렬 바텀시트를 연결했습니다.
- 검색 결과 목업 route를 Dev menu에 추가해 API 상태와 무관하게 UI를 검증할 수 있습니다.

### API / data layer

- `POST /members/location`으로 현재 사용자 위치를 업데이트합니다.
- `GET /members/location/nearby`로 반경 2km 주변 작가를 조회합니다.
- `GET /portfolios?photographerId=...`로 작가별 대표 포트폴리오를 조회합니다.
- API DTO는 `core:data`에 유지하고 mapper를 통해 domain model로 변환합니다.
- 주변 작가 응답의 nullable `photoMoods`와 `activeAreas`를 안전하게 빈 목록으로 변환합니다.
- Swagger에는 주변 작가 응답이 raw array로 표시되지만 실제 서버 응답은 `ApiResponse.data` 래퍼이므로 런타임 계약 기준으로 파싱하며 Source 테스트로 고정했습니다.

## Current Search Contract

현재 Swagger에는 작가명/지역/태그를 받는 전용 키워드 검색 API가 없습니다.
따라서 검색 submit 시 현재 위치 주변 작가 목록을 불러온 뒤 이름, 활동 지역, 분위기 태그를 클라이언트에서 필터링합니다.
입력 중 추천 목록은 UI 흐름 확인용 정적 데이터이며, 서버 자동완성 API가 생기면 후속 연동이 필요합니다.

## Test Scenario

### 고객 랜딩 및 홈

1. 기존 고객 계정으로 로그인합니다.
2. 사용자 정보 refresh 이후 고객 홈으로 이동하는지 확인합니다.
3. 위치 권한을 허용하고 주변 작가와 대표 포트폴리오가 표시되는지 확인합니다.
4. 위치 권한 거부 및 네트워크 실패 시 안내/재시도 상태가 표시되는지 확인합니다.
5. 지역명을 누른 뒤 scrim 탭 또는 drag로 바텀시트를 닫을 수 있는지 확인합니다.

### 검색

1. 홈 검색바를 눌러 검색 화면으로 이동합니다.
2. 검색어 입력 시 추천 목록이 표시되는지 확인합니다.
3. 검색을 submit하고 주변 작가 결과가 검색어로 필터링되는지 확인합니다.
4. 정렬 메뉴에서 정렬 기준을 변경하고 카드 순서가 갱신되는지 확인합니다.
5. 태그 목록을 가로 스크롤했을 때 마지막 태그와 오른쪽 여백이 잘리지 않는지 확인합니다.

### Debug UI

1. Debug 빌드 로그인 인트로 안내 영역을 5회 탭해 Dev menu로 진입합니다.
2. `MainSearch (검색완료 카드 목업)`을 선택합니다.
3. 기본 이미지, 바로촬영 상태, 여러 지역, 긴 태그 목록을 확인합니다.

## Verification

- [x] `./gradlew :feature:main:testDebugUnitTest :core:data:testDebugUnitTest :app:testDevDebugUnitTest`
- [x] `./gradlew :feature:main:ktlintCheck :core:data:ktlintCheck :app:ktlintCheck`
- [x] `./gradlew :feature:main:detekt :core:data:detekt :app:detekt`
- [x] `./gradlew :app:assembleDevDebug`
- [x] `./gradlew ktlintCheck detekt`
- [x] 정상 commit hook에서 전체 `ktlintCheck` + `detekt` 통과
- [x] 실제 Android 기기에서 Dev 검색 결과 목업 확인
- [x] 지역 바텀시트 scrim dismiss 및 drag dismiss 확인
- [x] 검색 결과 태그 가로 스크롤 및 마지막 태그 여백 확인
- [x] Swagger/OpenAPI에서 `/members/location`, `/members/location/nearby`, `/portfolios` 계약 확인

## Notes / Follow-up

- 전용 키워드 검색/자동완성 API가 추가되면 현재 클라이언트 필터링과 정적 추천 목록을 서버 검색으로 교체해야 합니다.
- 지역 바텀시트 선택값은 이번 PR에서 홈 표시 상태까지만 반영하며, 지역별 서버 필터링은 후속 API 계약이 필요합니다.
- 작가 가입 화면과 빠른촬영 화면의 별도 로컬 변경사항은 이번 PR에 포함하지 않았습니다.
