### PR TITLE
✨ 고객 예약 상세 – 거래 완료 처리 및 리뷰 작성 진입

### DIFF
--- a/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSuccessModal.kt
+++ b/core/ui/src/main/kotlin/com/hm/picplz/ui/screen/common/CommonSuccessModal.kt
@@ -1,0 +1,122 @@
+package com.hm.picplz.ui.screen.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hm.picplz.core.ui.R
+import com.hm.picplz.ui.theme.MainThemeColor
+import com.hm.picplz.ui.theme.MainThemeFont
+import com.hm.picplz.ui.theme.PicplzTheme
+
+private object CommonSuccessModalDefaults {
+    val Width = 304.dp
+    val Radius = RoundedCornerShape(5.dp)
+    val IconSize = 64.dp
+    val VerticalPadding = 28.dp
+    val HorizontalPadding = 20.dp
+    val IconMessageGap = 20.dp
+    val ScrimColor = Color(0x66000000)
+}
+
+/**
+ * 체크 아이콘 + 안내 문구만 있는 완료 모달. 버튼이 없어 스스로 닫히지 않으므로,
+ * 호출부에서 일정 시간 뒤 닫거나 다음 화면으로 넘겨야 합니다.
+ *
+ * 취소/확인 2버튼이 필요하면 [CommonButtonModal]을 쓰세요.
+ *
+ * @param dismissible false면 바깥 탭·뒤로가기로 닫히지 않습니다.
+ */
+@Composable
+fun CommonSuccessModal(
+    message: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissible: Boolean = true,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = dismissible,
+                dismissOnClickOutside = dismissible,
+            ),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(CommonSuccessModalDefaults.ScrimColor)
+                    .clickable(enabled = dismissible, onClick = onDismissRequest),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier =
+                    modifier
+                        .width(CommonSuccessModalDefaults.Width)
+                        .clickable(enabled = false, onClick = {}),
+                shape = CommonSuccessModalDefaults.Radius,
+                color = MainThemeColor.White,
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                vertical = CommonSuccessModalDefaults.VerticalPadding,
+                                horizontal = CommonSuccessModalDefaults.HorizontalPadding,
+                            ),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Image(
+                        painter = painterResource(R.drawable.check_circle),
+                        contentDescription = null,
+                        modifier = Modifier.size(CommonSuccessModalDefaults.IconSize),
+                    )
+
+                    Box(modifier = Modifier.height(CommonSuccessModalDefaults.IconMessageGap))
+
+                    Text(
+                        text = message,
+                        style = MainThemeFont.TitleSmall,
+                        color = MainThemeColor.Black,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true)
+@Composable
+private fun CommonSuccessModalPreview() {
+    PicplzTheme {
+        CommonSuccessModal(
+            message = "거래 완료 되었습니다",
+            onDismissRequest = {},
+        )
+    }
+}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -18,6 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonSuccessModal
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
 import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationCancelDialog
@@ -122,6 +123,15 @@ private fun DetailReservationScreen(
         if (state.showRefundPolicyTooltip) {
             ReservationRefundPolicyDialog(
                 onDismissRequest = onRefundPolicyDismiss,
+            )
+        }
+
+        if (state.showDealCompleteModal) {
+            // 잠시 뒤 리뷰 작성 화면으로 자동 이동하므로 사용자가 닫지 않도록 합니다.
+            CommonSuccessModal(
+                message = stringResource(R.string.reservation_deal_complete_modal_message),
+                onDismissRequest = {},
+                dismissible = false,
             )
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -12,4 +12,6 @@ data class DetailReservationState(
     val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
     val refundCondition: RefundCondition = RefundCondition.WITHIN_24_HOURS,
     val showRefundPolicyTooltip: Boolean = false,
+    /** "거래 완료 되었습니다" 모달 노출 여부. 잠시 보여준 뒤 리뷰 작성 화면으로 넘어갑니다. */
+    val showDealCompleteModal: Boolean = false,
 )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -6,6 +6,7 @@ import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -13,6 +14,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+/** 거래 완료 모달을 보여주고 리뷰 작성 화면으로 넘어가기까지의 시간 */
+private const val DEAL_COMPLETE_MODAL_DURATION_MS = 1500L
 
 @HiltViewModel
 class DetailReservationViewModel @Inject constructor() : ViewModel() {
@@ -40,11 +44,11 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
     fun handelIntent(intent: DetailReservationIntent) {
         when (intent) {
             // 상태 변경 확인 테스트를 위한 코드입니다.
-            is DetailReservationIntent.NavigateToChat,
-            is DetailReservationIntent.ConfirmReservation,
-            -> {
+            is DetailReservationIntent.NavigateToChat -> {
                 _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
             }
+
+            is DetailReservationIntent.ConfirmReservation -> confirmReservation()
 
             is DetailReservationIntent.NavigateToWriteReview -> {
                 viewModelScope.launch {
@@ -116,6 +120,28 @@ class DetailReservationViewModel @Inject constructor() : ViewModel() {
                     _sideEffect.emit(DetailReservationSideEffect.NavigateToPrev)
                 }
             }
+        }
+    }
+
+    /**
+     * "거래 완료하기" → 거래 완료 처리 → 완료 모달 → 리뷰 작성 화면.
+     *
+     * 리뷰를 쓰지 않고 나와도 거래는 이미 완료된 상태이므로,
+     * 예약 상세에 다시 들어오면 "리뷰 쓰기" 버튼이 노출됩니다.
+     */
+    private fun confirmReservation() {
+        // TODO: 거래 완료 API 연동 (성공 응답을 받은 뒤 아래 처리를 수행해야 합니다)
+        _state.update {
+            it.copy(
+                reservationStatus = ReservationStatus.COMPLETED,
+                showDealCompleteModal = true,
+            )
+        }
+
+        viewModelScope.launch {
+            delay(DEAL_COMPLETE_MODAL_DURATION_MS)
+            _state.update { it.copy(showDealCompleteModal = false) }
+            _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
         }
     }
 

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -32,6 +32,9 @@
     <string name="reservation_button_review">리뷰 쓰기</string>
     <string name="reservation_button_reservation_approve">예약 승인</string>
 
+    <!-- 거래 완료 모달 -->
+    <string name="reservation_deal_complete_modal_message">거래 완료 되었습니다</string>
+
     <!-- 촬영 일시 미확정 -->
     <string name="reservation_schedule_tbd">작가와 협의</string>
 


### PR DESCRIPTION
## 개요
고객 예약 상세에서 **"거래 완료하기"** 를 눌렀을 때의 플로우를 구현합니다.

```
거래 완료하기 클릭
  → 거래 완료 처리 (서버 호출은 TODO)
  → "거래 완료 되었습니다" 모달
  → 리뷰 작성 화면으로 자동 이동
```

리뷰를 쓰지 않고 나온 경우 거래는 이미 완료된 상태이므로, 예약 상세에 다시 들어오면 `COMPLETED` 상태(하단 **"리뷰 쓰기"** + "채팅 바로가기")로 보입니다. 즉 리뷰 작성은 나중에 다시 진입할 수 있습니다.

> **base 주의**: 리뷰 작성 화면 라우트(`WriteReview`)가 필요해 `feat/213`(#218) 위에 stack되어 있습니다. #218 머지 후 base를 `develop`으로 retarget해 주세요.

## 현황 (문제)
`DetailReservationViewModel`에서 **거래 완료와 채팅 이동이 한 브랜치로 묶인 테스트 스텁**이었습니다.

```kotlin
// 상태 변경 확인 테스트를 위한 코드입니다.
is DetailReservationIntent.NavigateToChat,
is DetailReservationIntent.ConfirmReservation,
-> {
    _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
}
```

"거래 완료하기"를 누르면 확인 절차도, 완료 안내도, 리뷰 작성 이동도 없이 상태만 한 단계 전진했습니다.

## 변경 사항

### ✨ 완료 모달 컴포넌트 신설 (`core/ui`)
- `core/ui`에는 **취소/확인 2버튼 고정인 `CommonButtonModal`만** 있어서 버튼 없는 완료 안내 모달을 만들 수 없었습니다.
- `CommonSuccessModal` 신설: 체크 아이콘 + 안내 문구. 기존 `check_circle.xml`(검정 원 + 흰 체크)이 피그마와 동일해 그대로 재사용했습니다.
- 스스로 닫히지 않으므로 호출부가 일정 시간 뒤 닫거나 다음 화면으로 넘겨야 하며, 그동안 사용자가 닫지 못하도록 `dismissible = false`를 줄 수 있습니다.

### ✨ 거래 완료 → 리뷰 작성 진입
- `ConfirmReservation`을 `NavigateToChat`과 분리
- 거래 완료 시 `COMPLETED`로 전이 + 완료 모달 노출 → 리뷰 작성 화면(`WriteReview(orderId)`)으로 자동 이동
- 모달은 자동으로 넘어가므로 바깥 탭·뒤로가기로 닫히지 않게 처리

## 범위 외 / 남은 후속
- **거래 완료 API 연동** — 서버 호출 자리는 `// TODO`로 두고 로컬 상태 전이로 동작합니다.
- **"채팅 바로가기"가 채팅방으로 이동하지 않는 문제는 이 PR에서 고치지 않았습니다.** `NavigateToChat`에 대응하는 SideEffect가 없고, 고객 채팅방 라우트 `ChatRoom(roomId)`에 넘길 **roomId를 예약 상세가 들고 있지 않습니다**(`DetailReservationState`에 채팅방 정보 없음). 예약 정보 API가 붙는 시점에 같이 처리하는 게 맞다고 보고, 기존 테스트 스텁(누르면 상태 한 단계 전진)을 그대로 뒀습니다. — 덕분에 이 PR의 검증 경로도 유지됩니다.

## 스크린샷 (에뮬레이터 검증)
<!-- 아래 표의 각 셀(파일명 자리)에 스크린샷 폴더의 해당 파일을 드래그&드롭 해주세요 -->

| 거래 완료 직후 모달 | 리뷰 작성 화면 자동 진입 | 뒤로 나온 뒤 "리뷰 쓰기" 상태 |
|:---:|:---:|:---:|
| `01_deal_complete_modal.png` | `02_auto_navigated.png` | `03_back_to_detail.png` |

> 검증 경로: Dev → DetailReservation → "채팅 바로가기" 2회로 `촬영 진행중` 전이 → **거래 완료하기** → 완료 모달 → 리뷰 작성 화면 자동 진입 → 뒤로가기 → 예약 상세가 `거래 완료`/"리뷰 쓰기" 상태 → **"리뷰 쓰기" 재진입 성공**까지 확인. 크래시 없음.

## 관련 이슈
1. #213 별점 선택 화면 (1/2) — PR #218
2. #214 촬영 경험 입력 및 등록 (2/2) — PR #219
3. #215 촬영 사진 첨부 (최대 10장) — PR #220
4. #217 리뷰 등록·조회·삭제 API 연동

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다. (`:app:compileDevDebugKotlin` + `ktlintCheck` + `detekt` + 에뮬레이터 전 구간 검증)
- [ ] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #216
