### PR TITLE
✨ 고객 리뷰 작성 – 촬영 사진 첨부 (최대 10장)

### DIFF
--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewIntent.kt
@@ -7,6 +7,13 @@ sealed interface WriteReviewIntent {
 
     data class UpdateContent(val text: String) : WriteReviewIntent
 
+    /** "사진 추가" 타일 탭 → 사진 선택기 실행 */
+    data object OnAddPhotoClick : WriteReviewIntent
+
+    data class AddPhotos(val uris: List<String>) : WriteReviewIntent
+
+    data class RemovePhoto(val uri: String) : WriteReviewIntent
+
     /** 별점 선택(1/2)의 "별점 등록" */
     data object OnRatingSubmitClick : WriteReviewIntent
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewScreen.kt
@@ -1,6 +1,10 @@
 package com.hm.picplz.ui.screen.write_review
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,6 +43,16 @@ fun WriteReviewScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    // Android Photo Picker. 시스템 선택기를 쓰므로 저장소 권한이 필요 없습니다.
+    val photoPickerLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.PickMultipleVisualMedia(REVIEW_PHOTO_MAX_COUNT),
+        ) { uris ->
+            if (uris.isNotEmpty()) {
+                viewModel.handleIntent(WriteReviewIntent.AddPhotos(uris.map(Uri::toString)))
+            }
+        }
+
     BackHandler {
         viewModel.handleIntent(WriteReviewIntent.OnBackClick)
     }
@@ -48,6 +62,11 @@ fun WriteReviewScreen(
             when (sideEffect) {
                 WriteReviewSideEffect.NavigateBack -> onNavigateBack()
                 is WriteReviewSideEffect.NavigateToReviewDetail -> onNavigateToReviewDetail(sideEffect.reviewId)
+                WriteReviewSideEffect.LaunchPhotoPicker -> {
+                    photoPickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                    )
+                }
             }
         }
     }
@@ -65,6 +84,10 @@ fun WriteReviewScreen(
         onContentChange = { text ->
             viewModel.handleIntent(WriteReviewIntent.UpdateContent(text))
         },
+        onAddPhotoClick = { viewModel.handleIntent(WriteReviewIntent.OnAddPhotoClick) },
+        onRemovePhotoClick = { uri ->
+            viewModel.handleIntent(WriteReviewIntent.RemovePhoto(uri))
+        },
         onRatingSubmitClick = { viewModel.handleIntent(WriteReviewIntent.OnRatingSubmitClick) },
         onReviewSubmitClick = { viewModel.handleIntent(WriteReviewIntent.OnReviewSubmitClick) },
         onExitDialogConfirm = { viewModel.handleIntent(WriteReviewIntent.OnExitDialogConfirm) },
@@ -81,6 +104,8 @@ private fun WriteReviewScreenContent(
     onRatingSelect: (ReviewRating) -> Unit,
     onNegativeFeedbackChange: (String) -> Unit,
     onContentChange: (String) -> Unit,
+    onAddPhotoClick: () -> Unit,
+    onRemovePhotoClick: (String) -> Unit,
     onRatingSubmitClick: () -> Unit,
     onReviewSubmitClick: () -> Unit,
     onExitDialogConfirm: () -> Unit,
@@ -128,7 +153,11 @@ private fun WriteReviewScreenContent(
                         WriteReviewExperienceContent(
                             modifier = Modifier.weight(1f),
                             contentText = state.contentText,
+                            photoUris = state.photoUris,
+                            canAddPhoto = state.canAddPhoto(),
                             onContentChange = onContentChange,
+                            onAddPhotoClick = onAddPhotoClick,
+                            onRemovePhotoClick = onRemovePhotoClick,
                         )
 
                         WriteReviewBottomButton(
@@ -206,6 +235,8 @@ private fun WriteReviewScreenRatingEmptyPreview() {
             onRatingSelect = {},
             onNegativeFeedbackChange = {},
             onContentChange = {},
+            onAddPhotoClick = {},
+            onRemovePhotoClick = {},
             onRatingSubmitClick = {},
             onReviewSubmitClick = {},
             onExitDialogConfirm = {},
@@ -232,6 +263,8 @@ private fun WriteReviewScreenContentStepPreview() {
             onRatingSelect = {},
             onNegativeFeedbackChange = {},
             onContentChange = {},
+            onAddPhotoClick = {},
+            onRemovePhotoClick = {},
             onRatingSubmitClick = {},
             onReviewSubmitClick = {},
             onExitDialogConfirm = {},
@@ -259,6 +292,8 @@ private fun WriteReviewScreenExitDialogPreview() {
             onRatingSelect = {},
             onNegativeFeedbackChange = {},
             onContentChange = {},
+            onAddPhotoClick = {},
+            onRemovePhotoClick = {},
             onRatingSubmitClick = {},
             onReviewSubmitClick = {},
             onExitDialogConfirm = {},

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewSideEffect.kt
@@ -5,4 +5,6 @@ sealed interface WriteReviewSideEffect {
 
     /** 리뷰 등록 완료 → 작가 리뷰 상세로 이동 */
     data class NavigateToReviewDetail(val reviewId: Int) : WriteReviewSideEffect
+
+    data object LaunchPhotoPicker : WriteReviewSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewState.kt
@@ -4,6 +4,9 @@ package com.hm.picplz.ui.screen.write_review
 const val REVIEW_CONTENT_MIN_LENGTH = 10
 const val REVIEW_CONTENT_MAX_LENGTH = 600
 
+/** 첨부 가능한 촬영 사진 최대 장수 */
+const val REVIEW_PHOTO_MAX_COUNT = 10
+
 data class WriteReviewState(
     val orderId: String = "",
     val currentStep: Step = Step.RATING,
@@ -14,6 +17,8 @@ data class WriteReviewState(
     val negativeFeedbackText: String = "",
     /** "촬영 경험을 들려주세요" 입력값 (필수) */
     val contentText: String = "",
+    /** 첨부한 촬영 사진 URI (선택사항, 최대 [REVIEW_PHOTO_MAX_COUNT]장) */
+    val photoUris: List<String> = emptyList(),
     val showExitDialog: Boolean = false,
     /**
      * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 문구가 남아 있어야 하므로
@@ -28,8 +33,11 @@ data class WriteReviewState(
     /** 부정 평가(1~2점)일 때만 아쉬운 점 입력란을 노출합니다. */
     fun showNegativeFeedback(): Boolean = selectedRating?.needsNegativeFeedback == true
 
-    /** 촬영 경험(2/2) 단계의 "리뷰 등록" 활성화 조건 */
+    /** 촬영 경험(2/2) 단계의 "리뷰 등록" 활성화 조건. 사진은 선택사항이라 조건에 넣지 않습니다. */
     fun isContentStepValid(): Boolean = contentText.length >= REVIEW_CONTENT_MIN_LENGTH
+
+    /** 최대 장수에 도달하면 사진 추가 타일을 숨깁니다. */
+    fun canAddPhoto(): Boolean = photoUris.size < REVIEW_PHOTO_MAX_COUNT
 
     enum class Step { RATING, CONTENT }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/WriteReviewViewModel.kt
@@ -59,6 +59,16 @@ class WriteReviewViewModel
                     _state.update { it.copy(contentText = intent.text.take(REVIEW_CONTENT_MAX_LENGTH)) }
                 }
 
+                WriteReviewIntent.OnAddPhotoClick -> {
+                    emitSideEffect(WriteReviewSideEffect.LaunchPhotoPicker)
+                }
+
+                is WriteReviewIntent.AddPhotos -> addPhotos(intent.uris)
+
+                is WriteReviewIntent.RemovePhoto -> {
+                    _state.update { it.copy(photoUris = it.photoUris - intent.uri) }
+                }
+
                 WriteReviewIntent.OnRatingSubmitClick -> {
                     _state.update { it.copy(currentStep = Step.CONTENT) }
                 }
@@ -80,6 +90,16 @@ class WriteReviewViewModel
                     // 퇴장 애니메이션 동안 문구가 남아 있어야 하므로 resId는 유지합니다.
                     _state.update { it.copy(showToast = false) }
                 }
+            }
+        }
+
+        /**
+         * 사진 선택기가 남은 장수보다 많이 돌려줄 수 있으므로 최대 장수로 잘라 담습니다.
+         * 같은 사진을 다시 고른 경우는 중복으로 쌓지 않습니다.
+         */
+        private fun addPhotos(uris: List<String>) {
+            _state.update { state ->
+                state.copy(photoUris = (state.photoUris + uris).distinct().take(REVIEW_PHOTO_MAX_COUNT))
             }
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/ReviewPhotoAttachment.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/ReviewPhotoAttachment.kt
@@ -1,0 +1,192 @@
+package com.hm.picplz.ui.screen.write_review.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.write_review.REVIEW_PHOTO_MAX_COUNT
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+import com.hm.picplz.core.ui.R as CoreUiR
+
+private val photoTileSize = 120.dp
+private val photoTileRadius = 5.dp
+private val removeBadgeSize = 22.dp
+private val removeIconSize = 10.dp
+private const val REMOVE_BADGE_ALPHA = 0.6f
+
+/**
+ * 촬영 사진 첨부 영역. 좌측 고정 "사진 추가" 타일 + 첨부한 사진 썸네일 가로 스크롤.
+ */
+@Composable
+fun ReviewPhotoAttachment(
+    photoUris: List<String>,
+    canAddPhoto: Boolean,
+    onAddClick: () -> Unit,
+    onRemoveClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.write_review_photo_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.write_review_photo_subtitle),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray4,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
+        )
+
+        LazyRow(
+            modifier = Modifier.padding(top = 16.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (canAddPhoto) {
+                item {
+                    AddPhotoTile(
+                        photoCount = photoUris.size,
+                        onClick = onAddClick,
+                    )
+                }
+            }
+
+            items(photoUris, key = { it }) { uri ->
+                ReviewPhotoThumbnail(
+                    uri = uri,
+                    onRemoveClick = { onRemoveClick(uri) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddPhotoTile(
+    photoCount: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .size(photoTileSize)
+                .clip(RoundedCornerShape(photoTileRadius))
+                .background(MainThemeColor.Gray1)
+                .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            painter = painterResource(CoreUiR.drawable.plus_icon),
+            contentDescription = null,
+            tint = MainThemeColor.Gray5,
+        )
+
+        Text(
+            text = stringResource(R.string.write_review_photo_add),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray5,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.write_review_photo_count_format, photoCount, REVIEW_PHOTO_MAX_COUNT),
+            style = MainThemeFont.Caption,
+            color = MainThemeColor.Gray3,
+        )
+    }
+}
+
+@Composable
+private fun ReviewPhotoThumbnail(
+    uri: String,
+    onRemoveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.size(photoTileSize)) {
+        AsyncImage(
+            model = uri,
+            contentDescription = stringResource(R.string.write_review_photo_thumbnail),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(photoTileRadius))
+                    .background(MainThemeColor.Gray1),
+        )
+
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp)
+                    .size(removeBadgeSize)
+                    .clip(CircleShape)
+                    .background(MainThemeColor.Black.copy(alpha = REMOVE_BADGE_ALPHA))
+                    .clickable(onClick = onRemoveClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(CoreUiR.drawable.full_close),
+                contentDescription = stringResource(R.string.write_review_photo_remove),
+                tint = MainThemeColor.White,
+                modifier = Modifier.size(removeIconSize),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReviewPhotoAttachmentPreviewEmpty() {
+    PicplzTheme {
+        ReviewPhotoAttachment(
+            photoUris = emptyList(),
+            canAddPhoto = true,
+            onAddClick = {},
+            onRemoveClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReviewPhotoAttachmentPreviewWithPhotos() {
+    PicplzTheme {
+        ReviewPhotoAttachment(
+            photoUris = listOf("photo1", "photo2", "photo3"),
+            canAddPhoto = true,
+            onAddClick = {},
+            onRemoveClick = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewExperienceContent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/write_review/composable/WriteReviewExperienceContent.kt
@@ -22,7 +22,11 @@ import com.hm.picplz.ui.theme.PicplzTheme
 @Composable
 fun WriteReviewExperienceContent(
     contentText: String,
+    photoUris: List<String>,
+    canAddPhoto: Boolean,
     onContentChange: (String) -> Unit,
+    onAddPhotoClick: () -> Unit,
+    onRemovePhotoClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -52,6 +56,14 @@ fun WriteReviewExperienceContent(
             placeholder = stringResource(R.string.write_review_content_placeholder, REVIEW_CONTENT_MIN_LENGTH),
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
         )
+
+        ReviewPhotoAttachment(
+            photoUris = photoUris,
+            canAddPhoto = canAddPhoto,
+            onAddClick = onAddPhotoClick,
+            onRemoveClick = onRemovePhotoClick,
+            modifier = Modifier.padding(top = 36.dp),
+        )
     }
 }
 
@@ -61,7 +73,11 @@ private fun WriteReviewExperienceContentPreviewEmpty() {
     PicplzTheme {
         WriteReviewExperienceContent(
             contentText = "",
+            photoUris = emptyList(),
+            canAddPhoto = true,
             onContentChange = {},
+            onAddPhotoClick = {},
+            onRemovePhotoClick = {},
         )
     }
 }
@@ -72,7 +88,11 @@ private fun WriteReviewExperienceContentPreviewFilled() {
     PicplzTheme {
         WriteReviewExperienceContent(
             contentText = "재밌었어요 사진도 잘찍으심",
+            photoUris = listOf("photo1", "photo2"),
+            canAddPhoto = true,
             onContentChange = {},
+            onAddPhotoClick = {},
+            onRemovePhotoClick = {},
         )
     }
 }

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -186,6 +186,14 @@
     <string name="write_review_content_too_short">최소 %1$d자 이상 작성해주세요.</string>
     <string name="write_review_content_button_submit">리뷰 등록</string>
 
+    <!-- 리뷰 작성 - 촬영 사진 첨부 -->
+    <string name="write_review_photo_title">촬영 사진을 올려주세요</string>
+    <string name="write_review_photo_subtitle">최종 결과물 사진, 사진 이미지 일부 혹은 촬영과 관련된 사진을 공유해주세요. 다른 고객님들께 큰 도움이 됩니다. (선택사항)</string>
+    <string name="write_review_photo_add">사진 추가</string>
+    <string name="write_review_photo_count_format">%1$d/%2$d</string>
+    <string name="write_review_photo_thumbnail">촬영 사진</string>
+    <string name="write_review_photo_remove">사진 삭제</string>
+
     <!-- 리뷰 작성 - 중단 다이얼로그 -->
     <string name="write_review_exit_dialog_title">리뷰 등록을 중단하시겠어요?</string>
     <string name="write_review_exit_dialog_description">나가기를 누르면\n입력한 내용이 저장되지 않아요.</string>


### PR DESCRIPTION
## 개요
리뷰 작성 2단계에 **촬영 사진 첨부(선택사항, 최대 10장)** 를 추가합니다. 이걸로 피그마의 `3리뷰 등록` 화면이 완성됩니다.


## 변경 사항

### ✨ 다중 사진 선택 도입 — 프로젝트 첫 적용
- `ActivityResultContracts.PickMultipleVisualMedia(10)` 사용
- 기존 프로젝트는 전부 `GetContent()` **단일 선택**만 썼습니다 (프로필 이미지, 작가 프로필 수정, 촬영 패키지 배너 3곳)
- **저장소 런타임 권한이 필요 없습니다.** Android Photo Picker는 시스템 선택기가 URI를 넘겨주는 방식이라 `READ_MEDIA_IMAGES`/`READ_EXTERNAL_STORAGE`를 요구하지 않습니다.
  → 이슈에 적었던 "사진 권한 처리 공통화"는 **불필요해져서 하지 않았습니다.** `MyPagePhotographerModifyProfileScreen`의 권한 분기 로직을 추출하지 않아도 됩니다.

### ✨ 사진 첨부 UI
- 섹션 `촬영 사진을 올려주세요` + 설명 `... 다른 고객님들께 큰 도움이 됩니다. (선택사항)`
- 좌측 고정 **`사진 추가` `N/10` 타일** + 첨부 사진 **썸네일 가로 스크롤**(`LazyRow`)
- 썸네일 우상단 **X 배지로 개별 삭제**
- 최대 장수 도달 시 추가 타일 숨김
- 선택 결과는 최대 장수로 잘라 담고, 같은 사진을 다시 고르면 중복으로 쌓지 않습니다

## 범위 외
- **사진 순서 변경(꾹 눌러 드래그)** — 프로젝트에 드래그 리오더 구현·라이브러리가 전혀 없고, 참고할 포트폴리오 편집 화면도 미구현입니다. 리뷰는 대표 사진 개념도 없어 순서 가치가 낮아, 리오더 인프라 도입은 포트폴리오와 함께 다루는 별도 이슈로 남깁니다.
- 대표 사진 지정 없음
- S3 업로드(`imageType = "REVIEW"`)와 등록 API 연동 → #217. 이 PR은 로컬 `Uri` 상태만 관리합니다.

## 스크린샷 (에뮬레이터 검증)
<!-- 아래 표의 각 셀(파일명 자리)에 스크린샷 폴더의 해당 파일을 드래그&드롭 해주세요 -->

| 사진 없음 (0/10) | 시스템 사진 선택기 | 3장 첨부 (3/10) | 최대 도달 시 추가 타일 숨김 |
|:---:|:---:|:---:|:---:|
|<img width="1080" height="2220" alt="01_photo_empty" src="https://github.com/user-attachments/assets/7814c7dd-3c50-4e14-8e3d-3cc701136a57" />|<img width="1080" height="2220" alt="02_picker" src="https://github.com/user-attachments/assets/7cbd5b25-b3ee-4856-b3c3-87d19b1ee325" />|<img width="1080" height="2220" alt="04_photos_added" src="https://github.com/user-attachments/assets/af3f3fb3-6509-4b08-b696-322f196af82b" />|<img width="1080" height="2220" alt="07_cap_reached" src="https://github.com/user-attachments/assets/48f7442c-42f3-4c93-b8f8-ff326b5732bb" />|

> 썸네일 이미지가 흰 배경으로 보이는 이유는 테스트용으로 넣은 이미지가 앱 스크린샷이기 때문입니다.

> 검증 내역: 사진 선택기 실행(**권한 프롬프트 없음 확인**) → 다중 선택 3장 첨부 → 카운터 `3/10` → X 배지로 1장 삭제 → `2/10` → 재선택 시 중복 미증가. 최대 장수 동작은 테스트 이미지가 4장뿐이라, **`REVIEW_PHOTO_MAX_COUNT`를 잠시 3으로 낮춰 추가 타일이 사라지는 것까지 확인한 뒤 10으로 되돌렸습니다.** 크래시 없음.

## 관련 이슈
1. #213 별점 선택 화면 (1/2) — PR #218
2. #214 촬영 경험 입력 및 등록 (2/2) — PR #219
3. **#215 촬영 사진 첨부 (최대 10장)** ← 이 PR
4. #217 리뷰 등록·조회·삭제 API 연동

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다. (`:app:compileDevDebugKotlin` + `ktlintCheck` + `detekt` + 에뮬레이터 검증)
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #215
