### PR TITLE
✨ 작가 예약 거절 플로우 신설 (사유 입력·확인)

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
@@ -37,6 +37,7 @@ import com.hm.picplz.navigation.model.PhotographerCancelReservation
 import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.PhotographerMainGraph
+import com.hm.picplz.navigation.model.PhotographerRejectReservation
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.main.MainActivityUiState
 import kotlin.reflect.KClass
@@ -62,6 +63,7 @@ private val authRequiredRoutes: List<KClass<out Any>> =
         MyPageOrderSheet::class,
         DetailReservation::class,
         PhotographerDetailReservation::class,
+        PhotographerRejectReservation::class,
         CancelReservationConfirm::class,
         OrderDetail::class,
         CancelReservation::class,

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -43,6 +43,7 @@ import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerCancelReservation
 import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
+import com.hm.picplz.navigation.model.PhotographerRejectReservation
 import com.hm.picplz.navigation.model.Reservation
 import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationScreen
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
@@ -76,6 +77,7 @@ import com.hm.picplz.ui.screen.photographer_detail_reservation.PhotographerDetai
 import com.hm.picplz.ui.screen.photographer_main.PhotographerMainViewModel
 import com.hm.picplz.ui.screen.photographer_main.composable.EquipmentSettingScreen
 import com.hm.picplz.ui.screen.photographer_main.composable.PhotographerAddDeviceScreen
+import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejectReservationScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
@@ -327,8 +329,23 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateBack = {
                 navController.popBackStack()
             },
+            onNavigateToRejectReason = { orderId ->
+                navController.navigate(PhotographerRejectReservation(orderId = orderId))
+            },
             onNavigateToCancelReservation = { orderId ->
                 navController.navigate(PhotographerCancelReservation(orderId = orderId))
+            },
+        )
+    }
+
+    composable<PhotographerRejectReservation> {
+        PhotographerRejectReservationScreen(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+            onNavigateToChat = {
+                // 예약이 시작된 채팅방으로 복귀 (거절 사유·예약 상세 화면 정리)
+                navController.popBackStack<PhotographerChatRoom>(inclusive = false)
             },
         )
     }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -170,6 +170,9 @@ data object DetailReservation : NavigationRoute
 data object PhotographerDetailReservation : NavigationRoute
 
 @Serializable
+data class PhotographerRejectReservation(val orderId: String) : NavigationRoute
+
+@Serializable
 data class CancelReservationConfirm(val isPhotographer: Boolean = false) : NavigationRoute
 
 @Serializable

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/DirectInputTextField.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/composable/DirectInputTextField.kt
@@ -30,6 +30,7 @@ fun DirectInputTextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     maxLength: Int = CANCEL_REASON_INPUT_MAX_LENGTH,
+    placeholder: String = stringResource(R.string.cancel_reason_input_placeholder, maxLength),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -63,7 +64,7 @@ fun DirectInputTextField(
                 ) {
                     if (value.isEmpty()) {
                         Text(
-                            text = stringResource(R.string.cancel_reason_input_placeholder, maxLength),
+                            text = placeholder,
                             style = MainThemeFont.Body,
                             color = MainThemeColor.Gray3,
                         )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
@@ -7,6 +7,9 @@ sealed interface PhotographerDetailReservationIntent {
 
     data object ConfirmReservation : PhotographerDetailReservationIntent
 
+    /** 예약 승인 대기중 상태의 "예약 거절" 버튼 → 거절 사유 입력 화면으로 이동 */
+    data object RejectReservation : PhotographerDetailReservationIntent
+
     /** "예약 취소" 버튼 → 작가 취소 사유 입력 플로우로 이동 */
     data object NavigateToCancelReservation : PhotographerDetailReservationIntent
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -30,6 +30,7 @@ import com.hm.picplz.ui.theme.MainThemeColor
 @Composable
 fun PhotographerDetailReservationScreen(
     onNavigateBack: () -> Unit,
+    onNavigateToRejectReason: (orderId: String) -> Unit,
     onNavigateToCancelReservation: (orderId: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PhotographerDetailReservationViewModel = hiltViewModel(),
@@ -40,6 +41,9 @@ fun PhotographerDetailReservationScreen(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is PhotographerDetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
+
+                is PhotographerDetailReservationSideEffect.NavigateToRejectReason ->
+                    onNavigateToRejectReason(sideEffect.orderId)
 
                 is PhotographerDetailReservationSideEffect.NavigateToCancelReservation ->
                     onNavigateToCancelReservation(sideEffect.orderId)
@@ -60,7 +64,7 @@ fun PhotographerDetailReservationScreen(
             viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateToCancelReservation)
         },
         onCancelReject = {
-            // TODO: 예약 거절 플로우 연결 (별도 작업)
+            viewModel.handelIntent(PhotographerDetailReservationIntent.RejectReservation)
         },
         onReservationApproveClick = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.ApproveReservation)

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
@@ -3,5 +3,8 @@ package com.hm.picplz.ui.screen.photographer_detail_reservation
 sealed interface PhotographerDetailReservationSideEffect {
     data object NavigateToPrev : PhotographerDetailReservationSideEffect
 
+    /** "예약 거절" → 거절 사유 입력 화면으로 이동 */
+    data class NavigateToRejectReason(val orderId: String) : PhotographerDetailReservationSideEffect
+
     data class NavigateToCancelReservation(val orderId: String) : PhotographerDetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -46,6 +46,16 @@ class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel()
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
             }
 
+            is PhotographerDetailReservationIntent.RejectReservation -> {
+                viewModelScope.launch {
+                    _sideEffect.emit(
+                        PhotographerDetailReservationSideEffect.NavigateToRejectReason(
+                            orderId = _state.value.orderId,
+                        ),
+                    )
+                }
+            }
+
             is PhotographerDetailReservationIntent.NavigateToCancelReservation -> {
                 viewModelScope.launch {
                     _sideEffect.emit(

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReason.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReason.kt
@@ -1,0 +1,16 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+import com.hm.picplz.feature.reservation.R
+
+/** 직접 입력 거절 사유 최대 글자 수 */
+const val REJECT_REASON_MAX_LENGTH = 20
+
+/**
+ * 작가 예약 거절 사유. 취소 사유와 달리 단일 선택이며, 거절 전용 문구를 사용합니다.
+ */
+enum class PhotographerRejectReason(val stringRes: Int) {
+    AREA(R.string.reject_reason_option_area),
+    TIME(R.string.reject_reason_option_time),
+    EQUIPMENT(R.string.reject_reason_option_equipment),
+    DIRECT_INPUT(R.string.reject_reason_option_direct_input),
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationIntent.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+sealed interface PhotographerRejectReservationIntent {
+    /** 거절 사유 선택 (단일 선택) */
+    data class SelectReason(val reason: PhotographerRejectReason) : PhotographerRejectReservationIntent
+
+    /** 직접 입력 텍스트 변경 */
+    data class UpdateDirectInput(val text: String) : PhotographerRejectReservationIntent
+
+    /** 하단 "다음" 버튼 → 확인 다이얼로그 노출 */
+    data object OnNextClick : PhotographerRejectReservationIntent
+
+    /** 확인 다이얼로그 "확인" → 거절 확정 */
+    data object OnConfirmDialogConfirm : PhotographerRejectReservationIntent
+
+    /** 확인 다이얼로그 "취소" · 바깥 영역 터치 */
+    data object OnConfirmDialogDismiss : PhotographerRejectReservationIntent
+
+    /** 상단 뒤로가기 */
+    data object OnBackClick : PhotographerRejectReservationIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
@@ -1,0 +1,195 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.screen.photographer_reject_reservation.composable.PhotographerRejectReasonContent
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun PhotographerRejectReservationScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToChat: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PhotographerRejectReservationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    BackHandler {
+        viewModel.handleIntent(PhotographerRejectReservationIntent.OnBackClick)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                PhotographerRejectReservationSideEffect.NavigateBack -> onNavigateBack()
+                PhotographerRejectReservationSideEffect.NavigateToChat -> onNavigateToChat()
+            }
+        }
+    }
+
+    PhotographerRejectReservationScreenContent(
+        modifier = modifier,
+        state = state,
+        onBackClick = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnBackClick) },
+        onReasonSelect = { reason ->
+            viewModel.handleIntent(PhotographerRejectReservationIntent.SelectReason(reason))
+        },
+        onDirectInputChange = { text ->
+            viewModel.handleIntent(PhotographerRejectReservationIntent.UpdateDirectInput(text))
+        },
+        onNextClick = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnNextClick) },
+        onDialogConfirm = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnConfirmDialogConfirm) },
+        onDialogDismiss = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnConfirmDialogDismiss) },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun PhotographerRejectReservationScreenContent(
+    state: PhotographerRejectReservationState,
+    onBackClick: () -> Unit,
+    onReasonSelect: (PhotographerRejectReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    onNextClick: () -> Unit,
+    onDialogConfirm: () -> Unit,
+    onDialogDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonTopBar(
+                text = stringResource(R.string.reservation_reject),
+                onClickBack = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+        ) {
+            PhotographerRejectReasonContent(
+                modifier = Modifier.weight(1f),
+                selectedReason = state.selectedReason,
+                directInputText = state.directInputText,
+                onReasonSelect = onReasonSelect,
+                onDirectInputChange = onDirectInputChange,
+            )
+
+            CommonBottomButton(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
+                text = stringResource(R.string.reject_button_next),
+                onClick = onNextClick,
+                enabled = state.isNextEnabled(),
+            )
+        }
+
+        if (state.showConfirmDialog) {
+            PhotographerRejectConfirmDialog(
+                onConfirm = onDialogConfirm,
+                onDismiss = onDialogDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerRejectConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    CommonButtonModal(
+        onDismissRequest = onDismiss,
+        cancelText = stringResource(R.string.reject_dialog_button_no),
+        confirmText = stringResource(R.string.reject_dialog_button_yes),
+        onCancel = onDismiss,
+        onConfirm = onConfirm,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.reject_dialog_desc),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerRejectReservationReasonPreview() {
+    PicplzTheme {
+        PhotographerRejectReservationScreenContent(
+            state =
+                PhotographerRejectReservationState(
+                    orderId = "order123",
+                    selectedReason = PhotographerRejectReason.AREA,
+                ),
+            onBackClick = {},
+            onReasonSelect = {},
+            onDirectInputChange = {},
+            onNextClick = {},
+            onDialogConfirm = {},
+            onDialogDismiss = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerRejectReservationDialogPreview() {
+    PicplzTheme {
+        PhotographerRejectReservationScreenContent(
+            state =
+                PhotographerRejectReservationState(
+                    orderId = "order123",
+                    selectedReason = PhotographerRejectReason.DIRECT_INPUT,
+                    directInputText = "다른 지역 일정과 겹쳤어요",
+                    showConfirmDialog = true,
+                ),
+            onBackClick = {},
+            onReasonSelect = {},
+            onDirectInputChange = {},
+            onNextClick = {},
+            onDialogConfirm = {},
+            onDialogDismiss = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
@@ -142,8 +142,8 @@ private fun PhotographerRejectConfirmDialog(
         ) {
             Text(
                 text = stringResource(R.string.reject_dialog_desc),
-                style = MainThemeFont.TitleSmall,
-                color = MainThemeColor.Black,
+                style = MainThemeFont.Body,
+                color = MainThemeColor.Gray5,
                 textAlign = TextAlign.Center,
             )
         }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationSideEffect.kt
@@ -1,0 +1,9 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+sealed interface PhotographerRejectReservationSideEffect {
+    /** 상단 뒤로가기 → 이전 화면(예약 상세)으로 복귀 */
+    data object NavigateBack : PhotographerRejectReservationSideEffect
+
+    /** 거절 확정 → 예약이 시작된 채팅방으로 복귀 */
+    data object NavigateToChat : PhotographerRejectReservationSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationState.kt
@@ -1,0 +1,21 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+data class PhotographerRejectReservationState(
+    val orderId: String = "",
+    val selectedReason: PhotographerRejectReason? = null,
+    val directInputText: String = "",
+    val showConfirmDialog: Boolean = false,
+) {
+    /** 하단 "다음" 버튼 활성화 조건 */
+    fun isNextEnabled(): Boolean =
+        when (selectedReason) {
+            null -> false
+            PhotographerRejectReason.DIRECT_INPUT -> directInputText.isNotBlank()
+            else -> true
+        }
+
+    companion object {
+        fun idle(orderId: String): PhotographerRejectReservationState =
+            PhotographerRejectReservationState(orderId = orderId)
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationViewModel.kt
@@ -1,0 +1,68 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.PhotographerRejectReservation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PhotographerRejectReservationViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val orderId: String = savedStateHandle.toRoute<PhotographerRejectReservation>().orderId
+
+        private val _state = MutableStateFlow(PhotographerRejectReservationState.idle(orderId))
+        val state: StateFlow<PhotographerRejectReservationState> = _state.asStateFlow()
+
+        private val _sideEffect = MutableSharedFlow<PhotographerRejectReservationSideEffect>()
+        val sideEffect: SharedFlow<PhotographerRejectReservationSideEffect> = _sideEffect.asSharedFlow()
+
+        fun handleIntent(intent: PhotographerRejectReservationIntent) {
+            when (intent) {
+                is PhotographerRejectReservationIntent.SelectReason -> {
+                    _state.update { it.copy(selectedReason = intent.reason) }
+                }
+
+                is PhotographerRejectReservationIntent.UpdateDirectInput -> {
+                    _state.update { it.copy(directInputText = intent.text.take(REJECT_REASON_MAX_LENGTH)) }
+                }
+
+                PhotographerRejectReservationIntent.OnNextClick -> {
+                    _state.update { it.copy(showConfirmDialog = true) }
+                }
+
+                PhotographerRejectReservationIntent.OnConfirmDialogDismiss -> {
+                    _state.update { it.copy(showConfirmDialog = false) }
+                }
+
+                PhotographerRejectReservationIntent.OnConfirmDialogConfirm -> {
+                    _state.update { it.copy(showConfirmDialog = false) }
+                    // TODO: 거절 사유 전송 API 연동
+                    emitSideEffect(PhotographerRejectReservationSideEffect.NavigateToChat)
+                }
+
+                PhotographerRejectReservationIntent.OnBackClick -> {
+                    emitSideEffect(PhotographerRejectReservationSideEffect.NavigateBack)
+                }
+            }
+        }
+
+        private fun emitSideEffect(sideEffect: PhotographerRejectReservationSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.emit(sideEffect)
+            }
+        }
+    }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/composable/PhotographerRejectReasonContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/composable/PhotographerRejectReasonContent.kt
@@ -1,0 +1,124 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.composable.DirectInputTextField
+import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejectReason
+import com.hm.picplz.ui.screen.photographer_reject_reservation.REJECT_REASON_MAX_LENGTH
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+/** 라벨 텍스트 시작 위치 정렬용 들여쓰기 (좌측 여백 16 + 라디오 20 + 간격 10) */
+private val labelIndent = 46.dp
+
+@Composable
+fun PhotographerRejectReasonContent(
+    selectedReason: PhotographerRejectReason?,
+    directInputText: String,
+    onReasonSelect: (PhotographerRejectReason) -> Unit,
+    onDirectInputChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Text(
+            text = stringResource(R.string.reject_reason_input_title),
+            style = MainThemeFont.Title,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(vertical = 22.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            items(PhotographerRejectReason.entries) { reason ->
+                Column {
+                    RejectReasonRadioItem(
+                        text = stringResource(reason.stringRes),
+                        selected = selectedReason == reason,
+                        onSelect = { onReasonSelect(reason) },
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+
+                    if (reason == PhotographerRejectReason.TIME) {
+                        Text(
+                            text = stringResource(R.string.reject_reason_option_time_note),
+                            style = MainThemeFont.Caption,
+                            color = MainThemeColor.Red,
+                            modifier = Modifier.padding(start = labelIndent, end = 16.dp, top = 8.dp),
+                        )
+                    }
+                }
+            }
+
+            if (selectedReason == PhotographerRejectReason.DIRECT_INPUT) {
+                item {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        Text(
+                            text = stringResource(R.string.reject_reason_direct_input_label),
+                            style = MainThemeFont.TitleSmall,
+                            color = MainThemeColor.Black,
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        DirectInputTextField(
+                            value = directInputText,
+                            onValueChange = onDirectInputChange,
+                            maxLength = REJECT_REASON_MAX_LENGTH,
+                            placeholder =
+                                stringResource(
+                                    R.string.reject_reason_input_placeholder,
+                                    REJECT_REASON_MAX_LENGTH,
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerRejectReasonContentPreviewEmpty() {
+    PicplzTheme {
+        PhotographerRejectReasonContent(
+            selectedReason = null,
+            directInputText = "",
+            onReasonSelect = {},
+            onDirectInputChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotographerRejectReasonContentPreviewDirectInput() {
+    PicplzTheme {
+        PhotographerRejectReasonContent(
+            selectedReason = PhotographerRejectReason.DIRECT_INPUT,
+            directInputText = "다른 지역 일정과 겹쳤어요",
+            onReasonSelect = {},
+            onDirectInputChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/composable/RejectReasonRadioItem.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/composable/RejectReasonRadioItem.kt
@@ -1,0 +1,114 @@
+package com.hm.picplz.ui.screen.photographer_reject_reservation.composable
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+/**
+ * 단일 선택 라디오 + 라벨. 거절 사유 선택에 사용합니다.
+ * (취소 플로우의 다중 선택 [com.hm.picplz.ui.screen.cancel_reservation.composable.CheckboxWithLabel]와 구분)
+ */
+@Composable
+fun RejectReasonRadioItem(
+    text: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { onSelect() },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RejectReasonRadio(selected = selected)
+
+        Text(
+            text = text,
+            style = if (selected) MainThemeFont.BodyBold else MainThemeFont.Body,
+            color = if (selected) MainThemeColor.Black else MainThemeColor.Gray4,
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(start = 10.dp),
+        )
+    }
+}
+
+@Composable
+private fun RejectReasonRadio(
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(20.dp)
+                .border(
+                    border =
+                        BorderStroke(
+                            width = 1.5.dp,
+                            color = if (selected) MainThemeColor.Black else MainThemeColor.Gray3,
+                        ),
+                    shape = CircleShape,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(10.dp)
+                        .background(color = MainThemeColor.Black, shape = CircleShape),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RejectReasonRadioItemUnselectedPreview() {
+    PicplzTheme {
+        RejectReasonRadioItem(
+            text = "해당 지역은 촬영이 어려워요",
+            selected = false,
+            onSelect = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RejectReasonRadioItemSelectedPreview() {
+    PicplzTheme {
+        RejectReasonRadioItem(
+            text = "직접 입력",
+            selected = true,
+            onSelect = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -95,6 +95,20 @@
     <string name="cancel_reservation_top_bar_title">예약 취소</string>
     <string name="cancel_reservation_button_submit">예약 취소</string>
 
+    <!-- 예약 거절 사유 입력 화면 (작가) -->
+    <string name="reject_reason_input_title">거절 사유를 알려주세요</string>
+    <string name="reject_reason_option_area">해당 지역은 촬영이 어려워요</string>
+    <string name="reject_reason_option_time">희망한 시간대에 촬영이 어려워요</string>
+    <string name="reject_reason_option_time_note">* 수락 후, 시간대를 변경할 수도 있어요.\n채팅으로 일정을 조정해 보시는 건 어떨까요?</string>
+    <string name="reject_reason_option_equipment">장비 문제로 촬영이 불가해요</string>
+    <string name="reject_reason_option_direct_input">직접 입력</string>
+    <string name="reject_reason_direct_input_label">거절 사유를 적어주세요</string>
+    <string name="reject_reason_input_placeholder">거절 사유를 적어주세요. (최대 %1$d자)</string>
+    <string name="reject_button_next">다음</string>
+    <string name="reject_dialog_desc">예약 거절 후에는 이를 변경할 수 없습니다.\n거절하시겠습니까?</string>
+    <string name="reject_dialog_button_no">취소</string>
+    <string name="reject_dialog_button_yes">확인</string>
+
     <!-- 취소 완료 화면 - 작가 -->
     <string name="cancel_reservation_guide_photographer">자세한 거래내역은 \'받은 예약 > 완료됨\' 탭에서\n확인할 수 있습니다.</string>
     <string name="cancel_reservation_button_check_history">취소 내역 확인하기</string>


### PR DESCRIPTION
## 개요
작가 예약 거절 플로우를 새 피그마에 맞춰 신설합니다. 작가 예약 상세(예약 승인 대기중)에서 **"예약 거절"** 시 거절 사유를 입력하고 확인 다이얼로그를 거쳐 거절이 완료되며, 예약이 시작된 **채팅방으로 복귀**합니다.

기존에 `PhotographerReservationStatusHeader`의 "예약 거절" 버튼(`onCancelReject`)이 `// TODO` 빈 람다였던 것을 실제 플로우로 연결했습니다.

## 변경 사항

### ✨ 거절 사유 입력 화면 신설 (`photographer_reject_reservation`)
- `거절 사유를 알려주세요` — **단일 선택 라디오** 사유 3종 + `직접 입력`
  - 해당 지역은 촬영이 어려워요
  - 희망한 시간대에 촬영이 어려워요 → 하단 빨간 안내문(`* 수락 후, 시간대를 변경할 수도 있어요. 채팅으로 일정을 조정해 보시는 건 어떨까요?`)
  - 장비 문제로 촬영이 불가해요
  - 직접 입력 → `거절 사유를 적어주세요` 서브헤더 + 입력 필드(최대 20자)
- 하단 `다음`(사유 선택 시 활성화) → 확인 다이얼로그(`예약 거절 후에는 이를 변경할 수 없습니다. 거절하시겠습니까?` · 취소/확인)
- `PhotographerRejectReservation(orderId)` 라우트 신설(`authRequiredRoutes` 포함)
- 공유 `DirectInputTextField`에 optional `placeholder` 파라미터 추가(기존 동작 불변)

### ✨ 작가 예약 상세 진입점 연결
- 예약 승인 대기중 "예약 거절" 버튼 → `RejectReservation` 인텐트 → `NavigateToRejectReason(orderId)` → 거절 사유 화면
- 거절 확정(`확인`) 시 `popBackStack<PhotographerChatRoom>`로 상세·거절 화면 정리 후 채팅방 복귀

## 스크린샷 (실기기 검증 · 3개 상태)
<!-- 아래 표의 각 셀(파일명 자리)에 스크린샷 폴더의 해당 파일을 드래그&드롭 해주세요 -->

| 거절 사유 입력 | 직접 입력 | 확인 다이얼로그 |
|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="01_reason" src="https://github.com/user-attachments/assets/715504bd-0818-4619-9124-188d88f2afdf" />|<img width="1080" height="2220" alt="02_direct_input" src="https://github.com/user-attachments/assets/c2a5f103-9da3-454a-8d39-6d144b3f00ce" />|<img width="1080" height="2220" alt="03_confirm_dialog" src="https://github.com/user-attachments/assets/afc4d93a-bc85-46e1-99d0-65cb8bac6488" />|



> 검증 경로: 채팅방(작가) → 예약 정보 확인 → 예약 상세(예약 승인 대기중) → 예약 거절 → 사유 선택 → 다음 → 확인 → **채팅방 복귀**까지 전 구간 확인.

## 남은 후속
- 거절 사유 전송 API 연동 (현재 확정 시 채팅 복귀만, 전송은 TODO)
- 거절 확정 후 채팅방에 뜨는 **거절 메시지**(`예약 신청을 거절했어요 / [사유] 사유로 거절했습니다`)는 실제로 백엔드가 거절 API 응답으로 채팅에 내려주는 서버 메시지라, 백엔드 연동 시점에 처리 (본 PR 범위 제외)

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다. (`:app:compileDevDebugKotlin` + `:feature:reservation:detekt`/`ktlintCheck` + 실기기 3상태 검증)
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #210
