### PR TITLE
✨ 고객 리뷰 작성 – 별점 선택 화면 (1/2) 및 거래 완료 진입

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/MainNavHost.kt
@@ -39,6 +39,7 @@ import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.PhotographerMainGraph
 import com.hm.picplz.navigation.model.PhotographerRejectReservation
 import com.hm.picplz.navigation.model.Reservation
+import com.hm.picplz.navigation.model.WriteReview
 import com.hm.picplz.ui.main.MainActivityUiState
 import kotlin.reflect.KClass
 
@@ -68,6 +69,7 @@ private val authRequiredRoutes: List<KClass<out Any>> =
         OrderDetail::class,
         CancelReservation::class,
         PhotographerCancelReservation::class,
+        WriteReview::class,
     )
 
 @Composable

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -45,6 +45,7 @@ import com.hm.picplz.navigation.model.PhotographerChatRoom
 import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.PhotographerRejectReservation
 import com.hm.picplz.navigation.model.Reservation
+import com.hm.picplz.navigation.model.WriteReview
 import com.hm.picplz.ui.screen.cancel_reservation.CancelReservationScreen
 import com.hm.picplz.ui.screen.cancel_reservation_confirm.CancelReservationConfirmScreen
 import com.hm.picplz.ui.screen.chat.ChatScreen
@@ -79,6 +80,7 @@ import com.hm.picplz.ui.screen.photographer_main.composable.EquipmentSettingScre
 import com.hm.picplz.ui.screen.photographer_main.composable.PhotographerAddDeviceScreen
 import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejectReservationScreen
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
+import com.hm.picplz.ui.screen.write_review.WriteReviewScreen
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
     composable<Dev> {
@@ -318,8 +320,16 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateToOrderDetail = { orderId ->
                 navController.navigate(OrderDetail(orderId = orderId))
             },
-            onNavigateToWriteReview = {
-                // TODO: 리뷰 작성 화면 구현 후 네비게이션 연결
+            onNavigateToWriteReview = { orderId ->
+                navController.navigate(WriteReview(orderId = orderId))
+            },
+        )
+    }
+
+    composable<WriteReview> {
+        WriteReviewScreen(
+            onNavigateBack = {
+                navController.popBackStack()
             },
         )
     }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -185,4 +185,7 @@ data class CancelReservation(val orderId: String) : NavigationRoute
 data class PhotographerCancelReservation(val orderId: String) : NavigationRoute
 
 @Serializable
+data class WriteReview(val orderId: String) : NavigationRoute
+
+@Serializable
 data class PhotographerChatRoom(val roomId: String) : NavigationRoute

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSuccessModal.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSuccessModal.kt
@@ -1,0 +1,122 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+private object CommonSuccessModalDefaults {
+    val Width = 304.dp
+    val Radius = RoundedCornerShape(5.dp)
+    val IconSize = 64.dp
+    val VerticalPadding = 28.dp
+    val HorizontalPadding = 20.dp
+    val IconMessageGap = 20.dp
+    val ScrimColor = Color(0x66000000)
+}
+
+/**
+ * 체크 아이콘 + 안내 문구만 있는 완료 모달. 버튼이 없어 스스로 닫히지 않으므로,
+ * 호출부에서 일정 시간 뒤 닫거나 다음 화면으로 넘겨야 합니다.
+ *
+ * 취소/확인 2버튼이 필요하면 [CommonButtonModal]을 쓰세요.
+ *
+ * @param dismissible false면 바깥 탭·뒤로가기로 닫히지 않습니다.
+ */
+@Composable
+fun CommonSuccessModal(
+    message: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissible: Boolean = true,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = dismissible,
+                dismissOnClickOutside = dismissible,
+            ),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(CommonSuccessModalDefaults.ScrimColor)
+                    .clickable(enabled = dismissible, onClick = onDismissRequest),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier =
+                    modifier
+                        .width(CommonSuccessModalDefaults.Width)
+                        .clickable(enabled = false, onClick = {}),
+                shape = CommonSuccessModalDefaults.Radius,
+                color = MainThemeColor.White,
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                vertical = CommonSuccessModalDefaults.VerticalPadding,
+                                horizontal = CommonSuccessModalDefaults.HorizontalPadding,
+                            ),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Image(
+                        painter = painterResource(R.drawable.check_circle),
+                        contentDescription = null,
+                        modifier = Modifier.size(CommonSuccessModalDefaults.IconSize),
+                    )
+
+                    Box(modifier = Modifier.height(CommonSuccessModalDefaults.IconMessageGap))
+
+                    Text(
+                        text = message,
+                        style = MainThemeFont.TitleSmall,
+                        color = MainThemeColor.Black,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CommonSuccessModalPreview() {
+    PicplzTheme {
+        CommonSuccessModal(
+            message = "거래 완료 되었습니다",
+            onDismissRequest = {},
+        )
+    }
+}

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/StarRatingSelector.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/StarRatingSelector.kt
@@ -1,0 +1,90 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.PicplzTheme
+
+/** 선택 가능한 최대 별점 */
+const val MAX_STAR_RATING = 5
+
+private val defaultStarSize = 42.dp
+private val defaultStarSpacing = 4.dp
+
+/**
+ * 탭해서 1점 단위로 별점을 고르는 컴포넌트.
+ *
+ * 조회 전용 별점 표시는 [com.hm.picplz.ui.util.ReviewUtil.calculateStarRating]을 사용하세요.
+ *
+ * @param rating 현재 선택된 별점(1..[MAX_STAR_RATING]). 미선택은 0.
+ */
+@Composable
+fun StarRatingSelector(
+    rating: Int,
+    onRatingChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    starSize: Dp = defaultStarSize,
+    starSpacing: Dp = defaultStarSpacing,
+    selectedColor: Color = MainThemeColor.Green120,
+    unselectedColor: Color = MainThemeColor.Gray2,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(starSpacing),
+    ) {
+        for (score in 1..MAX_STAR_RATING) {
+            val interactionSource = remember { MutableInteractionSource() }
+
+            Icon(
+                painter = painterResource(R.drawable.star_full),
+                contentDescription = stringResource(R.string.star_rating_score_format, score),
+                tint = if (score <= rating) selectedColor else unselectedColor,
+                modifier =
+                    Modifier
+                        .size(starSize)
+                        .clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                        ) { onRatingChange(score) },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StarRatingSelectorPreviewEmpty() {
+    PicplzTheme {
+        StarRatingSelector(rating = 0, onRatingChange = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StarRatingSelectorPreviewPartial() {
+    PicplzTheme {
+        StarRatingSelector(rating = 2, onRatingChange = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StarRatingSelectorPreviewFull() {
+    PicplzTheme {
+        StarRatingSelector(rating = MAX_STAR_RATING, onRatingChange = {})
+    }
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <!-- ReviewSection -->
     <string name="shooting_satisfaction">촬영 만족도</string>
     <string name="star_rating">별점</string>
+    <string name="star_rating_score_format">%1$d점</string>
     <string name="no_reviews">아직 리뷰가\n없어요</string>
     <string name="review_empty_title">아직 작성한 리뷰가 없어요</string>
     <string name="review_empty_description">촬영 후 남긴 리뷰가 이곳에 모여 보여요</string>

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -34,7 +34,7 @@ fun DetailReservationScreen(
     onNavigateBack: () -> Unit,
     onNavigateToCancelReservation: (orderId: String) -> Unit,
     onNavigateToOrderDetail: (orderId: String) -> Unit,
-    onNavigateToWriteReview: () -> Unit,
+    onNavigateToWriteReview: (orderId: String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
@@ -51,7 +51,7 @@ fun DetailReservationScreen(
 
                 is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail(state.orderId)
 
-                is DetailReservationSideEffect.NavigateToWriteReview -> onNavigateToWriteReview()
+                is DetailReservationSideEffect.NavigateToWriteReview -> onNavigateToWriteReview(state.orderId)
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -18,6 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonSuccessModal
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
@@ -122,6 +123,15 @@ private fun DetailReservationScreen(
         if (state.showRefundPolicyTooltip) {
             ReservationRefundPolicyDialog(
                 onDismissRequest = onRefundPolicyDismiss,
+            )
+        }
+
+        if (state.showDealCompleteModal) {
+            // 잠시 뒤 리뷰 작성 화면으로 자동 이동하므로 사용자가 닫지 않도록 합니다.
+            CommonSuccessModal(
+                message = stringResource(R.string.reservation_deal_complete_modal_message),
+                onDismissRequest = {},
+                dismissible = false,
             )
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -12,4 +12,6 @@ data class DetailReservationState(
     val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
     val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
     val showRefundPolicyTooltip: Boolean = false,
+    /** "거래 완료 되었습니다" 모달 노출 여부. 잠시 보여준 뒤 리뷰 작성 화면으로 넘어갑니다. */
+    val showDealCompleteModal: Boolean = false,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -6,6 +6,7 @@ import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -13,6 +14,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+/** 거래 완료 모달을 보여주고 리뷰 작성 화면으로 넘어가기까지의 시간 */
+private const val DEAL_COMPLETE_MODAL_DURATION_MS = 1500L
 
 @HiltViewModel
 class DetailReservationViewModel @Inject constructor() : ViewModel() {
@@ -40,11 +44,11 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
     fun handelIntent(intent: DetailReservationIntent) {
         when (intent) {
             // 상태 변경 확인 테스트를 위한 코드입니다.
-            is DetailReservationIntent.NavigateToChat,
-            is DetailReservationIntent.ConfirmReservation,
-            -> {
+            is DetailReservationIntent.NavigateToChat -> {
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
             }
+
+            is DetailReservationIntent.ConfirmReservation -> confirmReservation()
 
             is DetailReservationIntent.NavigateToWriteReview -> {
                 viewModelScope.launch {
@@ -116,6 +120,28 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                     _sideEffect.emit(DetailReservationSideEffect.NavigateToPrev)
                 }
             }
+        }
+    }
+
+    /**
+     * "거래 완료하기" → 거래 완료 처리 → 완료 모달 → 리뷰 작성 화면.
+     *
+     * 리뷰를 쓰지 않고 나와도 거래는 이미 완료된 상태이므로,
+     * 예약 상세에 다시 들어오면 "리뷰 쓰기" 버튼이 노출됩니다.
+     */
+    private fun confirmReservation() {
+        // TODO: 거래 완료 API 연동 (성공 응답을 받은 뒤 아래 처리를 수행해야 합니다)
+        _state.update {
+            it.copy(
+                reservationStatus = ReservationStatus.COMPLETED,
+                showDealCompleteModal = true,
+            )
+        }
+
+        viewModelScope.launch {
+            delay(DEAL_COMPLETE_MODAL_DURATION_MS)
+            _state.update { it.copy(showDealCompleteModal = false) }
+            _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
         }
     }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/ReviewRating.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/ReviewRating.kt
@@ -1,0 +1,34 @@
+package com.hm.picplz.ui.screen.write_review
+
+import androidx.annotation.StringRes
+import com.hm.picplz.feature.reservation.R
+
+/** "어떤점이 아쉬웠나요?" 입력란 최대 글자 수 */
+const val NEGATIVE_FEEDBACK_MAX_LENGTH = 600
+
+/** 이 점수 이하를 부정 평가로 보고 아쉬운 점 입력란을 노출합니다. */
+private const val NEGATIVE_FEEDBACK_MAX_SCORE = 2
+
+/**
+ * 리뷰 별점(1~5)과 점수별 안내 문구.
+ */
+enum class ReviewRating(
+    val score: Int,
+    @get:StringRes val mainMessageRes: Int,
+    @get:StringRes val subMessageRes: Int,
+) {
+    VERY_BAD(1, R.string.write_review_rating_main_1, R.string.write_review_rating_sub_1),
+    BAD(2, R.string.write_review_rating_main_2, R.string.write_review_rating_sub_2),
+    OKAY(3, R.string.write_review_rating_main_3, R.string.write_review_rating_sub_3),
+    GOOD(4, R.string.write_review_rating_main_4, R.string.write_review_rating_sub_4),
+    EXCELLENT(5, R.string.write_review_rating_main_5, R.string.write_review_rating_sub_5),
+    ;
+
+    /** 부정 평가(1~2점)일 때만 아쉬운 점 입력란을 노출합니다. */
+    val needsNegativeFeedback: Boolean
+        get() = score <= NEGATIVE_FEEDBACK_MAX_SCORE
+
+    companion object {
+        fun fromScore(score: Int): ReviewRating? = entries.firstOrNull { it.score == score }
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
@@ -1,0 +1,12 @@
+package com.hm.picplz.ui.screen.write_review
+
+sealed interface WriteReviewIntent {
+    data class SelectRating(val rating: ReviewRating) : WriteReviewIntent
+
+    data class UpdateNegativeFeedback(val text: String) : WriteReviewIntent
+
+    /** 별점 선택(1/2)의 "별점 등록" */
+    data object OnRatingSubmitClick : WriteReviewIntent
+
+    data object OnBackClick : WriteReviewIntent
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
@@ -1,0 +1,154 @@
+package com.hm.picplz.ui.screen.write_review
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonTopBar
+import com.hm.picplz.ui.screen.write_review.WriteReviewState.Step
+import com.hm.picplz.ui.screen.write_review.composable.WriteReviewRatingContent
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun WriteReviewScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: WriteReviewViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    BackHandler {
+        viewModel.handleIntent(WriteReviewIntent.OnBackClick)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                WriteReviewSideEffect.NavigateBack -> onNavigateBack()
+            }
+        }
+    }
+
+    WriteReviewScreenContent(
+        modifier = modifier,
+        state = state,
+        onBackClick = { viewModel.handleIntent(WriteReviewIntent.OnBackClick) },
+        onRatingSelect = { rating ->
+            viewModel.handleIntent(WriteReviewIntent.SelectRating(rating))
+        },
+        onNegativeFeedbackChange = { text ->
+            viewModel.handleIntent(WriteReviewIntent.UpdateNegativeFeedback(text))
+        },
+        onRatingSubmitClick = { viewModel.handleIntent(WriteReviewIntent.OnRatingSubmitClick) },
+    )
+}
+
+@Composable
+private fun WriteReviewScreenContent(
+    state: WriteReviewState,
+    onBackClick: () -> Unit,
+    onRatingSelect: (ReviewRating) -> Unit,
+    onNegativeFeedbackChange: (String) -> Unit,
+    onRatingSubmitClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = MainThemeColor.White,
+        topBar = {
+            CommonTopBar(
+                text = stringResource(R.string.write_review_top_bar_title),
+                onClickBack = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+        ) {
+            when (state.currentStep) {
+                Step.RATING -> {
+                    WriteReviewRatingContent(
+                        modifier = Modifier.weight(1f),
+                        customerNickname = state.customerNickname,
+                        photographerName = state.photographerName,
+                        selectedRating = state.selectedRating,
+                        negativeFeedbackText = state.negativeFeedbackText,
+                        onRatingSelect = onRatingSelect,
+                        onNegativeFeedbackChange = onNegativeFeedbackChange,
+                    )
+
+                    CommonBottomButton(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
+                        text = stringResource(R.string.write_review_rating_button_submit),
+                        onClick = onRatingSubmitClick,
+                        enabled = state.isRatingStepValid(),
+                    )
+                }
+
+                // TODO(#214): 촬영 경험 입력(2/2) 단계
+                Step.CONTENT -> Unit
+            }
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewScreenRatingEmptyPreview() {
+    PicplzTheme {
+        WriteReviewScreenContent(
+            state =
+                WriteReviewState(
+                    orderId = "order123",
+                    customerNickname = "세연",
+                    photographerName = "유가영",
+                ),
+            onBackClick = {},
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+            onRatingSubmitClick = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewScreenRatingSelectedPreview() {
+    PicplzTheme {
+        WriteReviewScreenContent(
+            state =
+                WriteReviewState(
+                    orderId = "order123",
+                    customerNickname = "세연",
+                    photographerName = "유가영",
+                    selectedRating = ReviewRating.BAD,
+                ),
+            onBackClick = {},
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+            onRatingSubmitClick = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
@@ -1,0 +1,5 @@
+package com.hm.picplz.ui.screen.write_review
+
+sealed interface WriteReviewSideEffect {
+    data object NavigateBack : WriteReviewSideEffect
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.ui.screen.write_review
+
+data class WriteReviewState(
+    val orderId: String = "",
+    val currentStep: Step = Step.RATING,
+    val customerNickname: String = "",
+    val photographerName: String = "",
+    val selectedRating: ReviewRating? = null,
+    /** 1~2점 선택 시 받는 "어떤점이 아쉬웠나요?" 입력값 (선택사항) */
+    val negativeFeedbackText: String = "",
+) {
+    /** 별점 선택(1/2) 단계의 "별점 등록" 활성화 조건 */
+    fun isRatingStepValid(): Boolean = selectedRating != null
+
+    /** 부정 평가(1~2점)일 때만 아쉬운 점 입력란을 노출합니다. */
+    fun showNegativeFeedback(): Boolean = selectedRating?.needsNegativeFeedback == true
+
+    enum class Step { RATING, CONTENT }
+
+    companion object {
+        fun idle(orderId: String): WriteReviewState = WriteReviewState(orderId = orderId)
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
@@ -1,0 +1,69 @@
+package com.hm.picplz.ui.screen.write_review
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.hm.picplz.navigation.model.WriteReview
+import com.hm.picplz.ui.screen.write_review.WriteReviewState.Step
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// TODO(#217): 예약 정보 API 연동 시 실제 고객/작가 이름으로 교체
+private const val DUMMY_CUSTOMER_NICKNAME = "세연"
+private const val DUMMY_PHOTOGRAPHER_NAME = "유가영"
+
+@HiltViewModel
+class WriteReviewViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val orderId: String = savedStateHandle.toRoute<WriteReview>().orderId
+
+        private val _state =
+            MutableStateFlow(
+                WriteReviewState.idle(orderId).copy(
+                    customerNickname = DUMMY_CUSTOMER_NICKNAME,
+                    photographerName = DUMMY_PHOTOGRAPHER_NAME,
+                ),
+            )
+        val state: StateFlow<WriteReviewState> = _state.asStateFlow()
+
+        private val _sideEffect = MutableSharedFlow<WriteReviewSideEffect>()
+        val sideEffect: SharedFlow<WriteReviewSideEffect> = _sideEffect.asSharedFlow()
+
+        fun handleIntent(intent: WriteReviewIntent) {
+            when (intent) {
+                is WriteReviewIntent.SelectRating -> {
+                    _state.update { it.copy(selectedRating = intent.rating) }
+                }
+
+                is WriteReviewIntent.UpdateNegativeFeedback -> {
+                    _state.update { it.copy(negativeFeedbackText = intent.text.take(NEGATIVE_FEEDBACK_MAX_LENGTH)) }
+                }
+
+                WriteReviewIntent.OnRatingSubmitClick -> {
+                    _state.update { it.copy(currentStep = Step.CONTENT) }
+                }
+
+                WriteReviewIntent.OnBackClick -> {
+                    emitSideEffect(WriteReviewSideEffect.NavigateBack)
+                }
+            }
+        }
+
+        private fun emitSideEffect(sideEffect: WriteReviewSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.emit(sideEffect)
+            }
+        }
+    }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewRatingContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewRatingContent.kt
@@ -42,14 +42,14 @@ fun WriteReviewRatingContent(
         Text(
             text = stringResource(R.string.write_review_rating_title, customerNickname, photographerName),
             style = MainThemeFont.TitleSmall,
-            color = MainThemeColor.Black,
+            color = MainThemeColor.Gray5,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
         )
 
         Text(
             text = stringResource(R.string.write_review_rating_subtitle),
             style = MainThemeFont.Caption,
-            color = MainThemeColor.Gray3,
+            color = MainThemeColor.Gray4,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
         )
 
@@ -59,7 +59,7 @@ fun WriteReviewRatingContent(
             modifier =
                 Modifier
                     .align(Alignment.CenterHorizontally)
-                    .padding(top = 56.dp),
+                    .padding(top = 60.dp),
         )
 
         ReviewRatingMessage(
@@ -67,7 +67,7 @@ fun WriteReviewRatingContent(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, top = 30.dp),
+                    .padding(start = 16.dp, end = 16.dp, top = 32.dp),
         )
 
         if (selectedRating?.needsNegativeFeedback == true) {
@@ -114,7 +114,7 @@ private fun ReviewRatingMessage(
             style = MainThemeFont.Body,
             color = MainThemeColor.Gray5,
             textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 8.dp),
+            modifier = Modifier.padding(top = 12.dp),
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewRatingContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewRatingContent.kt
@@ -1,0 +1,165 @@
+package com.hm.picplz.ui.screen.write_review.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.composable.DirectInputTextField
+import com.hm.picplz.ui.screen.common.StarRatingSelector
+import com.hm.picplz.ui.screen.write_review.NEGATIVE_FEEDBACK_MAX_LENGTH
+import com.hm.picplz.ui.screen.write_review.ReviewRating
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun WriteReviewRatingContent(
+    customerNickname: String,
+    photographerName: String,
+    selectedRating: ReviewRating?,
+    negativeFeedbackText: String,
+    onRatingSelect: (ReviewRating) -> Unit,
+    onNegativeFeedbackChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+    ) {
+        Text(
+            text = stringResource(R.string.write_review_rating_title, customerNickname, photographerName),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.write_review_rating_subtitle),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray3,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
+        )
+
+        StarRatingSelector(
+            rating = selectedRating?.score ?: 0,
+            onRatingChange = { score -> ReviewRating.fromScore(score)?.let(onRatingSelect) },
+            modifier =
+                Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 56.dp),
+        )
+
+        ReviewRatingMessage(
+            rating = selectedRating,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 30.dp),
+        )
+
+        if (selectedRating?.needsNegativeFeedback == true) {
+            Text(
+                text = stringResource(R.string.write_review_negative_feedback_label),
+                style = MainThemeFont.TitleSmall,
+                color = MainThemeColor.Black,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 40.dp),
+            )
+
+            DirectInputTextField(
+                value = negativeFeedbackText,
+                onValueChange = onNegativeFeedbackChange,
+                maxLength = NEGATIVE_FEEDBACK_MAX_LENGTH,
+                placeholder = stringResource(R.string.write_review_negative_feedback_placeholder),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
+            )
+        }
+    }
+}
+
+/** 별점별 안내 문구. 미선택 시에는 별점을 매겨달라는 안내를 보여줍니다. */
+@Composable
+private fun ReviewRatingMessage(
+    rating: ReviewRating?,
+    modifier: Modifier = Modifier,
+) {
+    val mainMessageRes = rating?.mainMessageRes ?: R.string.write_review_rating_empty_main
+    val subMessageRes = rating?.subMessageRes ?: R.string.write_review_rating_empty_sub
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(mainMessageRes),
+            style = MainThemeFont.BodySmallButton2,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = stringResource(subMessageRes),
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray5,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewRatingContentPreviewEmpty() {
+    PicplzTheme {
+        WriteReviewRatingContent(
+            customerNickname = "세연",
+            photographerName = "유가영",
+            selectedRating = null,
+            negativeFeedbackText = "",
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewRatingContentPreviewNegative() {
+    PicplzTheme {
+        WriteReviewRatingContent(
+            customerNickname = "세연",
+            photographerName = "유가영",
+            selectedRating = ReviewRating.BAD,
+            negativeFeedbackText = "",
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewRatingContentPreviewExcellent() {
+    PicplzTheme {
+        WriteReviewRatingContent(
+            customerNickname = "세연",
+            photographerName = "유가영",
+            selectedRating = ReviewRating.EXCELLENT,
+            negativeFeedbackText = "",
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -32,6 +32,9 @@
     <string name="reservation_button_review">리뷰 쓰기</string>
     <string name="reservation_button_reservation_approve">예약 승인</string>
 
+    <!-- 거래 완료 모달 -->
+    <string name="reservation_deal_complete_modal_message">거래 완료 되었습니다</string>
+
     <!-- 촬영 일시 미확정 -->
     <string name="reservation_schedule_tbd">작가와 협의</string>
 

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -154,6 +154,28 @@
     <string name="photographer_cancel_dialog_button_no">아니오</string>
     <string name="photographer_cancel_dialog_button_yes">취소할게요</string>
 
+    <!-- 리뷰 작성 - 공통 -->
+    <string name="write_review_top_bar_title">리뷰 작성</string>
+
+    <!-- 리뷰 작성 - 별점 선택 (1/2) -->
+    <string name="write_review_rating_title">%1$s님,\n%2$s 작가님과 촬영이 어떠셨나요?</string>
+    <string name="write_review_rating_subtitle">촬영 만족도는 나만 볼 수 있어요</string>
+    <string name="write_review_rating_empty_main">별점을 매겨주세요</string>
+    <string name="write_review_rating_empty_sub">주관적으로 평가해도 괜찮아요.</string>
+    <string name="write_review_rating_main_1">별로에요</string>
+    <string name="write_review_rating_sub_1">이 작가님과 다시 촬영하고 싶지 않아요.</string>
+    <string name="write_review_rating_main_2">아쉬워요</string>
+    <string name="write_review_rating_sub_2">만족스럽지 못한 촬영이었어요.</string>
+    <string name="write_review_rating_main_3">괜찮았어요</string>
+    <string name="write_review_rating_sub_3">무난했지만, 조금 아쉬운 부분이 있었어요.</string>
+    <string name="write_review_rating_main_4">만족스러워요</string>
+    <string name="write_review_rating_sub_4">전반적으로 만족스러운 촬영이었어요.</string>
+    <string name="write_review_rating_main_5">최고였어요</string>
+    <string name="write_review_rating_sub_5">완벽한 촬영이었어요. 다음에 또 함께하고 싶어요!</string>
+    <string name="write_review_negative_feedback_label">어떤점이 아쉬웠나요?</string>
+    <string name="write_review_negative_feedback_placeholder">여기에 적어주세요. (선택사항)</string>
+    <string name="write_review_rating_button_submit">별점 등록</string>
+
     <!-- 포맷 문자열 -->
     <string name="amount_format">%,d원</string>
 </resources>


### PR DESCRIPTION
## 개요
고객 리뷰 작성 플로우의 **1단계(별점 선택)** 화면을 신설하고, **예약 상세에서 리뷰 작성으로 들어가는 두 경로**를 모두 연결합니다.

```
① 거래 완료하기 → (서버 호출: TODO) → "거래 완료 되었습니다" 모달 → 리뷰 작성 화면 자동 이동
② 리뷰를 쓰지 않고 나온 뒤 → 예약 상세 재진입 → "리뷰 쓰기" → 리뷰 작성 화면
```

리뷰 작성 화면이 프로젝트에 아예 없었고, 진입점만 `MainNavGraph`에 `onNavigateToWriteReview = { /* TODO */ }` 스텁으로 남아 있던 것을 실제 화면으로 연결했습니다.


## 구조 결정
- 화면 위치: **`feature/reservation`** 의 신규 패키지 `write_review/` (MVI 5분할)
  - 진입점이 예약 상세이고, 리뷰 **조회**는 새로 만들지 않고 기존 `DetailPhotographerSingleReview`로 이동시킵니다.
- 라우트: **단일 `WriteReview(orderId)` + 내부 스텝**(`RATING` → `CONTENT`)
  - `PhotographerCancelReservation`(사유 → 규정 2스텝)과 같은 선례를 따라, 별점·부정 피드백을 라우트 인자 대신 하나의 State에 유지합니다.
  - **`CONTENT` 스텝은 이 PR에서 비어 있습니다.** "별점 등록"을 누르면 빈 화면이 되며, 2단계 UI는 #219에서 채웁니다.

## 변경 사항

### ✨ 별점 선택 컴포넌트 신설 (`core/ui`)
- 기존 `ReviewUtil.calculateStarRating()`은 **조회 전용**(drawable resId 리스트 반환)이라 선택 동작을 표현할 수 없었습니다. 탭해서 고르는 `StarRatingSelector`를 신설했습니다.
- 1점 단위 선택, 선택분 `Green120` / 미선택 `Gray2`
- 큰 별 `star_full.xml`이 **Black**이라 tint로 색을 입혔습니다 (신규 drawable 추가 없이 재사용)
- 별 클릭 시 사각 리플이 생기지 않도록 `indication = null`

### ✨ 별점 선택 화면 (1/2)
- 타이틀 `{고객닉네임}님, {작가명} 작가님과 촬영이 어떠셨나요?` / 서브 `촬영 만족도는 나만 볼 수 있어요`
- **별점별 메인/서브 멘트 5종**을 `ReviewRating` enum으로 관리

| 별점 | 메인 | 서브 |
|:---:|---|---|
| 1 | 별로에요 | 이 작가님과 다시 촬영하고 싶지 않아요. |
| 2 | 아쉬워요 | 만족스럽지 못한 촬영이었어요. |
| 3 | 괜찮았어요 | 무난했지만, 조금 아쉬운 부분이 있었어요. |
| 4 | 만족스러워요 | 전반적으로 만족스러운 촬영이었어요. |
| 5 | 최고였어요 | 완벽한 촬영이었어요. 다음에 또 함께하고 싶어요! |

- 미선택 시 `별점을 매겨주세요` / `주관적으로 평가해도 괜찮아요.`
- **1~2점(부정 평가)일 때만** `어떤점이 아쉬웠나요?` 입력란 노출 (선택사항, 최대 600자)
- 하단 `별점 등록` — 별점 미선택 시 비활성

### ✨ 완료 모달 컴포넌트 신설 (`core/ui`)
- `core/ui`에는 **취소/확인 2버튼 고정인 `CommonButtonModal`만** 있어서 버튼 없는 완료 안내 모달을 만들 수 없었습니다.
- `CommonSuccessModal` 신설: 체크 아이콘 + 안내 문구. 기존 `check_circle.xml`(검정 원 + 흰 체크)이 피그마와 동일해 그대로 재사용했습니다.
- 스스로 닫히지 않으므로 호출부가 일정 시간 뒤 닫거나 다음 화면으로 넘겨야 하며, 그동안 사용자가 닫지 못하도록 `dismissible = false`를 줄 수 있습니다.

### ✨ 거래 완료 → 리뷰 작성 진입 (Resolves #216)
기존에는 **거래 완료와 채팅 이동이 한 브랜치로 묶인 테스트 스텁**이었습니다.

```kotlin
// 상태 변경 확인 테스트를 위한 코드입니다.
is DetailReservationIntent.NavigateToChat,
is DetailReservationIntent.ConfirmReservation,
-> {
    _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
}
```

- `ConfirmReservation`을 `NavigateToChat`과 분리
- 거래 완료 시 `COMPLETED`로 전이 + 완료 모달 노출 → 리뷰 작성 화면 자동 이동
- 모달은 자동으로 넘어가므로 바깥 탭·뒤로가기로 닫히지 않게 처리
- 리뷰를 쓰지 않고 나와도 거래는 완료 상태이므로, 재진입 시 `리뷰 쓰기` 버튼이 노출됩니다

### ✨ "리뷰 쓰기" 진입점 연결
- 거래 완료 상태 "리뷰 쓰기" → `WriteReview(orderId)`
- `onNavigateToWriteReview` 시그니처에 `orderId` 추가 (기존 `onNavigateToCancelReservation`과 동일한 형태)
- `WriteReview`를 `authRequiredRoutes`에 추가

## 스크린샷 (에뮬레이터 검증)
<!-- 아래 표의 각 셀(파일명 자리)에 스크린샷 폴더의 해당 파일을 드래그&드롭 해주세요 -->

**거래 완료 → 리뷰 작성 진입**

| 거래 완료 직후 모달 | 리뷰 작성 화면 자동 진입 | 뒤로 나온 뒤 "리뷰 쓰기" 상태 |
|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="01_deal_complete_modal" src="https://github.com/user-attachments/assets/8d7a51d4-f66a-41f8-9220-40b120974b19" />|<img width="1080" height="2220" alt="02_auto_navigated" src="https://github.com/user-attachments/assets/ec28c921-d92b-454f-b1fe-ae4986177b6e" />|<img width="1080" height="2220" alt="03_back_to_detail" src="https://github.com/user-attachments/assets/d8d884d3-4b25-42d4-a4f1-dfe8fc7dd41b" />|


**별점 선택 화면**

| 별점 선택 전 | 별점 2개 (입력란 노출) | 별점 3개 (입력란 없음) | 별점 5개 |
|:---:|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="01_rating_empty" src="https://github.com/user-attachments/assets/784076c9-cefe-4a19-a507-4ec909cc291a" />|<img width="1080" height="2220" alt="02_rating_2" src="https://github.com/user-attachments/assets/33045cd9-db83-4c9c-b55c-33e692d55c7c" />|<img width="1080" height="2220" alt="03_rating_3" src="https://github.com/user-attachments/assets/3218ca90-3eac-4e41-b9eb-8af1a24e47aa" />|<img width="1080" height="2220" alt="04_rating_5" src="https://github.com/user-attachments/assets/d912ba3a-ec58-42d9-944d-60f7bad0e945" />|



> 검증 경로: Dev 메뉴 → DetailReservation(예약 상세) → "채팅 바로가기" 2회로 `촬영 진행중` 전이 → **거래 완료하기** → 완료 모달 → 리뷰 작성 화면 자동 진입 → 별점 1~5점 전환 · 입력란 노출 조건 · 텍스트 입력 → 뒤로가기 → 예약 상세 `거래 완료`/"리뷰 쓰기" 상태 → **"리뷰 쓰기" 재진입 성공**까지 확인. 크래시 없음.

## 참고 / 남은 후속
- **거래 완료 API는 아직 붙이지 않았습니다.** 서버 호출 자리는 `// TODO`로 두고 로컬 상태 전이로 동작합니다.
- 타이틀의 **고객 닉네임·작가명은 더미**입니다. 현재 `DetailReservationState`에 이름 정보가 없어 #217(API 연동)에서 실데이터로 교체합니다.
- **"채팅 바로가기"가 채팅방으로 이동하지 않는 문제는 이 PR에서 고치지 않았습니다.** `NavigateToChat`에 대응하는 SideEffect가 없고, 고객 채팅방 라우트 `ChatRoom(roomId)`에 넘길 **roomId를 예약 상세가 들고 있지 않습니다**. 예약 정보 API가 붙는 시점에 함께 처리하는 게 맞다고 보고 기존 테스트 스텁을 그대로 뒀습니다 — 덕분에 이 PR의 검증 경로도 유지됩니다.
- 피그마와 기획 문서가 다른 부분은 **피그마 기준**으로 반영했습니다.
  - 하단 버튼 `다음` → **`별점 등록`**
  - 5점 멘트 `최고에요.` → **`최고였어요`**
  - 입력란 노출 조건: 기획 문서는 "선택사항"만 명시하나 피그마상 1~2점에만 존재 → **1~2점만 노출**

## 관련 이슈
리뷰 작성 플로우는 아래 순서로 진행합니다.
1. **#213 별점 선택 화면 (1/2) + #216 거래 완료 진입** ← 이 PR
2. #214 촬영 경험 입력 및 등록 (2/2) — PR #219
3. #215 촬영 사진 첨부 (최대 10장) — PR #220
4. #217 리뷰 등록·조회·삭제 API 연동

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다. (`:app:compileDevDebugKotlin` + `ktlintCheck` + `detekt` + 에뮬레이터 전 구간 검증)
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #213
- Resolves #216
