### PR TITLE
✨ 고객 리뷰 작성 – 촬영 경험 입력 및 등록 (2/2)

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -18,6 +18,7 @@ import com.hm.picplz.navigation.model.CancelReservation
 import com.hm.picplz.navigation.model.CancelReservationConfirm
 import com.hm.picplz.navigation.model.Chat
 import com.hm.picplz.navigation.model.ChatRoom
+import com.hm.picplz.navigation.model.DetailPhotographerSingleReview
 import com.hm.picplz.navigation.model.DetailReservation
 import com.hm.picplz.navigation.model.Dev
 import com.hm.picplz.navigation.model.DevMainSearchResultPreview
@@ -330,6 +331,18 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         WriteReviewScreen(
             onNavigateBack = {
                 navController.popBackStack()
+            },
+            onNavigateToReviewDetail = { reviewId ->
+                // 리뷰 작성 화면은 백스택에서 정리하고 작가 리뷰 상세로 이동
+                navController.navigate(
+                    DetailPhotographerSingleReview(
+                        reviewId = reviewId,
+                        photoIndex = 0,
+                        showRegisteredToast = true,
+                    ),
+                ) {
+                    popUpTo<WriteReview> { inclusive = true }
+                }
             },
         )
     }

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
@@ -1,6 +1,14 @@
 package com.hm.picplz.navigation.graph
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -21,6 +29,7 @@ import com.hm.picplz.navigation.model.PhotographerMain
 import com.hm.picplz.navigation.model.PhotographerMainGraph
 import com.hm.picplz.navigation.model.QuickShoot
 import com.hm.picplz.navigation.model.ReviewPhotographer
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerPhotoPortfoliosScreen
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerPhotoReviewsScreen
 import com.hm.picplz.ui.screen.detail_photographer.DetailPhotographerPortfoliosScreen
@@ -32,6 +41,7 @@ import com.hm.picplz.ui.screen.photographer_main.PhotographerMainViewModel
 import com.hm.picplz.ui.screen.photographer_main.composable.EquipmentSettingScreen
 import com.hm.picplz.ui.screen.photographer_main.composable.PhotographerAddDeviceScreen
 import com.hm.picplz.ui.screen.quick_shoot.QuickShootScreen
+import com.hm.picplz.core.ui.R as CoreUiR
 
 fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     composable<QuickShoot> {
@@ -60,11 +70,22 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
 
     composable<DetailPhotographerSingleReview> { backStackEntry ->
         val args = backStackEntry.toRoute<DetailPhotographerSingleReview>()
-        DetailPhotographerSingleReviewScreen(
-            navController = navController,
-            reviewId = args.reviewId,
-            photoIndex = args.photoIndex,
-        )
+        // 리뷰 작성 직후 진입한 경우에만 등록 완료 토스트를 덮어서 띄웁니다.
+        var showRegisteredToast by rememberSaveable { mutableStateOf(args.showRegisteredToast) }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            DetailPhotographerSingleReviewScreen(
+                navController = navController,
+                reviewId = args.reviewId,
+                photoIndex = args.photoIndex,
+            )
+
+            CommonToast(
+                message = stringResource(CoreUiR.string.review_registered_toast),
+                isVisible = showRegisteredToast,
+                onDismiss = { showRegisteredToast = false },
+            )
+        }
     }
 
     composable<DetailPhotographerPhotoPortfolios> { backStackEntry ->

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/PhotographerNavGraph.kt
@@ -3,6 +3,7 @@ package com.hm.picplz.navigation.graph
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -71,7 +72,16 @@ fun NavGraphBuilder.photographerNavGraph(navController: NavHostController) {
     composable<DetailPhotographerSingleReview> { backStackEntry ->
         val args = backStackEntry.toRoute<DetailPhotographerSingleReview>()
         // 리뷰 작성 직후 진입한 경우에만 등록 완료 토스트를 덮어서 띄웁니다.
-        var showRegisteredToast by rememberSaveable { mutableStateOf(args.showRegisteredToast) }
+        // 최초 컴포지션부터 visible이면 진입 애니메이션이 생략되므로 false로 시작해 다음 프레임에 켭니다.
+        var showRegisteredToast by rememberSaveable { mutableStateOf(false) }
+        var registeredToastShown by rememberSaveable { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            if (args.showRegisteredToast && !registeredToastShown) {
+                registeredToastShown = true
+                showRegisteredToast = true
+            }
+        }
 
         Box(modifier = Modifier.fillMaxSize()) {
             DetailPhotographerSingleReviewScreen(

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -157,7 +157,12 @@ data class DetailPhotographerPhotoPortfolios(val photographerId: Int) : Navigati
 data class ChatRoom(val roomId: String) : NavigationRoute
 
 @Serializable
-data class DetailPhotographerSingleReview(val reviewId: Int, val photoIndex: Int) : NavigationRoute
+data class DetailPhotographerSingleReview(
+    val reviewId: Int,
+    val photoIndex: Int,
+    /** 리뷰 작성 직후 진입한 경우 "리뷰가 등록되었습니다." 토스트를 띄웁니다. */
+    val showRegisteredToast: Boolean = false,
+) : NavigationRoute
 
 @Serializable
 data class DetailPhotographerPortfolioDetail(val portfolioId: Int, val photoIndex: Int) : NavigationRoute

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -49,4 +49,9 @@ dependencies {
     implementation(libs.kakao.maps)
 
     debugImplementation(libs.androidx.ui.tooling)
+
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.androidx.junit)
+    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/core/ui/src/androidTest/kotlin/com/hm/picplz/ui/screen/common/CommonToastAnimationTest.kt
+++ b/core/ui/src/androidTest/kotlin/com/hm/picplz/ui/screen/common/CommonToastAnimationTest.kt
@@ -1,0 +1,179 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TOAST_TEXT = "최소 10자 이상 작성해주세요."
+private const val TOAST_DURATION_MS = 2_000L
+
+/**
+ * CommonToast의 진입/퇴장 애니메이션이 실제로 재생되는지 프레임 단위로 고정한다.
+ *
+ * 두 가지 호출 실수를 막기 위한 회귀 테스트다.
+ *  1. `isVisible = true` 상수 전달 → 최초 컴포지션부터 visible이라 진입 애니메이션이 생략된다.
+ *  2. 조건부 컴포지션(`resId?.let { CommonToast(...) }`) → 사라질 때 노드가 즉시 제거되어
+ *     퇴장 애니메이션이 재생될 기회가 없다.
+ *
+ * 따라서 호출부는 CommonToast를 항상 컴포즈해 두고 isVisible만 토글해야 한다.
+ */
+@RunWith(AndroidJUnit4::class)
+class CommonToastAnimationTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun playsEnterAnimationWhenVisibilityTurnsOn() {
+        var visible by mutableStateOf(false)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CommonToast(message = TOAST_TEXT, isVisible = visible, onDismiss = {})
+            }
+        }
+
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.runOnUiThread { visible = true }
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.mainClock.advanceTimeByFrame()
+
+        val duringEnter = composeRule.onNodeWithText(TOAST_TEXT).getBoundsInRoot().top
+        composeRule.mainClock.advanceTimeBy(1_000)
+        val settled = composeRule.onNodeWithText(TOAST_TEXT).getBoundsInRoot().top
+
+        assertTrue(
+            "진입 애니메이션 중에는 최종 위치보다 아래에 있어야 한다 " +
+                "(during=$duringEnter, settled=$settled)",
+            duringEnter.value > settled.value,
+        )
+    }
+
+    @Test
+    fun staysMountedWhileExitAnimationRuns() {
+        var visible by mutableStateOf(false)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CommonToast(message = TOAST_TEXT, isVisible = visible, onDismiss = {})
+            }
+        }
+
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.runOnUiThread { visible = true }
+        composeRule.mainClock.advanceTimeBy(1_000)
+        composeRule.onNodeWithText(TOAST_TEXT).assertIsDisplayed()
+
+        composeRule.runOnUiThread { visible = false }
+        composeRule.mainClock.advanceTimeByFrame()
+
+        assertEquals(
+            "퇴장 애니메이션이 도는 동안에는 노드가 남아 있어야 한다",
+            1,
+            composeRule.toastNodeCount(),
+        )
+    }
+
+    /**
+     * 문구를 visibility와 함께 지우면 퇴장 애니메이션 도중에 텍스트만 먼저 사라진다.
+     * 호출부가 마지막 문구를 유지해야 하는 이유를 고정한다.
+     */
+    @Test
+    fun clearingMessageWithVisibilityDropsTextImmediately() {
+        var message by mutableStateOf("")
+        var visible by mutableStateOf(false)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CommonToast(message = message, isVisible = visible, onDismiss = {})
+            }
+        }
+
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.runOnUiThread {
+            message = TOAST_TEXT
+            visible = true
+        }
+        composeRule.mainClock.advanceTimeBy(1_000)
+        composeRule.onNodeWithText(TOAST_TEXT).assertIsDisplayed()
+
+        composeRule.runOnUiThread {
+            message = ""
+            visible = false
+        }
+        composeRule.mainClock.advanceTimeByFrame()
+
+        assertEquals(
+            "문구를 같이 지우면 퇴장 애니메이션 중에 텍스트가 남지 않는다",
+            0,
+            composeRule.toastNodeCount(),
+        )
+    }
+
+    @Test
+    fun autoDismissesAfterTimeout() {
+        var visible by mutableStateOf(false)
+        var dismissed = false
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CommonToast(
+                    message = TOAST_TEXT,
+                    isVisible = visible,
+                    onDismiss = { dismissed = true },
+                )
+            }
+        }
+
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.runOnUiThread { visible = true }
+        composeRule.mainClock.advanceTimeBy(TOAST_DURATION_MS - 500)
+        assertTrue("타임아웃 전에는 onDismiss가 호출되지 않아야 한다", !dismissed)
+
+        composeRule.mainClock.advanceTimeBy(600)
+        assertTrue("타임아웃 후에는 onDismiss가 호출되어야 한다", dismissed)
+    }
+
+    @Test
+    fun disappearsAfterExitAnimationCompletes() {
+        var visible by mutableStateOf(false)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CommonToast(
+                    message = TOAST_TEXT,
+                    isVisible = visible,
+                    onDismiss = { visible = false },
+                )
+            }
+        }
+
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.runOnUiThread { visible = true }
+        composeRule.mainClock.advanceTimeBy(1_000)
+        composeRule.mainClock.advanceTimeBy(TOAST_DURATION_MS)
+        composeRule.mainClock.advanceTimeBy(3_000)
+
+        assertEquals(
+            "퇴장 애니메이션이 끝나면 노드가 사라져야 한다",
+            0,
+            composeRule.toastNodeCount(),
+        )
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.toastNodeCount(): Int =
+        onAllNodes(hasText(TOAST_TEXT)).fetchSemanticsNodes().size
+}

--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonBottomButton.kt
@@ -22,20 +22,28 @@ private object CommonBottomButtonDefaults {
     val CornerRadius = 5.dp
 }
 
+/**
+ * @param enabled 버튼의 활성 여부. false면 비활성 색상으로 그려집니다.
+ * @param clickableWhenDisabled true면 [enabled]가 false여도 클릭을 받습니다(외형만 비활성).
+ *  입력이 부족할 때 버튼을 눌러 안내 토스트를 띄워야 하는 화면에서 사용합니다.
+ *  Material3 `Button`은 `enabled = false`면 클릭 자체를 막기 때문에 별도 분기가 필요합니다.
+ */
 @Composable
 fun CommonBottomButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    clickableWhenDisabled: Boolean = false,
 ) {
     Button(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors =
             ButtonDefaults.buttonColors(
-                containerColor = MainThemeColor.Black,
-                contentColor = MainThemeColor.White,
+                // enabled = false여도 클릭을 받아야 하면 Material에는 활성으로 넘기고 색만 비활성으로 그립니다.
+                containerColor = if (enabled) MainThemeColor.Black else MainThemeColor.Gray3,
+                contentColor = if (enabled) MainThemeColor.White else MainThemeColor.Gray2,
                 disabledContainerColor = MainThemeColor.Gray3,
                 disabledContentColor = MainThemeColor.Gray2,
             ),
@@ -45,7 +53,7 @@ fun CommonBottomButton(
                 vertical = CommonBottomButtonDefaults.VerticalPadding,
                 horizontal = CommonBottomButtonDefaults.HorizontalPadding,
             ),
-        enabled = enabled,
+        enabled = enabled || clickableWhenDisabled,
     ) {
         Text(
             text = text,
@@ -107,6 +115,20 @@ private fun CommonBottomButtonDisabledPreview() {
             text = "다음",
             onClick = {},
             enabled = false,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CommonBottomButtonDisabledButClickablePreview() {
+    PicplzTheme {
+        CommonBottomButton(
+            text = "리뷰 등록",
+            onClick = {},
+            enabled = false,
+            clickableWhenDisabled = true,
         )
     }
 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="shooting_satisfaction">촬영 만족도</string>
     <string name="star_rating">별점</string>
     <string name="star_rating_score_format">%1$d점</string>
+    <string name="review_registered_toast">리뷰가 등록되었습니다.</string>
     <string name="no_reviews">아직 리뷰가\n없어요</string>
     <string name="review_empty_title">아직 작성한 리뷰가 없어요</string>
     <string name="review_empty_description">촬영 후 남긴 리뷰가 이곳에 모여 보여요</string>

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
@@ -5,8 +5,19 @@ sealed interface WriteReviewIntent {
 
     data class UpdateNegativeFeedback(val text: String) : WriteReviewIntent
 
+    data class UpdateContent(val text: String) : WriteReviewIntent
+
     /** 별점 선택(1/2)의 "별점 등록" */
     data object OnRatingSubmitClick : WriteReviewIntent
 
+    /** 촬영 경험(2/2)의 "리뷰 등록" */
+    data object OnReviewSubmitClick : WriteReviewIntent
+
     data object OnBackClick : WriteReviewIntent
+
+    data object OnExitDialogConfirm : WriteReviewIntent
+
+    data object OnExitDialogDismiss : WriteReviewIntent
+
+    data object DismissToast : WriteReviewIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
@@ -1,6 +1,7 @@
 package com.hm.picplz.ui.screen.write_review
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,15 +18,22 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonDestructiveConfirmDialog
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.write_review.WriteReviewState.Step
+import com.hm.picplz.ui.screen.write_review.composable.WriteReviewExperienceContent
 import com.hm.picplz.ui.screen.write_review.composable.WriteReviewRatingContent
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 
+/** 하단 버튼(높이 + 바깥 여백)을 피해 토스트를 띄우기 위한 오프셋 */
+private val toastBottomOffset = 120.dp
+
 @Composable
 fun WriteReviewScreen(
     onNavigateBack: () -> Unit,
+    onNavigateToReviewDetail: (reviewId: Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: WriteReviewViewModel = hiltViewModel(),
 ) {
@@ -39,6 +47,7 @@ fun WriteReviewScreen(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 WriteReviewSideEffect.NavigateBack -> onNavigateBack()
+                is WriteReviewSideEffect.NavigateToReviewDetail -> onNavigateToReviewDetail(sideEffect.reviewId)
             }
         }
     }
@@ -53,63 +62,128 @@ fun WriteReviewScreen(
         onNegativeFeedbackChange = { text ->
             viewModel.handleIntent(WriteReviewIntent.UpdateNegativeFeedback(text))
         },
+        onContentChange = { text ->
+            viewModel.handleIntent(WriteReviewIntent.UpdateContent(text))
+        },
         onRatingSubmitClick = { viewModel.handleIntent(WriteReviewIntent.OnRatingSubmitClick) },
+        onReviewSubmitClick = { viewModel.handleIntent(WriteReviewIntent.OnReviewSubmitClick) },
+        onExitDialogConfirm = { viewModel.handleIntent(WriteReviewIntent.OnExitDialogConfirm) },
+        onExitDialogDismiss = { viewModel.handleIntent(WriteReviewIntent.OnExitDialogDismiss) },
+        onToastDismiss = { viewModel.handleIntent(WriteReviewIntent.DismissToast) },
     )
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun WriteReviewScreenContent(
     state: WriteReviewState,
     onBackClick: () -> Unit,
     onRatingSelect: (ReviewRating) -> Unit,
     onNegativeFeedbackChange: (String) -> Unit,
+    onContentChange: (String) -> Unit,
     onRatingSubmitClick: () -> Unit,
+    onReviewSubmitClick: () -> Unit,
+    onExitDialogConfirm: () -> Unit,
+    onExitDialogDismiss: () -> Unit,
+    onToastDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Scaffold(
-        modifier = modifier,
-        containerColor = MainThemeColor.White,
-        topBar = {
-            CommonTopBar(
-                text = stringResource(R.string.write_review_top_bar_title),
-                onClickBack = onBackClick,
-            )
-        },
-    ) { innerPadding ->
-        Column(
-            modifier =
-                Modifier
-                    .padding(innerPadding)
-                    .fillMaxSize(),
-        ) {
-            when (state.currentStep) {
-                Step.RATING -> {
-                    WriteReviewRatingContent(
-                        modifier = Modifier.weight(1f),
-                        customerNickname = state.customerNickname,
-                        photographerName = state.photographerName,
-                        selectedRating = state.selectedRating,
-                        negativeFeedbackText = state.negativeFeedbackText,
-                        onRatingSelect = onRatingSelect,
-                        onNegativeFeedbackChange = onNegativeFeedbackChange,
-                    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = modifier,
+            containerColor = MainThemeColor.White,
+            topBar = {
+                CommonTopBar(
+                    text = stringResource(R.string.write_review_top_bar_title),
+                    onClickBack = onBackClick,
+                )
+            },
+        ) { innerPadding ->
+            Column(
+                modifier =
+                    Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize(),
+            ) {
+                when (state.currentStep) {
+                    Step.RATING -> {
+                        WriteReviewRatingContent(
+                            modifier = Modifier.weight(1f),
+                            customerNickname = state.customerNickname,
+                            photographerName = state.photographerName,
+                            selectedRating = state.selectedRating,
+                            negativeFeedbackText = state.negativeFeedbackText,
+                            onRatingSelect = onRatingSelect,
+                            onNegativeFeedbackChange = onNegativeFeedbackChange,
+                        )
 
-                    CommonBottomButton(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
-                        text = stringResource(R.string.write_review_rating_button_submit),
-                        onClick = onRatingSubmitClick,
-                        enabled = state.isRatingStepValid(),
-                    )
+                        WriteReviewBottomButton(
+                            text = stringResource(R.string.write_review_rating_button_submit),
+                            onClick = onRatingSubmitClick,
+                            enabled = state.isRatingStepValid(),
+                        )
+                    }
+
+                    Step.CONTENT -> {
+                        WriteReviewExperienceContent(
+                            modifier = Modifier.weight(1f),
+                            contentText = state.contentText,
+                            onContentChange = onContentChange,
+                        )
+
+                        WriteReviewBottomButton(
+                            text = stringResource(R.string.write_review_content_button_submit),
+                            onClick = onReviewSubmitClick,
+                            enabled = state.isContentStepValid(),
+                            // 최소 글자 수 미달이어도 눌러서 안내 토스트를 받을 수 있어야 합니다.
+                            clickableWhenDisabled = true,
+                        )
+                    }
                 }
-
-                // TODO(#214): 촬영 경험 입력(2/2) 단계
-                Step.CONTENT -> Unit
             }
         }
+
+        if (state.showExitDialog) {
+            CommonDestructiveConfirmDialog(
+                title = stringResource(R.string.write_review_exit_dialog_title),
+                description = stringResource(R.string.write_review_exit_dialog_description),
+                cancelText = stringResource(R.string.write_review_exit_dialog_cancel),
+                confirmText = stringResource(R.string.write_review_exit_dialog_confirm),
+                onDismissRequest = onExitDialogDismiss,
+                onConfirm = onExitDialogConfirm,
+            )
+        }
+
+        state.toastMessageResId?.let { messageResId ->
+            CommonToast(
+                message = stringResource(messageResId, REVIEW_CONTENT_MIN_LENGTH),
+                isVisible = true,
+                onDismiss = onToastDismiss,
+                // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+                bottomOffset = toastBottomOffset,
+            )
+        }
     }
+}
+
+@Composable
+private fun WriteReviewBottomButton(
+    text: String,
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    clickableWhenDisabled: Boolean = false,
+) {
+    CommonBottomButton(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 48.dp),
+        text = text,
+        onClick = onClick,
+        enabled = enabled,
+        clickableWhenDisabled = clickableWhenDisabled,
+    )
 }
 
 @Suppress("UnusedPrivateMember")
@@ -127,7 +201,12 @@ private fun WriteReviewScreenRatingEmptyPreview() {
             onBackClick = {},
             onRatingSelect = {},
             onNegativeFeedbackChange = {},
+            onContentChange = {},
             onRatingSubmitClick = {},
+            onReviewSubmitClick = {},
+            onExitDialogConfirm = {},
+            onExitDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }
@@ -135,20 +214,52 @@ private fun WriteReviewScreenRatingEmptyPreview() {
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true)
 @Composable
-private fun WriteReviewScreenRatingSelectedPreview() {
+private fun WriteReviewScreenContentStepPreview() {
     PicplzTheme {
         WriteReviewScreenContent(
             state =
                 WriteReviewState(
                     orderId = "order123",
-                    customerNickname = "세연",
-                    photographerName = "유가영",
-                    selectedRating = ReviewRating.BAD,
+                    currentStep = Step.CONTENT,
+                    selectedRating = ReviewRating.EXCELLENT,
+                    contentText = "재밌었어요 사진도 잘찍으심",
                 ),
             onBackClick = {},
             onRatingSelect = {},
             onNegativeFeedbackChange = {},
+            onContentChange = {},
             onRatingSubmitClick = {},
+            onReviewSubmitClick = {},
+            onExitDialogConfirm = {},
+            onExitDialogDismiss = {},
+            onToastDismiss = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewScreenExitDialogPreview() {
+    PicplzTheme {
+        WriteReviewScreenContent(
+            state =
+                WriteReviewState(
+                    orderId = "order123",
+                    currentStep = Step.CONTENT,
+                    selectedRating = ReviewRating.EXCELLENT,
+                    contentText = "재밌었어요 사진도 잘찍으심",
+                    showExitDialog = true,
+                ),
+            onBackClick = {},
+            onRatingSelect = {},
+            onNegativeFeedbackChange = {},
+            onContentChange = {},
+            onRatingSubmitClick = {},
+            onReviewSubmitClick = {},
+            onExitDialogConfirm = {},
+            onExitDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
@@ -154,15 +154,19 @@ private fun WriteReviewScreenContent(
             )
         }
 
-        state.toastMessageResId?.let { messageResId ->
-            CommonToast(
-                message = stringResource(messageResId, REVIEW_CONTENT_MIN_LENGTH),
-                isVisible = true,
-                onDismiss = onToastDismiss,
-                // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
-                bottomOffset = toastBottomOffset,
-            )
-        }
+        // CommonToast는 항상 컴포즈해 두고 isVisible만 토글합니다.
+        // 조건부로 컴포즈하면 사라질 때 노드가 즉시 제거되어 퇴장 애니메이션이 재생되지 않고,
+        // isVisible을 상수 true로 넘기면 최초 컴포지션부터 visible이라 진입 애니메이션도 생략됩니다.
+        CommonToast(
+            message =
+                state.toastMessageResId
+                    ?.let { stringResource(it, REVIEW_CONTENT_MIN_LENGTH) }
+                    .orEmpty(),
+            isVisible = state.showToast,
+            onDismiss = onToastDismiss,
+            // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+            bottomOffset = toastBottomOffset,
+        )
     }
 }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
@@ -2,4 +2,7 @@ package com.hm.picplz.ui.screen.write_review
 
 sealed interface WriteReviewSideEffect {
     data object NavigateBack : WriteReviewSideEffect
+
+    /** 리뷰 등록 완료 → 작가 리뷰 상세로 이동 */
+    data class NavigateToReviewDetail(val reviewId: Int) : WriteReviewSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
@@ -15,7 +15,12 @@ data class WriteReviewState(
     /** "촬영 경험을 들려주세요" 입력값 (필수) */
     val contentText: String = "",
     val showExitDialog: Boolean = false,
+    /**
+     * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 문구가 남아 있어야 하므로
+     * [showToast]가 false가 되어도 지우지 않습니다.
+     */
     val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
 ) {
     /** 별점 선택(1/2) 단계의 "별점 등록" 활성화 조건 */
     fun isRatingStepValid(): Boolean = selectedRating != null

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
@@ -1,5 +1,9 @@
 package com.hm.picplz.ui.screen.write_review
 
+/** 촬영 경험 입력 최소/최대 글자 수 */
+const val REVIEW_CONTENT_MIN_LENGTH = 10
+const val REVIEW_CONTENT_MAX_LENGTH = 600
+
 data class WriteReviewState(
     val orderId: String = "",
     val currentStep: Step = Step.RATING,
@@ -8,12 +12,19 @@ data class WriteReviewState(
     val selectedRating: ReviewRating? = null,
     /** 1~2점 선택 시 받는 "어떤점이 아쉬웠나요?" 입력값 (선택사항) */
     val negativeFeedbackText: String = "",
+    /** "촬영 경험을 들려주세요" 입력값 (필수) */
+    val contentText: String = "",
+    val showExitDialog: Boolean = false,
+    val toastMessageResId: Int? = null,
 ) {
     /** 별점 선택(1/2) 단계의 "별점 등록" 활성화 조건 */
     fun isRatingStepValid(): Boolean = selectedRating != null
 
     /** 부정 평가(1~2점)일 때만 아쉬운 점 입력란을 노출합니다. */
     fun showNegativeFeedback(): Boolean = selectedRating?.needsNegativeFeedback == true
+
+    /** 촬영 경험(2/2) 단계의 "리뷰 등록" 활성화 조건 */
+    fun isContentStepValid(): Boolean = contentText.length >= REVIEW_CONTENT_MIN_LENGTH
 
     enum class Step { RATING, CONTENT }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
@@ -77,7 +77,8 @@ class WriteReviewViewModel
                 }
 
                 WriteReviewIntent.DismissToast -> {
-                    _state.update { it.copy(toastMessageResId = null) }
+                    // 퇴장 애니메이션 동안 문구가 남아 있어야 하므로 resId는 유지합니다.
+                    _state.update { it.copy(showToast = false) }
                 }
             }
         }
@@ -88,7 +89,12 @@ class WriteReviewViewModel
          */
         private fun submitReview() {
             if (!_state.value.isContentStepValid()) {
-                _state.update { it.copy(toastMessageResId = R.string.write_review_content_too_short) }
+                _state.update {
+                    it.copy(
+                        toastMessageResId = R.string.write_review_content_too_short,
+                        showToast = true,
+                    )
+                }
                 return
             }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.navigation.model.WriteReview
 import com.hm.picplz.ui.screen.write_review.WriteReviewState.Step
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,6 +21,9 @@ import javax.inject.Inject
 // TODO(#217): 예약 정보 API 연동 시 실제 고객/작가 이름으로 교체
 private const val DUMMY_CUSTOMER_NICKNAME = "세연"
 private const val DUMMY_PHOTOGRAPHER_NAME = "유가영"
+
+// TODO(#217): 리뷰 등록 API 응답의 reviewId로 교체
+private const val DUMMY_REVIEW_ID = 1
 
 @HiltViewModel
 class WriteReviewViewModel
@@ -51,13 +55,55 @@ class WriteReviewViewModel
                     _state.update { it.copy(negativeFeedbackText = intent.text.take(NEGATIVE_FEEDBACK_MAX_LENGTH)) }
                 }
 
+                is WriteReviewIntent.UpdateContent -> {
+                    _state.update { it.copy(contentText = intent.text.take(REVIEW_CONTENT_MAX_LENGTH)) }
+                }
+
                 WriteReviewIntent.OnRatingSubmitClick -> {
                     _state.update { it.copy(currentStep = Step.CONTENT) }
                 }
 
-                WriteReviewIntent.OnBackClick -> {
+                WriteReviewIntent.OnReviewSubmitClick -> submitReview()
+
+                WriteReviewIntent.OnBackClick -> onBackClick()
+
+                WriteReviewIntent.OnExitDialogConfirm -> {
+                    _state.update { it.copy(showExitDialog = false) }
                     emitSideEffect(WriteReviewSideEffect.NavigateBack)
                 }
+
+                WriteReviewIntent.OnExitDialogDismiss -> {
+                    _state.update { it.copy(showExitDialog = false) }
+                }
+
+                WriteReviewIntent.DismissToast -> {
+                    _state.update { it.copy(toastMessageResId = null) }
+                }
+            }
+        }
+
+        /**
+         * 촬영 경험이 최소 글자 수에 못 미치면 이동 대신 안내 토스트를 띄웁니다.
+         * (버튼은 비활성 외형이지만 클릭은 받습니다)
+         */
+        private fun submitReview() {
+            if (!_state.value.isContentStepValid()) {
+                _state.update { it.copy(toastMessageResId = R.string.write_review_content_too_short) }
+                return
+            }
+
+            // TODO(#217): 리뷰 등록 API 연동
+            emitSideEffect(WriteReviewSideEffect.NavigateToReviewDetail(reviewId = DUMMY_REVIEW_ID))
+        }
+
+        /**
+         * 촬영 경험 단계에서는 입력한 내용이 사라지므로 중단 여부를 먼저 확인합니다.
+         * 별점 단계에서는 바로 이탈합니다.
+         */
+        private fun onBackClick() {
+            when (_state.value.currentStep) {
+                Step.RATING -> emitSideEffect(WriteReviewSideEffect.NavigateBack)
+                Step.CONTENT -> _state.update { it.copy(showExitDialog = true) }
             }
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewExperienceContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewExperienceContent.kt
@@ -1,0 +1,78 @@
+package com.hm.picplz.ui.screen.write_review.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.cancel_reservation.composable.DirectInputTextField
+import com.hm.picplz.ui.screen.write_review.REVIEW_CONTENT_MAX_LENGTH
+import com.hm.picplz.ui.screen.write_review.REVIEW_CONTENT_MIN_LENGTH
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+@Composable
+fun WriteReviewExperienceContent(
+    contentText: String,
+    onContentChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+    ) {
+        Text(
+            text = stringResource(R.string.write_review_content_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.write_review_content_subtitle),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
+        )
+
+        DirectInputTextField(
+            value = contentText,
+            onValueChange = onContentChange,
+            maxLength = REVIEW_CONTENT_MAX_LENGTH,
+            placeholder = stringResource(R.string.write_review_content_placeholder, REVIEW_CONTENT_MIN_LENGTH),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewExperienceContentPreviewEmpty() {
+    PicplzTheme {
+        WriteReviewExperienceContent(
+            contentText = "",
+            onContentChange = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WriteReviewExperienceContentPreviewFilled() {
+    PicplzTheme {
+        WriteReviewExperienceContent(
+            contentText = "재밌었어요 사진도 잘찍으심",
+            onContentChange = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -179,6 +179,19 @@
     <string name="write_review_negative_feedback_placeholder">여기에 적어주세요. (선택사항)</string>
     <string name="write_review_rating_button_submit">별점 등록</string>
 
+    <!-- 리뷰 작성 - 촬영 경험 입력 (2/2) -->
+    <string name="write_review_content_title">촬영 경험을 들려주세요</string>
+    <string name="write_review_content_subtitle">촬영 과정과 작가에 대한 솔직한 의견을 작성해주세요.</string>
+    <string name="write_review_content_placeholder">어떤 부분이 만족스러우셨나요? 촬영 과정, 작가의 특징 등 생생한 경험을 들려주세요.\n(최소 %1$d자 이상)</string>
+    <string name="write_review_content_too_short">최소 %1$d자 이상 작성해주세요.</string>
+    <string name="write_review_content_button_submit">리뷰 등록</string>
+
+    <!-- 리뷰 작성 - 중단 다이얼로그 -->
+    <string name="write_review_exit_dialog_title">리뷰 등록을 중단하시겠어요?</string>
+    <string name="write_review_exit_dialog_description">나가기를 누르면\n입력한 내용이 저장되지 않아요.</string>
+    <string name="write_review_exit_dialog_cancel">취소</string>
+    <string name="write_review_exit_dialog_confirm">나가기</string>
+
     <!-- 포맷 문자열 -->
     <string name="amount_format">%,d원</string>
 </resources>


### PR DESCRIPTION
## 개요
고객 리뷰 작성 플로우의 **2단계(촬영 경험 입력)** 와 등록 처리를 구현합니다. 1단계(별점 선택)는 선행 PR #218에서 구현했습니다.

## 변경 사항

### ✨ `CommonBottomButton`에 `clickableWhenDisabled` 추가 (`core/ui`)
기획이 아래 두 가지를 동시에 요구합니다.
- 10자 이상 입력 시 `리뷰 등록` 버튼 **활성화**
- 10자 미만일 때 버튼을 누르면 토스트 `최소 10자 이상 작성해주세요.`

기존 `CommonBottomButton`은 `enabled`를 Material3 `Button`에 그대로 넘겨 **`enabled = false`면 클릭 자체가 차단**되고, `containerColor`도 하드코딩이라 "활성인데 회색"으로 그릴 수도 없었습니다.

→ **외형(`enabled`)과 클릭 수신(`clickableWhenDisabled`)을 분리**했습니다. 기본값 `false`이므로 기존 호출부 동작은 그대로입니다.

### ✨ 촬영 경험 입력 (2/2)
- `촬영 경험을 들려주세요` / `촬영 과정과 작가에 대한 솔직한 의견을 작성해주세요.`
- **필수 입력**, 최소 10자 / 최대 600자
- 10자 미만에서 `리뷰 등록` 탭 → `CommonToast`로 안내
  - 기본 토스트 오프셋(50dp)이 하단 버튼과 겹쳐서 버튼 위로 띄우도록 조정

### ✨ 뒤로가기 중단 다이얼로그
- 하드웨어 백(`BackHandler`)과 탑바 뒤로가기를 **같은 Intent로 수렴**
- 촬영 경험 단계에서만 `리뷰 등록을 중단하시겠어요?` / `나가기를 누르면 입력한 내용이 저장되지 않아요.` / `취소`·`나가기`
- 별점 단계에서는 다이얼로그 없이 바로 이탈 (입력값이 없으므로)
- `core/ui`의 `CommonDestructiveConfirmDialog` 재사용

### ✨ 등록 완료 → 리뷰 상세 이동 + 토스트
- `DetailPhotographerSingleReview`로 이동, `popUpTo<WriteReview>(inclusive = true)`로 작성 화면 정리
- `리뷰가 등록되었습니다.` 토스트
- 라우트에 `showRegisteredToast` 인자 추가(기본 `false` — 기존 호출부 영향 없음)
- **토스트는 리뷰 상세 화면 내부가 아니라 네비게이션 그래프에서 덮어 그립니다.** `DetailPhotographerSingleReviewScreen`이 리뷰 데이터가 없으면 조기 `return`하는 구조라, 화면 안에 넣으면 토스트까지 함께 사라지기 때문입니다. 기존 화면 코드는 건드리지 않았습니다.

## ⚠️ 확인된 선행 결함 (이 PR 범위 밖)
등록 후 이동한 **리뷰 상세 화면이 빈 화면으로 뜹니다.** 원인은 이 PR과 무관한 기존 구조 문제입니다.

- `DetailPhotographerSingleReview(reviewId, photoIndex)` 라우트에 **`photographerId`가 없습니다.**
- 그런데 `DetailPhotographerViewModel`은 `savedStateHandle["photographerId"] ?: 0`으로 로드 대상을 정합니다.
- Compose Navigation은 목적지마다 **자기 라우트 인자로 만든 `SavedStateHandle`** 을 주므로, 이 목적지는 항상 `photographerId = 0`으로 로드합니다.
- 결과적으로 `state.reviews`가 비고, `DetailPhotographerSingleReviewScreen`의 `?: return`에 걸려 아무것도 그려지지 않습니다.

즉 **리뷰 상세 화면은 리뷰 작성 플로우와 무관하게 원래 자기 데이터를 못 불러오는 상태**입니다. 네비게이션·토스트 배선은 이 PR에서 정상 동작하며(스크린샷 참고), 화면이 실제로 채워지는 것은 `photographerId` 전달 + 리뷰 API가 붙는 #217에서 해결되어야 합니다.

## 스크린샷 (에뮬레이터 검증)
<!-- 아래 표의 각 셀(파일명 자리)에 스크린샷 폴더의 해당 파일을 드래그&드롭 해주세요 -->

| 내용 없음 (비활성) | 10자 미만 탭 → 토스트 | 뒤로가기 중단 다이얼로그 | 등록 후 이동 + 토스트 |
|:---:|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="09_content_empty" src="https://github.com/user-attachments/assets/e688c8b5-ecdd-4541-b161-e4e5d52ca9fb" />|<img width="1080" height="2220" alt="10_toast_too_short" src="https://github.com/user-attachments/assets/c560ea58-01d9-4364-a4b7-50efee3df9b0" />|<img width="1080" height="2220" alt="12_exit_dialog" src="https://github.com/user-attachments/assets/dd2db3aa-c122-4dd5-a08d-818f5d88b0db" />|<img width="1080" height="2220" alt="13_after_submit" src="https://github.com/user-attachments/assets/45022c04-198d-4280-b20a-bfca8f8a0c02" />|

> 마지막 스크린샷의 빈 화면이 위에 적은 선행 결함입니다. 토스트는 정상 표시됩니다.


> 검증 경로: Dev → DetailReservation → `COMPLETED` 전이 → 리뷰 쓰기 → 별점 선택 → 별점 등록 → 촬영 경험 입력 → (빈 상태 탭/토스트 · 10자 이상 입력 시 활성화 · 뒤로가기 다이얼로그 취소·나가기 · 리뷰 등록) 전 구간 확인. 크래시 없음.

## 남은 후속
- 촬영 사진 첨부(피그마의 "촬영 사진을 올려주세요" 섹션)는 #215에서 같은 화면에 추가됩니다.
- 리뷰 등록 API 연동 및 실제 `reviewId` 사용, 리뷰 상세 데이터 로딩은 #217.

## 관련 이슈
1. #213 별점 선택 화면 (1/2) — PR #218
2. **#214 촬영 경험 입력 및 등록 (2/2)** ← 이 PR
3. #215 촬영 사진 첨부 (최대 10장)
4. #217 리뷰 등록·조회·삭제 API 연동

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다. (`:app:compileDevDebugKotlin` + `ktlintCheck` + `detekt` + 에뮬레이터 전 구간 검증)
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #214
