### PR TITLE
✨ 고객 예약 상세 화면 변경 피그마 반영

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -305,6 +305,9 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateToOrderDetail = { orderId ->
                 navController.navigate(OrderDetail(orderId = orderId))
             },
+            onNavigateToWriteReview = {
+                // TODO: 리뷰 작성 화면 구현 후 네비게이션 연결
+            },
         )
     }
 

--- a/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
@@ -10,6 +10,7 @@ object DateTimeUtil {
     private val dateFormat = SimpleDateFormat("yyyy년 MM월 dd일", Locale.KOREA)
     private val deadlineFormat = SimpleDateFormat("yyyy.MM.dd | hh:mm까지", Locale.KOREA)
     private val dateTimeFormat = SimpleDateFormat("MM월 dd일 hh:mm", Locale.KOREA)
+    private val reservationDateTimeFormat = SimpleDateFormat("yy.MM.dd a h:mm", Locale.KOREA)
 
     fun getFormattedTime(timestamp: Long): String {
         return timeFormat.format(Date(timestamp))
@@ -25,6 +26,13 @@ object DateTimeUtil {
 
     fun getFormattedDateTime(timestamp: Long): String {
         return dateTimeFormat.format(Date(timestamp))
+    }
+
+    /**
+     * 예약 확정 일시 표기용 포맷. (예: "25.12.12 오후 2:00")
+     */
+    fun getFormattedReservationDateTime(timestamp: Long): String {
+        return reservationDateTimeFormat.format(Date(timestamp))
     }
 
     fun getTimeAgoText(timestamp: Long): String {

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationIntent.kt
@@ -3,7 +3,7 @@ package com.hm.picplz.ui.screen.detail_reservation
 sealed interface DetailReservationIntent {
     data object NavigateToChat : DetailReservationIntent
 
-    data object NavigateToHistory : DetailReservationIntent
+    data object NavigateToWriteReview : DetailReservationIntent
 
     data object ConfirmReservation : DetailReservationIntent
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -11,10 +11,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.common.util.DateTimeUtil
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
@@ -22,6 +25,7 @@ import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSect
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationStatusHeader
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import com.hm.picplz.ui.theme.MainThemeColor
 
 @Suppress("LongParameterList")
@@ -30,6 +34,7 @@ fun DetailReservationScreen(
     onNavigateBack: () -> Unit,
     onNavigateCancelReservationConfirm: () -> Unit,
     onNavigateToOrderDetail: (orderId: String) -> Unit,
+    onNavigateToWriteReview: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
@@ -45,6 +50,8 @@ fun DetailReservationScreen(
                 }
 
                 is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail(state.orderId)
+
+                is DetailReservationSideEffect.NavigateToWriteReview -> onNavigateToWriteReview()
             }
         }
     }
@@ -55,11 +62,11 @@ fun DetailReservationScreen(
         onChatClick = {
             viewModel.handelIntent(DetailReservationIntent.NavigateToChat)
         },
-        onHistoryClick = {
-            viewModel.handelIntent(DetailReservationIntent.NavigateToHistory)
-        },
-        onConfirmClick = {
+        onDealCompleteClick = {
             viewModel.handelIntent(DetailReservationIntent.ConfirmReservation)
+        },
+        onReviewClick = {
+            viewModel.handelIntent(DetailReservationIntent.NavigateToWriteReview)
         },
         onCancelClick = {
             viewModel.handelIntent(DetailReservationIntent.ShowCancelDialog)
@@ -87,8 +94,8 @@ fun DetailReservationScreen(
 private fun DetailReservationScreen(
     state: DetailReservationState,
     onChatClick: () -> Unit,
-    onHistoryClick: () -> Unit,
-    onConfirmClick: () -> Unit,
+    onDealCompleteClick: () -> Unit,
+    onReviewClick: () -> Unit,
     onCancelClick: () -> Unit,
     onCancelDialogDismiss: () -> Unit,
     onCancelDialogConfirm: () -> Unit,
@@ -150,20 +157,40 @@ private fun DetailReservationScreen(
                 }
 
                 item {
-                    ReservationInfoSection(modifier = Modifier.padding(top = 28.dp, bottom = 24.dp))
+                    ReservationInfoSection(
+                        modifier = Modifier.padding(top = 28.dp, bottom = 24.dp),
+                        shootingDateText = state.reservationStatus.shootingDateText(state.confirmedDateTimeMillis),
+                    )
                 }
             }
 
             DetailReservationBottomButtons(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
                 currentReservationStatus = state.reservationStatus,
+                hasWrittenReview = state.hasWrittenReview,
                 onChatClick = onChatClick,
-                onHistoryClick = onHistoryClick,
-                onConfirmClick = onConfirmClick,
+                onDealCompleteClick = onDealCompleteClick,
+                onReviewClick = onReviewClick,
             )
         }
     }
 }
+
+/**
+ * 촬영 일시 표시 텍스트.
+ * 일시 미확정(예약 대기) 단계는 "작가와 협의", 확정 이후(촬영 진행/거래 완료)는 확정된 일시를 표시합니다.
+ */
+@Composable
+private fun ReservationStatus.shootingDateText(confirmedDateTimeMillis: Long): String =
+    when (this) {
+        ReservationStatus.RESERVED,
+        ReservationStatus.COMPLETED,
+        -> DateTimeUtil.getFormattedReservationDateTime(confirmedDateTimeMillis)
+
+        ReservationStatus.WAITING_APPROVAL,
+        ReservationStatus.WAITING_SCHEDULE,
+        -> stringResource(R.string.reservation_schedule_tbd)
+    }
 
 @Suppress("UnusedPrivateMember")
 @Preview
@@ -172,8 +199,8 @@ private fun DetailReservationScreenPreview() {
     DetailReservationScreen(
         state = DetailReservationState(),
         onChatClick = {},
-        onHistoryClick = {},
-        onConfirmClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
         onCancelClick = {},
         onCancelDialogDismiss = {},
         onCancelDialogConfirm = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationSideEffect.kt
@@ -6,4 +6,6 @@ sealed interface DetailReservationSideEffect {
     data object NavigateToCancelReservationConfirm : DetailReservationSideEffect
 
     data object NavigateToOrderDetail : DetailReservationSideEffect
+
+    data object NavigateToWriteReview : DetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -6,6 +6,7 @@ import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 data class DetailReservationState(
     val orderId: String = "",
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
+    val hasWrittenReview: Boolean = false,
     val showCancelDialog: Boolean = false,
     val shootingDateTimeMillis: Long = System.currentTimeMillis(),
     val confirmedDateTimeMillis: Long = System.currentTimeMillis(),

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -41,10 +41,15 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
         when (intent) {
             // 상태 변경 확인 테스트를 위한 코드입니다.
             is DetailReservationIntent.NavigateToChat,
-            is DetailReservationIntent.NavigateToHistory,
             is DetailReservationIntent.ConfirmReservation,
             -> {
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
+            }
+
+            is DetailReservationIntent.NavigateToWriteReview -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
+                }
             }
 
             is DetailReservationIntent.ShowCancelDialog -> {
@@ -74,7 +79,7 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                 viewModelScope.launch {
                     when (state.value.reservationStatus) {
                         ReservationStatus.WAITING_APPROVAL,
-                        ReservationStatus.WAITING_PAYMENT,
+                        ReservationStatus.WAITING_SCHEDULE,
                         -> {
                             _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservationConfirm)
                         }
@@ -117,8 +122,8 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
     // 상태 변경 확인 테스트를 위한 코드입니다.
     private fun ReservationStatus.next(): ReservationStatus =
         when (this) {
-            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_PAYMENT
-            ReservationStatus.WAITING_PAYMENT -> ReservationStatus.RESERVED
+            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_SCHEDULE
+            ReservationStatus.WAITING_SCHEDULE -> ReservationStatus.RESERVED
             ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
             ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/DetailReservationBottomButtons.kt
@@ -14,37 +14,44 @@ import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 
+/**
+ * 고객 예약 상세 하단 버튼.
+ * - WAITING_APPROVAL: 채팅 바로가기 단독
+ * - WAITING_SCHEDULE / RESERVED: 거래 완료하기(보조) + 채팅 바로가기(주)
+ * - COMPLETED: 리뷰 쓰기(보조, 작성 완료 시 비활성) + 채팅 바로가기(주)
+ */
 @Composable
 fun DetailReservationBottomButtons(
     currentReservationStatus: ReservationStatus,
+    hasWrittenReview: Boolean,
     onChatClick: () -> Unit,
-    onHistoryClick: () -> Unit,
-    onConfirmClick: () -> Unit,
+    onDealCompleteClick: () -> Unit,
+    onReviewClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (currentReservationStatus) {
-        ReservationStatus.WAITING_APPROVAL,
-        ReservationStatus.WAITING_PAYMENT,
-        -> {
+        ReservationStatus.WAITING_APPROVAL -> {
             ChatButton(
                 modifier = modifier,
                 onClick = onChatClick,
             )
         }
 
-        ReservationStatus.RESERVED -> {
+        ReservationStatus.WAITING_SCHEDULE,
+        ReservationStatus.RESERVED,
+        -> {
             Row(
                 modifier = modifier,
                 horizontalArrangement = Arrangement.spacedBy(5.dp),
             ) {
-                HistoryButton(
+                DealCompleteButton(
                     modifier = Modifier.weight(1f),
-                    onClick = onHistoryClick,
+                    onClick = onDealCompleteClick,
                 )
 
-                ConfirmButton(
+                ChatButton(
                     modifier = Modifier.weight(1f),
-                    onClick = onConfirmClick,
+                    onClick = onChatClick,
                 )
             }
         }
@@ -54,9 +61,10 @@ fun DetailReservationBottomButtons(
                 modifier = modifier,
                 horizontalArrangement = Arrangement.spacedBy(5.dp),
             ) {
-                HistoryButton(
+                ReviewButton(
                     modifier = Modifier.weight(1f),
-                    onClick = onHistoryClick,
+                    enabled = !hasWrittenReview,
+                    onClick = onReviewClick,
                 )
 
                 ChatButton(
@@ -66,18 +74,6 @@ fun DetailReservationBottomButtons(
             }
         }
     }
-}
-
-@Composable
-fun ReservationApproveButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    CommonBottomButton(
-        modifier = modifier,
-        text = stringResource(R.string.reservation_button_reservation_approve),
-        onClick = onClick,
-    )
 }
 
 @Composable
@@ -93,25 +89,27 @@ private fun ChatButton(
 }
 
 @Composable
-private fun HistoryButton(
+private fun DealCompleteButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     CommonBottomOutlinedButton(
         modifier = modifier,
-        text = stringResource(R.string.reservation_button_history),
+        text = stringResource(R.string.reservation_button_deal_complete),
         onClick = onClick,
     )
 }
 
 @Composable
-private fun ConfirmButton(
+private fun ReviewButton(
+    enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    CommonBottomButton(
+    CommonBottomOutlinedButton(
         modifier = modifier,
-        text = stringResource(R.string.reservation_button_confirm),
+        text = stringResource(R.string.reservation_button_review),
+        enabled = enabled,
         onClick = onClick,
     )
 }
@@ -121,20 +119,22 @@ private fun ConfirmButton(
 private fun DetailReservationBottomButtonsWaitingApprovalPreview() {
     DetailReservationBottomButtons(
         currentReservationStatus = ReservationStatus.WAITING_APPROVAL,
+        hasWrittenReview = false,
         onChatClick = {},
-        onHistoryClick = {},
-        onConfirmClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
     )
 }
 
 @Preview
 @Composable
-private fun DetailReservationBottomButtonsWaitingPaymentPreview() {
+private fun DetailReservationBottomButtonsWaitingSchedulePreview() {
     DetailReservationBottomButtons(
-        currentReservationStatus = ReservationStatus.WAITING_PAYMENT,
+        currentReservationStatus = ReservationStatus.WAITING_SCHEDULE,
+        hasWrittenReview = false,
         onChatClick = {},
-        onHistoryClick = {},
-        onConfirmClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
     )
 }
 
@@ -143,9 +143,10 @@ private fun DetailReservationBottomButtonsWaitingPaymentPreview() {
 private fun DetailReservationBottomButtonsReservedPreview() {
     DetailReservationBottomButtons(
         currentReservationStatus = ReservationStatus.RESERVED,
+        hasWrittenReview = false,
         onChatClick = {},
-        onHistoryClick = {},
-        onConfirmClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
     )
 }
 
@@ -154,8 +155,21 @@ private fun DetailReservationBottomButtonsReservedPreview() {
 private fun DetailReservationBottomButtonsCompletedPreview() {
     DetailReservationBottomButtons(
         currentReservationStatus = ReservationStatus.COMPLETED,
+        hasWrittenReview = false,
         onChatClick = {},
-        onHistoryClick = {},
-        onConfirmClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun DetailReservationBottomButtonsCompletedReviewedPreview() {
+    DetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.COMPLETED,
+        hasWrittenReview = true,
+        onChatClick = {},
+        onDealCompleteClick = {},
+        onReviewClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/PhotographerDetailReservationBottomButtons.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/PhotographerDetailReservationBottomButtons.kt
@@ -1,0 +1,144 @@
+@file:Suppress("UnusedPrivateMember")
+
+package com.hm.picplz.ui.screen.detail_reservation.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonBottomOutlinedButton
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+
+/**
+ * 작가 예약 상세 하단 버튼.
+ * 고객 버튼과 구성이 다르므로 별도 관리하며, 현재는 기존 동작을 유지합니다.
+ * (작가 피그마 확보 후 후속 이슈에서 정리)
+ */
+@Composable
+fun PhotographerDetailReservationBottomButtons(
+    currentReservationStatus: ReservationStatus,
+    onChatClick: () -> Unit,
+    onHistoryClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (currentReservationStatus) {
+        ReservationStatus.WAITING_APPROVAL,
+        ReservationStatus.WAITING_SCHEDULE,
+        -> {
+            ChatButton(
+                modifier = modifier,
+                onClick = onChatClick,
+            )
+        }
+
+        ReservationStatus.RESERVED -> {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                HistoryButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onHistoryClick,
+                )
+
+                ConfirmButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onConfirmClick,
+                )
+            }
+        }
+
+        ReservationStatus.COMPLETED -> {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                HistoryButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onHistoryClick,
+                )
+
+                ChatButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onChatClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ReservationApproveButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_reservation_approve),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun ChatButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_chat),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun HistoryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomOutlinedButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_history),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun ConfirmButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    CommonBottomButton(
+        modifier = modifier,
+        text = stringResource(R.string.reservation_button_confirm),
+        onClick = onClick,
+    )
+}
+
+@Preview
+@Composable
+private fun PhotographerDetailReservationBottomButtonsReservedPreview() {
+    PhotographerDetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.RESERVED,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun PhotographerDetailReservationBottomButtonsCompletedPreview() {
+    PhotographerDetailReservationBottomButtons(
+        currentReservationStatus = ReservationStatus.COMPLETED,
+        onChatClick = {},
+        onHistoryClick = {},
+        onConfirmClick = {},
+    )
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationCancelDialog.kt
@@ -135,7 +135,7 @@ private fun getDescriptionText(
         }
 
         ReservationStatus.WAITING_APPROVAL,
-        ReservationStatus.WAITING_PAYMENT,
+        ReservationStatus.WAITING_SCHEDULE,
         -> {
             stringResource(R.string.reservation_cancel_dialog_desc_waiting_approval)
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
@@ -19,6 +19,7 @@ import com.hm.picplz.ui.theme.MainThemeFont.Body
 fun ReservationInfoSection(
     modifier: Modifier = Modifier,
     customerName: String = "",
+    shootingDateText: String = "작가와 협의",
 ) {
     Column(
         modifier = modifier,
@@ -40,7 +41,7 @@ fun ReservationInfoSection(
         )
         ReservationInfoItem(
             title = "촬영 일시",
-            description = "작가와 협의",
+            description = shootingDateText,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationStatusHeader.kt
@@ -44,8 +44,8 @@ fun ReservationStatusHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         ReservationStatusInfo(
-            title = stringResource(currentReservationStatus.titleResId),
-            description = stringResource(currentReservationStatus.descriptionResId),
+            title = stringResource(currentReservationStatus.customerTitleResId),
+            description = stringResource(currentReservationStatus.customerDescriptionResId),
         )
 
         if (currentReservationStatus.showCancelButton()) {
@@ -69,8 +69,8 @@ fun PhotographerReservationStatusHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         ReservationStatusInfo(
-            title = stringResource(currentReservationStatus.titleResId),
-            description = stringResource(currentReservationStatus.descriptionResId),
+            title = stringResource(currentReservationStatus.photographerTitleResId),
+            description = stringResource(currentReservationStatus.photographerDescriptionResId),
         )
 
         when (currentReservationStatus) {
@@ -81,7 +81,7 @@ fun PhotographerReservationStatusHeader(
                 )
             }
 
-            ReservationStatus.WAITING_PAYMENT,
+            ReservationStatus.WAITING_SCHEDULE,
             ReservationStatus.RESERVED,
             -> {
                 ReservationCancelButton(
@@ -175,9 +175,9 @@ private fun ReservationStatusHeaderWaitingApprovalPreview() {
 
 @Preview
 @Composable
-private fun ReservationStatusHeaderWaitingPaymentPreview() {
+private fun ReservationStatusHeaderWaitingSchedulePreview() {
     ReservationStatusHeader(
-        currentReservationStatus = ReservationStatus.WAITING_PAYMENT,
+        currentReservationStatus = ReservationStatus.WAITING_SCHEDULE,
         onCancelClick = { },
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStatus.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/model/ReservationStatus.kt
@@ -3,30 +3,46 @@ package com.hm.picplz.ui.screen.detail_reservation.model
 import androidx.annotation.StringRes
 import com.hm.picplz.feature.reservation.R
 
+/**
+ * 예약 상태.
+ *
+ * 헤더 타이틀/설명은 고객·작가 관점이 다르므로 role별 리소스를 각각 보유합니다.
+ * (고객 화면: customer*, 작가 화면: photographer*)
+ */
 enum class ReservationStatus(
     val step: ReservationStep,
-    @get:StringRes val titleResId: Int,
-    @get:StringRes val descriptionResId: Int,
+    @get:StringRes val customerTitleResId: Int,
+    @get:StringRes val customerDescriptionResId: Int,
+    @get:StringRes val photographerTitleResId: Int,
+    @get:StringRes val photographerDescriptionResId: Int,
 ) {
     WAITING_APPROVAL(
         step = ReservationStep.WAITING,
-        titleResId = R.string.reservation_status_title_waiting_approval,
-        descriptionResId = R.string.reservation_status_description_waiting_approval,
+        customerTitleResId = R.string.reservation_status_title_waiting_approval,
+        customerDescriptionResId = R.string.reservation_status_description_waiting_approval,
+        photographerTitleResId = R.string.reservation_status_title_waiting_approval,
+        photographerDescriptionResId = R.string.reservation_status_description_waiting_approval,
     ),
-    WAITING_PAYMENT(
+    WAITING_SCHEDULE(
         step = ReservationStep.WAITING,
-        titleResId = R.string.reservation_status_title_waiting_payment,
-        descriptionResId = R.string.reservation_status_description_waiting_payment,
+        customerTitleResId = R.string.reservation_status_customer_title_waiting_schedule,
+        customerDescriptionResId = R.string.reservation_status_customer_description_waiting_schedule,
+        photographerTitleResId = R.string.reservation_status_title_waiting_payment,
+        photographerDescriptionResId = R.string.reservation_status_description_waiting_payment,
     ),
     RESERVED(
         step = ReservationStep.IN_PROGRESS,
-        titleResId = R.string.reservation_status_title_reserved,
-        descriptionResId = R.string.reservation_status_description_reserved,
+        customerTitleResId = R.string.reservation_status_customer_title_reserved,
+        customerDescriptionResId = R.string.reservation_status_description_reserved,
+        photographerTitleResId = R.string.reservation_status_title_reserved,
+        photographerDescriptionResId = R.string.reservation_status_description_reserved,
     ),
     COMPLETED(
         step = ReservationStep.CONFIRMED,
-        titleResId = R.string.reservation_status_title_completed,
-        descriptionResId = R.string.reservation_status_description_completed,
+        customerTitleResId = R.string.reservation_status_customer_title_completed,
+        customerDescriptionResId = R.string.reservation_status_description_completed,
+        photographerTitleResId = R.string.reservation_status_title_completed,
+        photographerDescriptionResId = R.string.reservation_status_description_completed,
     ),
     ;
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
+import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerDetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerReservationStatusHeader
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationApproveButton
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
@@ -172,7 +172,7 @@ private fun PhotographerDetailReservationScreen(
             }
 
             if (state.reservationStatus != ReservationStatus.WAITING_APPROVAL) {
-                DetailReservationBottomButtons(
+                PhotographerDetailReservationBottomButtons(
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 48.dp),
                     currentReservationStatus = state.reservationStatus,
                     onChatClick = onChatClick,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -74,7 +74,7 @@ class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel()
                 viewModelScope.launch {
                     when (state.value.reservationStatus) {
                         ReservationStatus.WAITING_APPROVAL,
-                        ReservationStatus.WAITING_PAYMENT,
+                        ReservationStatus.WAITING_SCHEDULE,
                         -> {
                             _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToRejectReservationConfirm)
                         }
@@ -117,8 +117,8 @@ class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel()
     // 상태 변경 확인 테스트를 위한 코드입니다.
     private fun ReservationStatus.next(): ReservationStatus =
         when (this) {
-            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_PAYMENT
-            ReservationStatus.WAITING_PAYMENT -> ReservationStatus.RESERVED
+            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_SCHEDULE
+            ReservationStatus.WAITING_SCHEDULE -> ReservationStatus.RESERVED
             ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
             ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
         }

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -2,21 +2,39 @@
 <resources>
     <string name="reservation_cancel">예약 취소</string>
     <string name="reservation_reject">예약 거절</string>
+    <!-- 진행 스텝 (고객·작가 공통) -->
     <string name="reservation_step_waiting">예약 대기</string>
     <string name="reservation_step_in_progress">촬영 진행</string>
-    <string name="reservation_step_confirmed">거래 확정</string>
+    <string name="reservation_step_confirmed">거래 완료</string>
+
+    <!-- 예약 상태 헤더 - 공통 -->
     <string name="reservation_status_title_waiting_approval">예약 승인 대기중…</string>
-    <string name="reservation_status_title_waiting_payment">결제 및 촬영 일시 확정 대기중…</string>
-    <string name="reservation_status_title_reserved">예약 확정</string>
-    <string name="reservation_status_title_completed">거래 확정</string>
-    <string name="reservation_status_description_waiting_approval">n분 이내로 승인되지 않으면 자동 취소됩니다.</string>
-    <string name="reservation_status_description_waiting_payment">결제 및 촬영 일시 확정을 진행해 주세요.</string>
+    <string name="reservation_status_description_waiting_approval">24시간 이내로 승인되지 않으면 자동 취소됩니다.</string>
     <string name="reservation_status_description_reserved">작가와 촬영을 진행해주세요!</string>
     <string name="reservation_status_description_completed">이미 완료된 촬영입니다.</string>
+
+    <!-- 예약 상태 헤더 - 고객 -->
+    <string name="reservation_status_customer_title_waiting_schedule">일시 확정 대기중…</string>
+    <string name="reservation_status_customer_description_waiting_schedule">촬영 일시를 확정해 주세요.</string>
+    <string name="reservation_status_customer_title_reserved">촬영 진행중…</string>
+    <string name="reservation_status_customer_title_completed">거래 완료</string>
+
+    <!-- 예약 상태 헤더 - 작가 (기존 유지, 작가 피그마 확보 후 후속 정리) -->
+    <string name="reservation_status_title_waiting_payment">결제 및 촬영 일시 확정 대기중…</string>
+    <string name="reservation_status_description_waiting_payment">결제 및 촬영 일시 확정을 진행해 주세요.</string>
+    <string name="reservation_status_title_reserved">예약 확정</string>
+    <string name="reservation_status_title_completed">거래 확정</string>
+
+    <!-- 하단 버튼 -->
     <string name="reservation_button_chat">채팅 바로가기</string>
     <string name="reservation_button_history">내역 보기</string>
     <string name="reservation_button_confirm">거래 확정하기</string>
+    <string name="reservation_button_deal_complete">거래 완료하기</string>
+    <string name="reservation_button_review">리뷰 쓰기</string>
     <string name="reservation_button_reservation_approve">예약 승인</string>
+
+    <!-- 촬영 일시 미확정 -->
+    <string name="reservation_schedule_tbd">작가와 협의</string>
 
     <!-- 예약 취소 다이얼로그 -->
     <string name="reservation_cancel_dialog_title">예약을 취소하시겠습니까?</string>


### PR DESCRIPTION
## 개요
변경된 피그마에 맞춰 **고객 기준 예약 정보 확인 화면(`detail_reservation`)** 을 업데이트합니다.
화면은 이미 구현돼 있어 바뀐 부분(델타)만 반영했고, 작가 화면과 공유되던 부분은 role별로 분리해 **작가 화면 동작을 그대로 유지**했습니다.

## 변경 사항

### ♻️ 고객/작가 role 분리 (작가 화면 동결)
- 예약 상태 헤더 타이틀/설명을 고객·작가 role별 리소스로 분리 (작가 문구 유지)
- 하단 버튼을 고객용 / 작가용(`PhotographerDetailReservationBottomButtons`)으로 분리
- 결제 단계 제거 반영: `WAITING_PAYMENT` → `WAITING_SCHEDULE` 리네임

### ✨ 고객 화면 새 피그마 반영
- 진행 스텝 `거래 확정` → `거래 완료`, 상태별 타이틀/버튼 재구성 (거래 완료하기 / 리뷰 쓰기 + 채팅 바로가기)
- 리뷰 작성 여부에 따른 `리뷰 쓰기` 버튼 활성/비활성 + 네비게이션 (리뷰 작성 화면 미구현 → placeholder)
- 촬영 일시 확정/미확정 동적 바인딩 (`DateTimeUtil` 예약 일시 포맷터 추가)

## 스크린샷 (실기기 검증)

| 예약 승인 대기중 | 일시 확정 대기중 | 촬영 진행중 |
|:---:|:---:|:---:|
| <img src="https://raw.githubusercontent.com/Picplz/picplz-android/pr-assets/feat-200/screenshots/04_waiting_approval.png" width="230"/> | <img src="https://raw.githubusercontent.com/Picplz/picplz-android/pr-assets/feat-200/screenshots/05_waiting_schedule.png" width="230"/> | <img src="https://raw.githubusercontent.com/Picplz/picplz-android/pr-assets/feat-200/screenshots/03_reserved.png" width="230"/> |

| 거래 완료 | 거래 완료 (리뷰 작성됨) |
|:---:|:---:|
| <img src="https://raw.githubusercontent.com/Picplz/picplz-android/pr-assets/feat-200/screenshots/01_completed.png" width="230"/> | <img src="https://raw.githubusercontent.com/Picplz/picplz-android/pr-assets/feat-200/screenshots/02_completed_reviewed.png" width="230"/> |

> ℹ️ "거래 완료(리뷰 작성됨)"의 리뷰 쓰기 비활성 상태는 리뷰 작성 화면이 아직 없어, 확인용 임시 토글로 캡처했습니다. (해당 임시 코드는 커밋에 미포함)

## 남은 후속 (이슈 #200 참고)
- 리뷰 작성 화면 구현 후 네비게이션 연결
- 작가 기준 화면 문구/버튼은 작가 피그마 확보 후 별도 이슈
- 결제 제거에 따른 취소 다이얼로그 환불 문구 파급은 범위 제외

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #200
