### PR TITLE
✨ 작가 예약 취소 플로우 새 피그마 반영

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
@@ -33,6 +33,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographerKeywordEdit
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
+import com.hm.picplz.navigation.model.PhotographerCancelReservation
 import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.PhotographerMainGraph
@@ -64,6 +65,7 @@ private val authRequiredRoutes: List<KClass<out Any>> =
         CancelReservationConfirm::class,
         OrderDetail::class,
         CancelReservation::class,
+        PhotographerCancelReservation::class,
     )
 
 @Composable

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -40,6 +40,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographerKeywordEdit
 import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
+import com.hm.picplz.navigation.model.PhotographerCancelReservation
 import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.Reservation
@@ -69,6 +70,7 @@ import com.hm.picplz.ui.screen.my_page.MyPageScreen
 import com.hm.picplz.ui.screen.my_page.MyPageShootingHistoryScreen
 import com.hm.picplz.ui.screen.my_page.MyReviewScreen
 import com.hm.picplz.ui.screen.order_detail.OrderDetailScreen
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReservationScreen
 import com.hm.picplz.ui.screen.photographer_chat_room.PhotographerChatRoomScreen
 import com.hm.picplz.ui.screen.photographer_detail_reservation.PhotographerDetailReservationScreen
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainViewModel
@@ -325,17 +327,27 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateBack = {
                 navController.popBackStack()
             },
-            onNavigateRejectReservationConfirm = {
-                // TODO
-            },
-            onNavigateToOrderDetail = { orderId ->
-                navController.navigate(OrderDetail(orderId = orderId))
+            onNavigateToCancelReservation = { orderId ->
+                navController.navigate(PhotographerCancelReservation(orderId = orderId))
             },
         )
     }
 
-    composable<CancelReservationConfirm> {
+    composable<PhotographerCancelReservation> {
+        PhotographerCancelReservationScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            onNavigateToCancelConfirm = {
+                navController.navigate(CancelReservationConfirm(isPhotographer = true))
+            },
+        )
+    }
+
+    composable<CancelReservationConfirm> { backStackEntry ->
+        val args = backStackEntry.toRoute<CancelReservationConfirm>()
         CancelReservationConfirmScreen(
+            isPhotographer = args.isPhotographer,
             onNavigateBack = {
                 navController.popBackStack()
             },
@@ -365,7 +377,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 navController.popBackStack()
             },
             onNavigateToCancelConfirm = {
-                navController.navigate(CancelReservationConfirm)
+                navController.navigate(CancelReservationConfirm(isPhotographer = false))
             },
         )
     }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -170,13 +170,16 @@ data object DetailReservation : NavigationRoute
 data object PhotographerDetailReservation : NavigationRoute
 
 @Serializable
-data object CancelReservationConfirm : NavigationRoute
+data class CancelReservationConfirm(val isPhotographer: Boolean = false) : NavigationRoute
 
 @Serializable
 data class OrderDetail(val orderId: String) : NavigationRoute
 
 @Serializable
 data class CancelReservation(val orderId: String) : NavigationRoute
+
+@Serializable
+data class PhotographerCancelReservation(val orderId: String) : NavigationRoute
 
 @Serializable
 data class PhotographerChatRoom(val roomId: String) : NavigationRoute

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation_confirm/CancelReservationConfirmScreen.kt
@@ -28,6 +28,7 @@ import com.hm.picplz.core.ui.R as CoreR
 @Composable
 fun CancelReservationConfirmScreen(
     modifier: Modifier = Modifier,
+    isPhotographer: Boolean = false,
     onNavigateBack: () -> Unit,
     onNavigateHome: () -> Unit,
     viewModel: CancelReservationConfirmViewModel = hiltViewModel(),
@@ -44,6 +45,7 @@ fun CancelReservationConfirmScreen(
 
     CancelReservationConfirmScreenContent(
         modifier = modifier,
+        isPhotographer = isPhotographer,
         onNavigateBack = onNavigateBack,
         onHistoryClick = { viewModel.handleIntent(CancelReservationConfirmIntent.NavigateToHistory) },
         onHomeClick = { viewModel.handleIntent(CancelReservationConfirmIntent.NavigateToHome) },
@@ -54,6 +56,7 @@ fun CancelReservationConfirmScreen(
 private fun CancelReservationConfirmScreenContent(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
+    isPhotographer: Boolean = false,
     onHistoryClick: () -> Unit = {},
     onHomeClick: () -> Unit = {},
 ) {
@@ -83,10 +86,11 @@ private fun CancelReservationConfirmScreenContent(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            CancelReservationGuide()
+            CancelReservationGuide(isPhotographer = isPhotographer)
 
             CancelReservationButtons(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 64.dp, bottom = 48.dp),
+                isPhotographer = isPhotographer,
                 onHistoryClick = onHistoryClick,
                 onHomeClick = onHomeClick,
             )
@@ -133,12 +137,22 @@ private fun CancelReservationDescription(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun CancelReservationGuide(modifier: Modifier = Modifier) {
+private fun CancelReservationGuide(
+    isPhotographer: Boolean,
+    modifier: Modifier = Modifier,
+) {
     Text(
         modifier =
             modifier
                 .padding(horizontal = 16.dp),
-        text = stringResource(R.string.cancel_reservation_guide),
+        text =
+            stringResource(
+                if (isPhotographer) {
+                    R.string.cancel_reservation_guide_photographer
+                } else {
+                    R.string.cancel_reservation_guide
+                },
+            ),
         style = pretendardTypography.bodyMedium,
         color = MainThemeColor.Gray4,
     )
@@ -146,10 +160,22 @@ private fun CancelReservationGuide(modifier: Modifier = Modifier) {
 
 @Composable
 private fun CancelReservationButtons(
+    isPhotographer: Boolean,
     onHistoryClick: () -> Unit,
     onHomeClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    if (isPhotographer) {
+        // 작가 취소 완료: "취소 내역 확인하기" 단일 버튼
+        // TODO: '받은 예약 > 완료됨' 탭 라우트 연결 시 onHomeClick 대신 해당 목적지로 이동
+        CommonBottomButton(
+            modifier = modifier.fillMaxWidth(),
+            text = stringResource(R.string.cancel_reservation_button_check_history),
+            onClick = onHomeClick,
+        )
+        return
+    }
+
     Row(
         modifier =
             modifier

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReason.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReason.kt
@@ -1,0 +1,17 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+import com.hm.picplz.feature.reservation.R
+
+/**
+ * 작가 예약 취소 사유. 고객 취소 사유([com.hm.picplz.ui.screen.cancel_reservation.CancelReason])와
+ * 문구가 다르기 때문에 별도로 정의합니다.
+ */
+enum class PhotographerCancelReason(val stringRes: Int) {
+    SCHEDULE(R.string.photographer_cancel_reason_schedule),
+    HEALTH(R.string.photographer_cancel_reason_health),
+    CUSTOMER_RESPONSE(R.string.photographer_cancel_reason_customer_response),
+    MISTAKE(R.string.photographer_cancel_reason_mistake),
+    EQUIPMENT(R.string.photographer_cancel_reason_equipment),
+    EXTERNAL(R.string.photographer_cancel_reason_external),
+    DIRECT_INPUT(R.string.photographer_cancel_reason_direct_input),
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationIntent.kt
@@ -1,0 +1,26 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+sealed interface PhotographerCancelReservationIntent {
+    data class ToggleReason(val reason: PhotographerCancelReason) : PhotographerCancelReservationIntent
+
+    data class UpdateDirectInput(val text: String) : PhotographerCancelReservationIntent
+
+    data class SetAgreedWithCustomer(val agreed: Boolean) : PhotographerCancelReservationIntent
+
+    data class SetAgreedToPolicy(val agreed: Boolean) : PhotographerCancelReservationIntent
+
+    /** 사유 입력(1/2) → 취소 규정(2/2) */
+    data object OnNextClick : PhotographerCancelReservationIntent
+
+    /** 취소 규정(2/2)의 "예약 취소" 버튼 → 확인 다이얼로그 노출 */
+    data object OnSubmitClick : PhotographerCancelReservationIntent
+
+    /** 확인 다이얼로그 "취소할게요" */
+    data object OnConfirmDialogConfirm : PhotographerCancelReservationIntent
+
+    /** 확인 다이얼로그 "아니오" · 바깥 영역 터치 */
+    data object OnConfirmDialogDismiss : PhotographerCancelReservationIntent
+
+    /** 상단 뒤로가기 (2단계면 1단계로, 1단계면 화면 종료) */
+    data object OnBackClick : PhotographerCancelReservationIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
@@ -1,0 +1,261 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.composable.CheckboxWithLabel
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReservationState.Step
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.composable.PhotographerCancelPolicyContent
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.composable.PhotographerCancelReasonContent
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.composable.PhotographerCancelStepIndicator
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun PhotographerCancelReservationScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToCancelConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PhotographerCancelReservationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    BackHandler {
+        viewModel.handleIntent(PhotographerCancelReservationIntent.OnBackClick)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                PhotographerCancelReservationSideEffect.NavigateBack -> onNavigateBack()
+                PhotographerCancelReservationSideEffect.NavigateToCancelConfirm -> onNavigateToCancelConfirm()
+            }
+        }
+    }
+
+    PhotographerCancelReservationScreenContent(
+        modifier = modifier,
+        state = state,
+        onBackClick = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnBackClick) },
+        onReasonToggle = { reason ->
+            viewModel.handleIntent(PhotographerCancelReservationIntent.ToggleReason(reason))
+        },
+        onDirectInputChange = { text ->
+            viewModel.handleIntent(PhotographerCancelReservationIntent.UpdateDirectInput(text))
+        },
+        onAgreedWithCustomerChange = { agreed ->
+            viewModel.handleIntent(PhotographerCancelReservationIntent.SetAgreedWithCustomer(agreed))
+        },
+        onAgreedToPolicyChange = { agreed ->
+            viewModel.handleIntent(PhotographerCancelReservationIntent.SetAgreedToPolicy(agreed))
+        },
+        onNextClick = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnNextClick) },
+        onSubmitClick = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnSubmitClick) },
+        onDialogConfirm = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnConfirmDialogConfirm) },
+        onDialogDismiss = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnConfirmDialogDismiss) },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun PhotographerCancelReservationScreenContent(
+    state: PhotographerCancelReservationState,
+    onBackClick: () -> Unit,
+    onReasonToggle: (PhotographerCancelReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    onAgreedWithCustomerChange: (Boolean) -> Unit,
+    onAgreedToPolicyChange: (Boolean) -> Unit,
+    onNextClick: () -> Unit,
+    onSubmitClick: () -> Unit,
+    onDialogConfirm: () -> Unit,
+    onDialogDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonTopBar(
+                text = stringResource(R.string.photographer_cancel_reservation_top_bar_title),
+                onClickBack = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+        ) {
+            PhotographerCancelStepIndicator(
+                currentStep = state.currentStep,
+                modifier = Modifier.padding(start = 16.dp, top = 8.dp),
+            )
+
+            when (state.currentStep) {
+                Step.REASON -> {
+                    PhotographerCancelReasonContent(
+                        modifier = Modifier.weight(1f),
+                        selectedReasons = state.selectedReasons,
+                        directInputText = state.directInputText,
+                        onReasonToggle = onReasonToggle,
+                        onDirectInputChange = onDirectInputChange,
+                    )
+
+                    CheckboxWithLabel(
+                        text = stringResource(R.string.photographer_cancel_reason_agreement),
+                        isSelected = state.agreedWithCustomer,
+                        onToggle = { onAgreedWithCustomerChange(!state.agreedWithCustomer) },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+
+                    CommonBottomButton(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
+                        text = stringResource(R.string.photographer_cancel_reason_button_next),
+                        onClick = onNextClick,
+                        enabled = state.isReasonStepValid(),
+                    )
+                }
+
+                Step.POLICY -> {
+                    PhotographerCancelPolicyContent(
+                        modifier = Modifier.weight(1f),
+                    )
+
+                    CheckboxWithLabel(
+                        text = stringResource(R.string.photographer_cancel_policy_agreement),
+                        isSelected = state.agreedToPolicy,
+                        onToggle = { onAgreedToPolicyChange(!state.agreedToPolicy) },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+
+                    CommonBottomButton(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
+                        text = stringResource(R.string.photographer_cancel_policy_button_submit),
+                        onClick = onSubmitClick,
+                        enabled = state.isPolicyStepValid(),
+                    )
+                }
+            }
+        }
+
+        if (state.showConfirmDialog) {
+            PhotographerCancelConfirmDialog(
+                onConfirm = onDialogConfirm,
+                onDismiss = onDialogDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerCancelConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    CommonButtonModal(
+        onDismissRequest = onDismiss,
+        cancelText = stringResource(R.string.photographer_cancel_dialog_button_no),
+        confirmText = stringResource(R.string.photographer_cancel_dialog_button_yes),
+        onCancel = onDismiss,
+        onConfirm = onConfirm,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.photographer_cancel_dialog_title),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.photographer_cancel_dialog_desc),
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelReservationReasonPreview() {
+    PicplzTheme {
+        PhotographerCancelReservationScreenContent(
+            state =
+                PhotographerCancelReservationState(
+                    orderId = "order123",
+                    currentStep = Step.REASON,
+                    selectedReasons = setOf(PhotographerCancelReason.SCHEDULE),
+                ),
+            onBackClick = {},
+            onReasonToggle = {},
+            onDirectInputChange = {},
+            onAgreedWithCustomerChange = {},
+            onAgreedToPolicyChange = {},
+            onNextClick = {},
+            onSubmitClick = {},
+            onDialogConfirm = {},
+            onDialogDismiss = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelReservationPolicyPreview() {
+    PicplzTheme {
+        PhotographerCancelReservationScreenContent(
+            state =
+                PhotographerCancelReservationState(
+                    orderId = "order123",
+                    currentStep = Step.POLICY,
+                    agreedToPolicy = true,
+                ),
+            onBackClick = {},
+            onReasonToggle = {},
+            onDirectInputChange = {},
+            onAgreedWithCustomerChange = {},
+            onAgreedToPolicyChange = {},
+            onNextClick = {},
+            onSubmitClick = {},
+            onDialogConfirm = {},
+            onDialogDismiss = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationSideEffect.kt
@@ -1,0 +1,7 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+sealed interface PhotographerCancelReservationSideEffect {
+    data object NavigateBack : PhotographerCancelReservationSideEffect
+
+    data object NavigateToCancelConfirm : PhotographerCancelReservationSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationState.kt
@@ -1,0 +1,31 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+data class PhotographerCancelReservationState(
+    val orderId: String = "",
+    val currentStep: Step = Step.REASON,
+    val selectedReasons: Set<PhotographerCancelReason> = emptySet(),
+    val directInputText: String = "",
+    /** 1페이지 하단 "고객과 취소에 대해 사전 합의를 진행했어요." 체크 여부 */
+    val agreedWithCustomer: Boolean = false,
+    /** 2페이지 하단 "위 내용을 모두 확인하였으며, 이에 동의합니다." 체크 여부 */
+    val agreedToPolicy: Boolean = false,
+    val showConfirmDialog: Boolean = false,
+    val isLoading: Boolean = false,
+) {
+    /** 사유 입력(1/2) 단계의 "다음" 활성화 조건 */
+    fun isReasonStepValid(): Boolean =
+        selectedReasons.isNotEmpty() && (
+            selectedReasons.any { it != PhotographerCancelReason.DIRECT_INPUT } || // 직접 입력 외 사유가 있거나
+                directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
+        )
+
+    /** 취소 규정(2/2) 단계의 "예약 취소" 활성화 조건 */
+    fun isPolicyStepValid(): Boolean = agreedToPolicy
+
+    enum class Step { REASON, POLICY }
+
+    companion object {
+        fun idle(orderId: String): PhotographerCancelReservationState =
+            PhotographerCancelReservationState(orderId = orderId)
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationViewModel.kt
@@ -1,0 +1,93 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.PhotographerCancelReservation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val CANCEL_REASON_MAX_LENGTH = 100
+
+@HiltViewModel
+class PhotographerCancelReservationViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val orderId: String = savedStateHandle.toRoute<PhotographerCancelReservation>().orderId
+
+        private val _state = MutableStateFlow(PhotographerCancelReservationState.idle(orderId))
+        val state: StateFlow<PhotographerCancelReservationState> = _state.asStateFlow()
+
+        private val _sideEffect = MutableSharedFlow<PhotographerCancelReservationSideEffect>()
+        val sideEffect: SharedFlow<PhotographerCancelReservationSideEffect> = _sideEffect.asSharedFlow()
+
+        fun handleIntent(intent: PhotographerCancelReservationIntent) {
+            when (intent) {
+                is PhotographerCancelReservationIntent.ToggleReason -> {
+                    _state.update { currentState ->
+                        val newReasons = currentState.selectedReasons.toMutableSet()
+                        if (!newReasons.remove(intent.reason)) {
+                            newReasons.add(intent.reason)
+                        }
+                        currentState.copy(selectedReasons = newReasons)
+                    }
+                }
+
+                is PhotographerCancelReservationIntent.UpdateDirectInput -> {
+                    _state.update { it.copy(directInputText = intent.text.take(CANCEL_REASON_MAX_LENGTH)) }
+                }
+
+                is PhotographerCancelReservationIntent.SetAgreedWithCustomer -> {
+                    _state.update { it.copy(agreedWithCustomer = intent.agreed) }
+                }
+
+                is PhotographerCancelReservationIntent.SetAgreedToPolicy -> {
+                    _state.update { it.copy(agreedToPolicy = intent.agreed) }
+                }
+
+                PhotographerCancelReservationIntent.OnNextClick -> {
+                    _state.update { it.copy(currentStep = PhotographerCancelReservationState.Step.POLICY) }
+                }
+
+                PhotographerCancelReservationIntent.OnSubmitClick -> {
+                    _state.update { it.copy(showConfirmDialog = true) }
+                }
+
+                PhotographerCancelReservationIntent.OnConfirmDialogDismiss -> {
+                    _state.update { it.copy(showConfirmDialog = false) }
+                }
+
+                PhotographerCancelReservationIntent.OnConfirmDialogConfirm -> {
+                    _state.update { it.copy(showConfirmDialog = false) }
+                    // TODO: 취소 사유·사전 합의 여부 전송 API 연동
+                    emitSideEffect(PhotographerCancelReservationSideEffect.NavigateToCancelConfirm)
+                }
+
+                PhotographerCancelReservationIntent.OnBackClick -> {
+                    val currentStep = _state.value.currentStep
+                    if (currentStep == PhotographerCancelReservationState.Step.POLICY) {
+                        _state.update { it.copy(currentStep = PhotographerCancelReservationState.Step.REASON) }
+                    } else {
+                        emitSideEffect(PhotographerCancelReservationSideEffect.NavigateBack)
+                    }
+                }
+            }
+        }
+
+        private fun emitSideEffect(sideEffect: PhotographerCancelReservationSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.emit(sideEffect)
+            }
+        }
+    }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/CancelPenaltyTable.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/CancelPenaltyTable.kt
@@ -1,0 +1,141 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+/**
+ * 작가 취소 페널티 부여 기준 표. "고객과 사전 합의됨" 여부에 따른 경고 부여 기준을 안내합니다.
+ */
+@Composable
+fun CancelPenaltyTable(modifier: Modifier = Modifier) {
+    val rows =
+        listOf(
+            stringResource(R.string.photographer_cancel_policy_table_not_agreed) to
+                stringResource(R.string.photographer_cancel_policy_table_not_agreed_penalty),
+            stringResource(R.string.photographer_cancel_policy_table_agreed) to
+                stringResource(R.string.photographer_cancel_policy_table_agreed_penalty),
+        )
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(
+                        width = 1.dp,
+                        color = MainThemeColor.Gray3,
+                        shape = RoundedCornerShape(8.dp),
+                    ),
+        ) {
+            // 헤더
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Max)
+                        .background(MainThemeColor.Black),
+            ) {
+                HeaderCell(
+                    text = stringResource(R.string.photographer_cancel_policy_table_header_situation),
+                    weight = 0.6f,
+                )
+                HeaderCell(
+                    text = stringResource(R.string.photographer_cancel_policy_table_header_penalty),
+                    weight = 0.4f,
+                )
+            }
+
+            // 각 행
+            rows.forEach { (situation, penalty) ->
+                HorizontalDivider(color = MainThemeColor.Gray3, thickness = 1.dp)
+
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(IntrinsicSize.Max),
+                ) {
+                    BodyCell(text = situation, weight = 0.6f)
+                    VerticalDivider(color = MainThemeColor.Gray3, thickness = 1.dp)
+                    BodyCell(text = penalty, weight = 0.4f)
+                }
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.photographer_cancel_policy_table_note),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Red,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun RowScope.HeaderCell(
+    text: String,
+    weight: Float,
+    textColor: Color = MainThemeColor.White,
+) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .weight(weight)
+                .padding(vertical = 12.dp, horizontal = 8.dp),
+        color = textColor,
+        style = MainThemeFont.BodyBold,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+private fun RowScope.BodyCell(
+    text: String,
+    weight: Float,
+    textColor: Color = MainThemeColor.Gray4,
+) {
+    Text(
+        text = text,
+        modifier =
+            Modifier
+                .weight(weight)
+                .padding(vertical = 12.dp, horizontal = 8.dp),
+        color = textColor,
+        style = MainThemeFont.Caption,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CancelPenaltyTablePreview() {
+    PicplzTheme {
+        CancelPenaltyTable(modifier = Modifier.padding(16.dp))
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelPolicyContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelPolicyContent.kt
@@ -1,0 +1,103 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun PhotographerCancelPolicyContent(modifier: Modifier = Modifier) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.photographer_cancel_policy_title),
+            style = MainThemeFont.Title,
+            modifier = Modifier.padding(top = 24.dp, bottom = 24.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.photographer_cancel_policy_penalty_criteria_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        CancelPenaltyTable()
+
+        Text(
+            text = stringResource(R.string.photographer_cancel_policy_guide_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(top = 28.dp, bottom = 12.dp),
+        )
+
+        GuideLabel(text = stringResource(R.string.photographer_cancel_policy_guide_activity_label))
+        GuideBullet(text = stringResource(R.string.photographer_cancel_policy_guide_activity_1))
+        GuideBullet(text = stringResource(R.string.photographer_cancel_policy_guide_activity_2))
+
+        GuideLabel(
+            text = stringResource(R.string.photographer_cancel_policy_guide_system_label),
+            modifier = Modifier.padding(top = 8.dp),
+        )
+        GuideBullet(text = stringResource(R.string.photographer_cancel_policy_guide_system_1))
+    }
+}
+
+@Composable
+private fun GuideLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MainThemeFont.BodyBold,
+        color = MainThemeColor.Black,
+        modifier = modifier.padding(bottom = 4.dp),
+    )
+}
+
+@Composable
+private fun GuideBullet(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(bottom = 4.dp),
+    ) {
+        Text(
+            text = "• ",
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+        Text(
+            text = text,
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+        )
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelPolicyContentPreview() {
+    PicplzTheme {
+        PhotographerCancelPolicyContent()
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelReasonContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelReasonContent.kt
@@ -1,0 +1,113 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation.composable
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.composable.CheckboxWithLabel
+import com.hm.picplz.ui.screen.cancel_reservation.composable.DirectInputTextField
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReason
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun PhotographerCancelReasonContent(
+    selectedReasons: Set<PhotographerCancelReason>,
+    directInputText: String,
+    onReasonToggle: (PhotographerCancelReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Text(
+            text = stringResource(R.string.photographer_cancel_reason_title),
+            style = MainThemeFont.Title,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = 22.dp),
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.photographer_cancel_reason_subtitle),
+                    style = MainThemeFont.Caption,
+                    color = MainThemeColor.Green120,
+                    modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
+                )
+            }
+
+            items(PhotographerCancelReason.entries) { reason ->
+                CheckboxWithLabel(
+                    text = stringResource(reason.stringRes),
+                    isSelected = selectedReasons.contains(reason),
+                    onToggle = { onReasonToggle(reason) },
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 20.dp),
+                )
+            }
+
+            if (selectedReasons.contains(PhotographerCancelReason.DIRECT_INPUT)) {
+                item {
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = expandVertically(),
+                        exit = shrinkVertically(),
+                    ) {
+                        DirectInputTextField(
+                            value = directInputText,
+                            onValueChange = onDirectInputChange,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelReasonContentPreviewEmpty() {
+    PicplzTheme {
+        PhotographerCancelReasonContent(
+            selectedReasons = emptySet(),
+            directInputText = "",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelReasonContentPreviewWithDirectInput() {
+    PicplzTheme {
+        PhotographerCancelReasonContent(
+            selectedReasons =
+                setOf(
+                    PhotographerCancelReason.SCHEDULE,
+                    PhotographerCancelReason.DIRECT_INPUT,
+                ),
+            directInputText = "장비 점검이 필요해 부득이하게 취소합니다.",
+            onReasonToggle = {},
+            onDirectInputChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelStepIndicator.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/composable/PhotographerCancelStepIndicator.kt
@@ -1,0 +1,73 @@
+package com.hm.picplz.ui.screen.photographer_cancel_reservation.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReservationState.Step
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun PhotographerCancelStepIndicator(
+    currentStep: Step,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        StepCircle(number = 1, isActive = currentStep == Step.REASON)
+        StepCircle(number = 2, isActive = currentStep == Step.POLICY)
+    }
+}
+
+@Composable
+private fun StepCircle(
+    number: Int,
+    isActive: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(24.dp)
+                .background(
+                    color = if (isActive) MainThemeColor.Olive else MainThemeColor.Gray2,
+                    shape = CircleShape,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = number.toString(),
+            style = MainThemeFont.BodyBold,
+            color = if (isActive) MainThemeColor.White else MainThemeColor.Gray3,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelStepIndicatorReasonPreview() {
+    PicplzTheme {
+        PhotographerCancelStepIndicator(currentStep = Step.REASON)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerCancelStepIndicatorPolicyPreview() {
+    PicplzTheme {
+        PhotographerCancelStepIndicator(currentStep = Step.POLICY)
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
@@ -7,15 +7,8 @@ sealed interface PhotographerDetailReservationIntent {
 
     data object ConfirmReservation : PhotographerDetailReservationIntent
 
-    data object ShowCancelDialog : PhotographerDetailReservationIntent
-
-    data object DismissCancelDialog : PhotographerDetailReservationIntent
-
-    data object ConfirmCancel : PhotographerDetailReservationIntent
-
-    data object ShowRefundPolicyDialog : PhotographerDetailReservationIntent
-
-    data object DismissRefundPolicyTooltip : PhotographerDetailReservationIntent
+    /** "예약 취소" 버튼 → 작가 취소 사유 입력 플로우로 이동 */
+    data object NavigateToCancelReservation : PhotographerDetailReservationIntent
 
     data object NavigateBack : PhotographerDetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -22,19 +22,15 @@ import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMa
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerDetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerReservationStatusHeader
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationApproveButton
-import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationInfoSection
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgressStepper
-import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationRefundPolicyDialog
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import com.hm.picplz.ui.theme.MainThemeColor
 
-@Suppress("LongParameterList")
 @Composable
 fun PhotographerDetailReservationScreen(
     onNavigateBack: () -> Unit,
-    onNavigateRejectReservationConfirm: () -> Unit,
-    onNavigateToOrderDetail: (orderId: String) -> Unit,
+    onNavigateToCancelReservation: (orderId: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PhotographerDetailReservationViewModel = hiltViewModel(),
 ) {
@@ -45,14 +41,8 @@ fun PhotographerDetailReservationScreen(
             when (sideEffect) {
                 is PhotographerDetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
 
-                is PhotographerDetailReservationSideEffect.NavigateToRejectReservationConfirm -> {
-                    onNavigateRejectReservationConfirm()
-                }
-
-                is PhotographerDetailReservationSideEffect.NavigateToOrderDetail ->
-                    onNavigateToOrderDetail(
-                        state.orderId,
-                    )
+                is PhotographerDetailReservationSideEffect.NavigateToCancelReservation ->
+                    onNavigateToCancelReservation(sideEffect.orderId)
             }
         }
     }
@@ -67,25 +57,13 @@ fun PhotographerDetailReservationScreen(
             viewModel.handelIntent(PhotographerDetailReservationIntent.ConfirmReservation)
         },
         onCancelClick = {
-            viewModel.handelIntent(PhotographerDetailReservationIntent.ShowCancelDialog)
+            viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateToCancelReservation)
         },
         onCancelReject = {
-            // TODO
+            // TODO: 예약 거절 플로우 연결 (별도 작업)
         },
         onReservationApproveClick = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.ApproveReservation)
-        },
-        onCancelDialogDismiss = {
-            viewModel.handelIntent(PhotographerDetailReservationIntent.DismissCancelDialog)
-        },
-        onCancelDialogConfirm = {
-            viewModel.handelIntent(PhotographerDetailReservationIntent.ConfirmCancel)
-        },
-        onInfoClick = {
-            viewModel.handelIntent(PhotographerDetailReservationIntent.ShowRefundPolicyDialog)
-        },
-        onRefundPolicyDismiss = {
-            viewModel.handelIntent(PhotographerDetailReservationIntent.DismissRefundPolicyTooltip)
         },
         onCloseClick = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateBack)
@@ -102,10 +80,6 @@ private fun PhotographerDetailReservationScreen(
     onCancelClick: () -> Unit,
     onCancelReject: () -> Unit,
     onReservationApproveClick: () -> Unit,
-    onCancelDialogDismiss: () -> Unit,
-    onCancelDialogConfirm: () -> Unit,
-    onInfoClick: () -> Unit,
-    onRefundPolicyDismiss: () -> Unit,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -113,23 +87,6 @@ private fun PhotographerDetailReservationScreen(
         modifier = modifier,
         containerColor = MainThemeColor.White,
     ) { innerPadding ->
-        if (state.showCancelDialog) {
-            ReservationCancelDialog(
-                status = state.reservationStatus,
-                refundCondition = state.refundCondition,
-                onDismiss = onCancelDialogDismiss,
-                onCancel = onCancelDialogDismiss,
-                onConfirm = onCancelDialogConfirm,
-                onInfoClick = onInfoClick,
-            )
-        }
-
-        if (state.showRefundPolicyTooltip) {
-            ReservationRefundPolicyDialog(
-                onDismissRequest = onRefundPolicyDismiss,
-            )
-        }
-
         Column(modifier = Modifier.padding(innerPadding)) {
             DetailReservationMap(
                 modifier =
@@ -215,10 +172,6 @@ private fun PhotographerDetailReservationScreenPreview() {
         onCancelClick = {},
         onCancelReject = {},
         onReservationApproveClick = {},
-        onCancelDialogDismiss = {},
-        onCancelDialogConfirm = {},
-        onInfoClick = {},
-        onRefundPolicyDismiss = {},
         onCloseClick = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
@@ -3,7 +3,5 @@ package com.hm.picplz.ui.screen.photographer_detail_reservation
 sealed interface PhotographerDetailReservationSideEffect {
     data object NavigateToPrev : PhotographerDetailReservationSideEffect
 
-    data object NavigateToRejectReservationConfirm : PhotographerDetailReservationSideEffect
-
-    data object NavigateToOrderDetail : PhotographerDetailReservationSideEffect
+    data class NavigateToCancelReservation(val orderId: String) : PhotographerDetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
@@ -1,16 +1,12 @@
 package com.hm.picplz.ui.screen.photographer_detail_reservation
 
-import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 
 data class PhotographerDetailReservationState(
     val orderId: String = "",
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
-    val showCancelDialog: Boolean = false,
     val shootingDateTimeMillis: Long = System.currentTimeMillis(),
     val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
-    val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
-    val showRefundPolicyTooltip: Boolean = false,
     val customerName: String = DUMMY_CUSTOMER_NAME,
 )
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -3,7 +3,6 @@ package com.hm.picplz.ui.screen.photographer_detail_reservation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hm.picplz.common.util.DateTimeUtil
-import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -47,61 +46,12 @@ class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel()
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
             }
 
-            is PhotographerDetailReservationIntent.ShowCancelDialog -> {
-                val currentState = _state.value
-                val refundCondition =
-                    RefundCondition.calculate(
-                        currentMillis = System.currentTimeMillis(),
-                        shootingMillis = currentState.shootingDateTimeMillis,
-                        confirmedMillis = currentState.confirmedDateTimeMillis,
-                    )
-
-                _state.update {
-                    it.copy(
-                        showCancelDialog = true,
-                        refundCondition = refundCondition,
-                    )
-                }
-            }
-
-            is PhotographerDetailReservationIntent.DismissCancelDialog -> {
-                _state.update { it.copy(showCancelDialog = false) }
-            }
-
-            is PhotographerDetailReservationIntent.ConfirmCancel -> {
-                _state.update { it.copy(showCancelDialog = false) }
-
+            is PhotographerDetailReservationIntent.NavigateToCancelReservation -> {
                 viewModelScope.launch {
-                    when (state.value.reservationStatus) {
-                        ReservationStatus.WAITING_APPROVAL,
-                        ReservationStatus.WAITING_SCHEDULE,
-                        -> {
-                            _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToRejectReservationConfirm)
-                        }
-
-                        ReservationStatus.RESERVED,
-                        ReservationStatus.COMPLETED,
-                        -> {
-                            _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToOrderDetail)
-                        }
-                    }
-                }
-            }
-
-            is PhotographerDetailReservationIntent.ShowRefundPolicyDialog -> {
-                _state.update {
-                    it.copy(
-                        showRefundPolicyTooltip = true,
-                        showCancelDialog = false,
-                    )
-                }
-            }
-
-            is PhotographerDetailReservationIntent.DismissRefundPolicyTooltip -> {
-                _state.update {
-                    it.copy(
-                        showRefundPolicyTooltip = false,
-                        showCancelDialog = true,
+                    _sideEffect.emit(
+                        PhotographerDetailReservationSideEffect.NavigateToCancelReservation(
+                            orderId = _state.value.orderId,
+                        ),
                     )
                 }
             }

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -95,6 +95,51 @@
     <string name="cancel_reservation_top_bar_title">예약 취소</string>
     <string name="cancel_reservation_button_submit">예약 취소</string>
 
+    <!-- 취소 완료 화면 - 작가 -->
+    <string name="cancel_reservation_guide_photographer">자세한 거래내역은 \'받은 예약 > 완료됨\' 탭에서\n확인할 수 있습니다.</string>
+    <string name="cancel_reservation_button_check_history">취소 내역 확인하기</string>
+
+    <!-- 작가 예약 취소 - 공통 -->
+    <string name="photographer_cancel_reservation_top_bar_title">예약 취소</string>
+
+    <!-- 작가 예약 취소 - 사유 입력 (1/2) -->
+    <string name="photographer_cancel_reason_title">취소 사유를 알려주세요</string>
+    <string name="photographer_cancel_reason_subtitle">* 중복 선택 가능</string>
+    <string name="photographer_cancel_reason_schedule">갑작스럽게 다른 일정이 생겼어요</string>
+    <string name="photographer_cancel_reason_health">컨디션이나 건강 문제로 촬영이 어려워졌어요</string>
+    <string name="photographer_cancel_reason_customer_response">고객의 답변이 늦거나 불확실했어요</string>
+    <string name="photographer_cancel_reason_mistake">실수로 예약을 수락했어요</string>
+    <string name="photographer_cancel_reason_equipment">장비에 문제가 생겨 촬영이 불가능해졌어요</string>
+    <string name="photographer_cancel_reason_external">외부 요인(날씨, 장소 확보 등)으로 진행이 어려워요</string>
+    <string name="photographer_cancel_reason_direct_input">직접 입력</string>
+    <string name="photographer_cancel_reason_agreement">고객과 취소에 대해 사전 합의를 진행했어요.</string>
+    <string name="photographer_cancel_reason_button_next">다음</string>
+
+    <!-- 작가 예약 취소 - 취소 규정 확인 (2/2) -->
+    <string name="photographer_cancel_policy_title">취소 규정을 확인해주세요.</string>
+    <string name="photographer_cancel_policy_penalty_criteria_title">취소 페널티 부여 기준</string>
+    <string name="photographer_cancel_policy_table_header_situation">취소 상황</string>
+    <string name="photographer_cancel_policy_table_header_penalty">패널티</string>
+    <string name="photographer_cancel_policy_table_not_agreed">고객과 합의되지 않음</string>
+    <string name="photographer_cancel_policy_table_not_agreed_penalty">경고 0.5회</string>
+    <string name="photographer_cancel_policy_table_agreed">고객과 사전 합의됨</string>
+    <string name="photographer_cancel_policy_table_agreed_penalty">경고 없음</string>
+    <string name="photographer_cancel_policy_table_note">* 외부 요인 : 날씨, 장소 확보 불가 등 정당한 사유 인정 시</string>
+    <string name="photographer_cancel_policy_guide_title">취소 페널티 안내</string>
+    <string name="photographer_cancel_policy_guide_activity_label">[활동 페널티]</string>
+    <string name="photographer_cancel_policy_guide_activity_1">누적 경고 횟수 3회: 14일간 작가 활동 제한</string>
+    <string name="photographer_cancel_policy_guide_activity_2">누적 경고 횟수 7회: 작가 활동 영구 정지</string>
+    <string name="photographer_cancel_policy_guide_system_label">[추가 시스템 적용 사항]</string>
+    <string name="photographer_cancel_policy_guide_system_1">작가의 누적 경고 점수에 따라, 작가 List 내 노출 순서가 하단으로 조정될 수 있습니다. 또한 허위 사실 기재 시 별도의 통보 없이 활동이 제한될 수 있습니다.</string>
+    <string name="photographer_cancel_policy_agreement">위 내용을 모두 확인하였으며, 이에 동의합니다.</string>
+    <string name="photographer_cancel_policy_button_submit">예약 취소</string>
+
+    <!-- 작가 예약 취소 - 확인 다이얼로그 -->
+    <string name="photographer_cancel_dialog_title">예약을 취소하시겠습니까?</string>
+    <string name="photographer_cancel_dialog_desc">예약 취소 후에는 이를 변경할 수 없으며,\n취소 규정에 따라 패널티가 부여될 수 있습니다.</string>
+    <string name="photographer_cancel_dialog_button_no">아니오</string>
+    <string name="photographer_cancel_dialog_button_yes">취소할게요</string>
+
     <!-- 포맷 문자열 -->
     <string name="amount_format">%,d원</string>
 </resources>


### PR DESCRIPTION
## 개요
작가 예약 취소 플로우를 새 피그마에 맞춰 신설합니다. 작가 예약 상세에서 "예약 취소" 시 취소 사유 입력과 취소 규정(페널티) 확인 2스텝을 거쳐 취소가 완료됩니다.

## 변경 사항
- **전용 플로우 신설**: 작가 예약 상세 "예약 취소"(일시 확정 대기중/촬영 진행중) → 사유 입력(1/2) → 취소 규정 확인(2/2) → 확인 다이얼로그 → 취소 완료
- **사유 입력(1/2)**: 스텝 인디케이터, 작가 전용 사유 6종 + 직접 입력, `고객과 취소에 대해 사전 합의를 진행했어요.` 체크박스
- **취소 규정(2/2)**: `취소 페널티 부여 기준` 표(고객 합의 여부 기준) + `취소 페널티 안내` 문구 + `위 내용을 모두 확인하였으며, 이에 동의합니다.` 체크박스
- **확인 다이얼로그**: `예약을 취소하시겠습니까?` 노출 후 취소 확정
- **작가 예약 상세 정리**: 기존 취소 다이얼로그·`OrderDetail` 중간 단계 제거 후 새 플로우로 직행
- `photographer_cancel_reservation` 패키지 신설, `PhotographerCancelReservation(orderId)` 라우트 추가(`authRequiredRoutes` 포함)
- **취소 완료 화면 role 분기**: 공유 `CancelReservationConfirm`에 `isPhotographer` 플래그 추가 (작가: `받은 예약 > 완료됨` 안내 + 단일 버튼 `취소 내역 확인하기`)
- 에뮬레이터로 전 구간(상세 → 사유 → 규정 → 다이얼로그 → 완료) 검증 완료

## 스크린샷
<!-- 각 셀에 아래 로컬 파일을 드래그해서 넣어주세요 -->
| 취소 사유 입력 (1/2) | 직접 입력 (1/2) | 취소 규정 확인 (2/2) | 확인 다이얼로그 | 취소 완료 |
|:---:|:---:|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="pc_step1" src="https://github.com/user-attachments/assets/4dcce410-8f7b-4958-ba4a-a3916d62aa4b" />|<img width="1080" height="2220" alt="pc_step1_di" src="https://github.com/user-attachments/assets/a0e6fd97-4fea-4ce1-8ae9-3d198418badc" />|<img width="1080" height="2220" alt="pc_step2" src="https://github.com/user-attachments/assets/2e603f5d-b7fe-4562-9196-ebf3e45c9318" />|<img width="1080" height="2220" alt="pc_dialog" src="https://github.com/user-attachments/assets/04820616-2a36-44a6-b7d1-502fb306a32a" />|<img width="1080" height="2220" alt="pc_complete" src="https://github.com/user-attachments/assets/8d8467e2-7fe2-4c4b-9876-e71457cdb49f" />|


## 참고
- 고객 예약 취소 PR(#207, `feat/206`) 위에 스택된 브랜치입니다. base를 `feat/206`으로 설정했으며, #207 머지 후 `develop`으로 리타겟 예정입니다.

## 체크리스트
- [ ] 코드가 작동하는지 확인했습니다.
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #208
