### PR TITLE
✨ 빠른촬영 주변 작가 탐색 실제 API 연동

### DIFF
--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/ProductApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/ProductApi.kt
@@ -1,5 +1,6 @@
 package com.hm.picplz.data.api
 
+import com.hm.picplz.data.model.ApiResponse
 import com.hm.picplz.data.model.CreateProductRequest
 import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ProductIdResponse
@@ -13,7 +14,7 @@ interface ProductApi {
     @GET("api/v1/photographers/{photographerId}/products")
     suspend fun getPhotographerProducts(
         @Path("photographerId") photographerId: Long,
-    ): Response<List<ProductDto>>
+    ): Response<ApiResponse<List<ProductDto>>>
 
     @POST("api/v1/products")
     suspend fun createProduct(

--- a/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
@@ -23,9 +23,10 @@ fun NearbyPhotographerCard.toDomain(): Photographer {
         profileImageUri = profileImage,
         isActive = active == "Y",
         distance = distance,
-        photoMoods = photoMoods?.mapNotNull { it?.takeUnless(String::isBlank) } ?: emptyList(),
+        photoMoods = photoMoods.toNormalizedPhotoMoods(),
         activeAreas = activeAreas ?: emptyList(),
         instagram = null,
+        equipment = emptyList(),
         portfolioPhotos = emptyList(),
     )
 }
@@ -46,11 +47,27 @@ fun PhotographerDetailDto.toPhotographerInfo(): PhotographerInfo {
         followCount = followers ?: 0,
         profileImageUri = profileImage ?: "",
         workingArea = area?.mapNotNull { it.name } ?: emptyList(),
-        keyword = photoMoods?.mapNotNull { it?.takeUnless(String::isBlank) } ?: emptyList(),
-        equipment = emptyList(),
+        keyword = photoMoods.toNormalizedPhotoMoods(),
+        equipment =
+            cameras
+                .orEmpty()
+                .map { "${it.brand} ${it.name}".trim() }
+                .filter(String::isNotBlank)
+                .distinct(),
         photoPortfolios = emptyList(),
     )
 }
+
+private fun List<String?>?.toNormalizedPhotoMoods(): List<String> =
+    orEmpty()
+        .mapNotNull { mood ->
+            mood
+                ?.trim()
+                ?.trimStart('#')
+                ?.trim()
+                ?.takeUnless(String::isBlank)
+        }
+        .distinct()
 
 fun ReviewPhotoDto.toPhotoReview(reviewId: Long): PhotoReview {
     return PhotoReview(

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/CameraModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/CameraModel.kt
@@ -6,6 +6,7 @@ data class CameraInfoDto(
     @SerializedName("type") val type: String,
     @SerializedName("brand") val brand: String,
     @SerializedName("name") val name: String,
+    @SerializedName("cameraType") val cameraType: String? = null,
 )
 
 data class CameraListData(

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerDetailDto.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerDetailDto.kt
@@ -9,6 +9,7 @@ data class PhotographerDetailDto(
     val active: String,
     val instagram: String?,
     val photoMoods: List<String?>?,
+    val cameras: List<CameraInfoDto>? = null,
     val followers: Int?,
     val isFollowing: String?,
 )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/ProductSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/ProductSource.kt
@@ -20,7 +20,7 @@ class ProductSourceImpl
         private val productApi: ProductApi,
     ) : ProductSource {
         override suspend fun getPhotographerProducts(photographerId: Long): AppResult<List<ProductDto>> =
-            safeApiCall { productApi.getPhotographerProducts(photographerId) }
+            safeApiCall({ productApi.getPhotographerProducts(photographerId) }) { it.data }
 
         override suspend fun createProduct(request: CreateProductRequest): AppResult<ProductIdResponse> =
             safeApiCall { productApi.createProduct(request) }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/mapper/PhotographerMapperTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/mapper/PhotographerMapperTest.kt
@@ -1,0 +1,55 @@
+package com.hm.picplz.data.mapper
+
+import com.hm.picplz.data.model.ActiveAreaDto
+import com.hm.picplz.data.model.CameraInfoDto
+import com.hm.picplz.data.model.NearbyPhotographerCard
+import com.hm.picplz.data.model.PhotographerDetailDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PhotographerMapperTest {
+    @Test
+    fun `nearby photographer moods remove blank values hashes and duplicates`() {
+        val photographer =
+            NearbyPhotographerCard(
+                photographerId = 7L,
+                nickname = "유가영",
+                profileImage = null,
+                active = "Y",
+                distance = 100L,
+                photoMoods = listOf("캐주얼", null, " #캐주얼 ", "#자연광", " "),
+            ).toDomain()
+
+        assertEquals(listOf("캐주얼", "자연광"), photographer.photoMoods)
+    }
+
+    @Test
+    fun `photographer detail maps runtime areas moods and cameras`() {
+        val photographer =
+            PhotographerDetailDto(
+                photographerId = 7L,
+                nickname = "유가영",
+                profileImage = "profile.jpg",
+                area = listOf(ActiveAreaDto(code = 1L, name = "마포구", priority = 1)),
+                introduction = "",
+                active = "Y",
+                instagram = "imdooring",
+                photoMoods = listOf("캐주얼", null, "#캐주얼", "#자연광"),
+                cameras =
+                    listOf(
+                        CameraInfoDto(
+                            type = "CAMERA",
+                            brand = "Sony",
+                            name = "A7IV",
+                            cameraType = "미러리스",
+                        ),
+                    ),
+                followers = 0,
+                isFollowing = "N",
+            ).toPhotographerInfo()
+
+        assertEquals(listOf("마포구"), photographer.workingArea)
+        assertEquals(listOf("캐주얼", "자연광"), photographer.keyword)
+        assertEquals(listOf("Sony A7IV"), photographer.equipment)
+    }
+}

--- a/core/data/src/test/kotlin/com/hm/picplz/data/source/ProductSourceTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/source/ProductSourceTest.kt
@@ -1,0 +1,60 @@
+package com.hm.picplz.data.source
+
+import com.hm.picplz.data.api.ProductApi
+import com.hm.picplz.data.model.ApiResponse
+import com.hm.picplz.data.model.CreateProductRequest
+import com.hm.picplz.data.model.ProductDto
+import com.hm.picplz.data.model.ProductIdResponse
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import retrofit2.Response
+
+class ProductSourceTest {
+    @Test
+    fun `photographer products unwraps runtime ApiResponse data`() =
+        runTest {
+            val product =
+                ProductDto(
+                    productId = 17L,
+                    photographerId = 7L,
+                    title = null,
+                    name = "남친생기는 프사",
+                    price = null,
+                    shootPrice = 9_900,
+                    description = null,
+                    shootingTime = null,
+                    shootDuration = 15,
+                    imageUrl = null,
+                    otherDetails = "아이폰 촬영",
+                    productPhotos = emptyList(),
+                )
+            val source =
+                ProductSourceImpl(
+                    FakeProductApi(
+                        productsResponse =
+                            Response.success(
+                                ApiResponse(
+                                    timestamp = "2026-07-27T00:00:00",
+                                    statusCode = 200,
+                                    message = "success",
+                                    data = listOf(product),
+                                ),
+                            ),
+                    ),
+                )
+
+            val products = source.getPhotographerProducts(7L).getOrThrow()
+
+            assertEquals(listOf(product), products)
+        }
+}
+
+private class FakeProductApi(
+    private val productsResponse: Response<ApiResponse<List<ProductDto>>>,
+) : ProductApi {
+    override suspend fun getPhotographerProducts(photographerId: Long): Response<ApiResponse<List<ProductDto>>> =
+        productsResponse
+
+    override suspend fun createProduct(request: CreateProductRequest): Response<ProductIdResponse> = error("Not used")
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Photographer.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Photographer.kt
@@ -9,6 +9,7 @@ data class Photographer(
     val photoMoods: List<String>,
     val activeAreas: List<String> = emptyList(),
     val instagram: String? = null,
+    val equipment: List<String> = emptyList(),
     val portfolioPhotos: List<String> = emptyList(),
 )
 

--- a/feature/photographer/build.gradle.kts
+++ b/feature/photographer/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
 
     debugImplementation(libs.androidx.ui.tooling)
 }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootIntent.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootIntent.kt
@@ -24,6 +24,8 @@ sealed interface QuickShootIntent {
 
     data class SetIsSearchingPhotographer(val isSearchingPhotographer: Boolean) : QuickShootIntent
 
+    data class SetNearbyPhotographerLoadFailed(val failed: Boolean) : QuickShootIntent
+
     data class SetNearbyPhotographers(val nearbyPhotographers: FilteredPhotographers) : QuickShootIntent
 
     data object FetchNearbyPhotographers : QuickShootIntent

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootScreen.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootScreen.kt
@@ -8,11 +8,14 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateOffsetAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -25,31 +28,29 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -59,7 +60,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -70,7 +70,6 @@ import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.ui.navigation.BottomNavigationBar
 import com.hm.picplz.ui.screen.common.AddressMarker
 import com.hm.picplz.ui.screen.common.CommonBottomSheetScaffold
-import com.hm.picplz.ui.screen.common.CommonGrayDragHandle
 import com.hm.picplz.ui.screen.common.RefetchButton
 import com.hm.picplz.ui.screen.quick_shoot.composable.PhotographerListSheet
 import com.hm.picplz.ui.screen.quick_shoot.composable.PhotographerProfile
@@ -80,6 +79,7 @@ import com.hm.picplz.ui.screen.quick_shoot.composable.QuickShootSortBottomSheet
 import com.hm.picplz.ui.screen.quick_shoot.composable.QuickShootSortType
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import com.hm.picplz.feature.photographer.R as PhotographerR
@@ -157,16 +157,20 @@ fun QuickShootScreen(
             bottomSheetState = bottomSheetState,
         )
 
-    val modalSheetState =
-        rememberModalBottomSheetState(
-            skipPartiallyExpanded = true,
-        )
-
-    val selectedPhotographer =
+    val nearbySelectedPhotographer =
         currentState.selectedPhotographerId?.let { selectedId ->
             val allPhotographers = currentState.nearbyPhotographers.active + currentState.nearbyPhotographers.inactive
             allPhotographers.find { it.id == selectedId }
         }
+    val selectedPhotographer = currentState.selectedPhotographerPreview ?: nearbySelectedPhotographer
+    val hasSelectedPhotographer = currentState.selectedPhotographerId != null
+    val previewPhotoSize =
+        ((LocalConfiguration.current.screenWidthDp - PREVIEW_PHOTO_HORIZONTAL_SPACE_DP) / 3f).dp
+    val selectedPhotographerPeekHeight = previewPhotoSize + selectedPhotographerNonPhotoHeight
+    val hasNearbyPhotographers =
+        currentState.nearbyPhotographers.active.isNotEmpty() ||
+            currentState.nearbyPhotographers.inactive.isNotEmpty()
+    val showNearbyLoadError = currentState.nearbyPhotographerLoadFailed && !hasNearbyPhotographers
 
     val isPermissionDenied = !currentState.locationPermissionGranted && currentState.hasRequestedPermission
     val isFirstEntry = !currentState.locationPermissionGranted && !currentState.hasRequestedPermission
@@ -210,19 +214,49 @@ fun QuickShootScreen(
             CommonBottomSheetScaffold(
                 modifier = Modifier.fillMaxSize(),
                 sheetContent = {
-                    PhotographerListSheet(
-                        photographers = currentState.nearbyPhotographers,
-                        selectedSortType = currentState.selectedSortType,
-                        onSortClick = {
-                            viewModel.handleIntent(QuickShootIntent.ToggleSortSheet(true))
-                        },
-                        onPhotographerClick = { id ->
-                            mainNavController.navigate(DetailPhotographer(id.toInt()))
-                        },
-                    )
+                    when {
+                        currentState.isLoadingSelectedPhotographer -> {
+                            QuickShootPhotographerSheetLoading()
+                        }
+
+                        selectedPhotographer != null -> {
+                            PhotographerSheet(
+                                photographer = selectedPhotographer,
+                                onNavigateToDetail = { id ->
+                                    mainNavController.navigate(DetailPhotographer(id.toInt()))
+                                },
+                            )
+                        }
+
+                        else -> {
+                            PhotographerListSheet(
+                                photographers = currentState.nearbyPhotographers,
+                                selectedSortType = currentState.selectedSortType,
+                                onSortClick = {
+                                    viewModel.handleIntent(QuickShootIntent.ToggleSortSheet(true))
+                                },
+                                onPhotographerClick = { id ->
+                                    mainNavController.navigate(DetailPhotographer(id.toInt()))
+                                },
+                                emptyContent =
+                                    if (showNearbyLoadError) {
+                                        {
+                                            QuickShootLoadErrorState()
+                                        }
+                                    } else {
+                                        null
+                                    },
+                            )
+                        }
+                    }
                 },
                 scaffoldState = scaffoldState,
-                sheetPeekHeight = 76.dp,
+                sheetPeekHeight =
+                    if (hasSelectedPhotographer) {
+                        selectedPhotographerPeekHeight
+                    } else {
+                        defaultSheetPeekHeight
+                    },
                 sheetMaxHeight = (LocalConfiguration.current.screenHeightDp * 0.9f).dp,
                 navigationBarPadding = true,
             ) {
@@ -253,25 +287,9 @@ fun QuickShootScreen(
                                 },
                     ) {
                         if (currentState.isFetchingGPS && currentState.userLocation == null) {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center,
-                                ) {
-                                    CircularProgressIndicator(
-                                        color = MainThemeColor.Black,
-                                    )
-                                    Spacer(modifier = Modifier.height(8.dp))
-                                    Text(
-                                        text = stringResource(PhotographerR.string.quick_shoot_loading_location),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MainThemeColor.Black,
-                                    )
-                                }
-                            }
+                            QuickShootLoadingState(
+                                message = stringResource(PhotographerR.string.quick_shoot_loading_location),
+                            )
                         } else {
                             QuickShootLocationHeader(
                                 address = currentState.address,
@@ -282,12 +300,11 @@ fun QuickShootScreen(
 
                             val entirePhotographers =
                                 currentState.nearbyPhotographers.active + currentState.nearbyPhotographers.inactive
-                            val isEmpty =
-                                entirePhotographers.isEmpty() &&
-                                    !currentState.isSearchingPhotographer &&
-                                    currentState.userLocation != null
+                            val isEmpty = entirePhotographers.isEmpty() && currentState.userLocation != null
 
-                            if (isEmpty) {
+                            if (currentState.isSearchingPhotographer) {
+                                QuickShootPhotographerLoadingState()
+                            } else if (isEmpty) {
                                 QuickShootEmptyState()
                             } else {
                                 val boxOffset by animateOffsetAsState(
@@ -349,44 +366,29 @@ fun QuickShootScreen(
                                 }
                             }
                         }
-                    }
-                }
-            }
 
-            if (selectedPhotographer != null) {
-                val sheetNestedScrollConnection =
-                    remember {
-                        object : NestedScrollConnection {
-                            override fun onPostScroll(
-                                consumed: Offset,
-                                available: Offset,
-                                source: NestedScrollSource,
-                            ): Offset = available.copy(x = 0f, y = available.y.coerceAtLeast(0f))
-
-                            override suspend fun onPostFling(
-                                consumed: Velocity,
-                                available: Velocity,
-                            ): Velocity = available.copy(x = 0f, y = available.y.coerceAtLeast(0f))
+                        if (showNearbyLoadError) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .background(MainThemeColor.Gray1),
+                            ) {
+                                QuickShootLocationHeader(
+                                    address = currentState.address,
+                                    onRefetchClick = {
+                                        viewModel.handleIntent(QuickShootIntent.RefetchNearbyPhotographers)
+                                    },
+                                )
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    QuickShootLoadErrorState()
+                                }
+                            }
                         }
                     }
-                ModalBottomSheet(
-                    onDismissRequest = {
-                        viewModel.handleIntent(QuickShootIntent.SetSelectedPhotographerId(null))
-                        viewModel.handleIntent(QuickShootIntent.CenterSelectedPhotographer(Offset.Zero))
-                    },
-                    sheetState = modalSheetState,
-                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-                    containerColor = MainThemeColor.White,
-                    scrimColor = MainThemeColor.Black.copy(alpha = 0.4f),
-                    dragHandle = { CommonGrayDragHandle() },
-                    modifier = Modifier.wrapContentHeight().nestedScroll(sheetNestedScrollConnection),
-                ) {
-                    PhotographerSheet(
-                        photographer = selectedPhotographer,
-                        onNavigateToDetail = { id ->
-                            mainNavController.navigate(DetailPhotographer(id.toInt()))
-                        },
-                    )
                 }
             }
 
@@ -401,6 +403,176 @@ fun QuickShootScreen(
                 },
             )
         }
+    }
+}
+
+private val defaultSheetPeekHeight = 76.dp
+private val selectedPhotographerNonPhotoHeight = 145.dp
+private const val PREVIEW_PHOTO_HORIZONTAL_SPACE_DP = 40
+
+@Composable
+private fun QuickShootPhotographerSheetLoading() {
+    var activeDotIndex by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(PHOTOGRAPHER_SHEET_LOADING_INTERVAL_MILLIS)
+            activeDotIndex = (activeDotIndex + 1) % PHOTOGRAPHER_SHEET_LOADING_DOT_COUNT
+        }
+    }
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(183.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(PHOTOGRAPHER_SHEET_LOADING_DOT_COUNT) { index ->
+            val isActive = index == activeDotIndex
+            Box(
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .background(
+                            color = if (isActive) MainThemeColor.Black else MainThemeColor.White,
+                            shape = CircleShape,
+                        )
+                        .border(
+                            width = 2.dp,
+                            color = MainThemeColor.Black,
+                            shape = CircleShape,
+                        ),
+            )
+        }
+    }
+}
+
+private const val PHOTOGRAPHER_SHEET_LOADING_DOT_COUNT = 3
+private const val PHOTOGRAPHER_SHEET_LOADING_INTERVAL_MILLIS = 300L
+
+@Composable
+private fun QuickShootLoadingState(message: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(
+                color = MainThemeColor.Black,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MainThemeColor.Black,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickShootPhotographerLoadingState() {
+    val loadingAlpha = remember { Animatable(0f) }
+    val placeholderOffsets =
+        remember {
+            listOf(
+                Offset(x = 0f, y = -180f),
+                Offset(x = -145f, y = -35f),
+                Offset(x = 145f, y = -35f),
+                Offset(x = -90f, y = 145f),
+                Offset(x = 90f, y = 145f),
+            )
+        }
+
+    LaunchedEffect(Unit) {
+        loadingAlpha.snapTo(0f)
+        loadingAlpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 500),
+        )
+        loadingAlpha.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(durationMillis = 500),
+        )
+        loadingAlpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 500),
+        )
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.multicircle),
+            contentDescription = stringResource(PhotographerR.string.quick_shoot_range_image_desc),
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier.scale(1.5f),
+        )
+
+        placeholderOffsets.forEach { offset ->
+            Box(
+                modifier =
+                    Modifier
+                        .offset(x = offset.x.dp, y = offset.y.dp)
+                        .size(74.dp)
+                        .alpha(loadingAlpha.value)
+                        .background(
+                            color = MainThemeColor.Gray2,
+                            shape = CircleShape,
+                        ),
+            )
+        }
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = stringResource(PhotographerR.string.quick_shoot_loading_photographers),
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Gray4,
+                modifier = Modifier.alpha(loadingAlpha.value),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Image(
+                painter = painterResource(id = R.drawable.center_char),
+                contentDescription = stringResource(PhotographerR.string.quick_shoot_center_char_desc),
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(PhotographerR.string.quick_shoot_loading_me),
+                style = MainThemeFont.Caption,
+                color = MainThemeColor.Black,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickShootLoadErrorState() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(PhotographerR.string.quick_shoot_load_error_title),
+            style = MainThemeFont.TitleSmall,
+            color = MainThemeColor.Black,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(PhotographerR.string.quick_shoot_load_error_guide),
+            style = MainThemeFont.Body,
+            color = MainThemeColor.Gray4,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootState.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootState.kt
@@ -2,6 +2,7 @@ package com.hm.picplz.ui.screen.quick_shoot
 
 import androidx.compose.ui.geometry.Offset
 import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.Photographer
 import com.hm.picplz.ui.screen.quick_shoot.composable.QuickShootSortType
 import com.kakao.vectormap.LatLng
 
@@ -13,9 +14,12 @@ data class QuickShootState(
     val userLocation: LatLng? = null,
     val isFetchingGPS: Boolean = false,
     val isSearchingPhotographer: Boolean = false,
+    val nearbyPhotographerLoadFailed: Boolean = false,
     val nearbyPhotographers: FilteredPhotographers = FilteredPhotographers(),
     val randomOffsets: Map<Long, Offset> = emptyMap(),
     val selectedPhotographerId: Long? = null,
+    val selectedPhotographerPreview: Photographer? = null,
+    val isLoadingSelectedPhotographer: Boolean = false,
     val centerOffset: Offset? = null,
     val showSortSheet: Boolean = false,
     val selectedSortType: QuickShootSortType = QuickShootSortType.DISTANCE,

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootViewModel.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootViewModel.kt
@@ -6,12 +6,18 @@ import androidx.lifecycle.viewModelScope
 import com.hm.picplz.data.provider.TokenManager
 import com.hm.picplz.data.service.KakaoMapService
 import com.hm.picplz.data.service.LocationService
-import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerDetailUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerPortfoliosUseCase
+import com.hm.picplz.domain.usecase.GetPortfolioUseCase
 import com.hm.picplz.ui.screen.quick_shoot.handler.LocationHandler
 import com.hm.picplz.ui.screen.quick_shoot.handler.PhotographerSearchHandler
 import com.hm.picplz.ui.screen.quick_shoot.util.OffsetGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -23,7 +29,10 @@ import javax.inject.Inject
 class QuickShootViewModel
     @Inject
     constructor(
-        private val photographerRepository: PhotographerRepository,
+        private val getNearbyPhotographersUseCase: GetNearbyPhotographersUseCase,
+        private val getPhotographerDetailUseCase: GetPhotographerDetailUseCase,
+        private val getPhotographerPortfoliosUseCase: GetPhotographerPortfoliosUseCase,
+        private val getPortfolioUseCase: GetPortfolioUseCase,
         private val locationService: LocationService,
         private val kakaoMapService: KakaoMapService,
         private val tokenManager: TokenManager,
@@ -93,29 +102,37 @@ class QuickShootViewModel
                 is QuickShootIntent.FetchNearbyPhotographers,
                 is QuickShootIntent.RefetchNearbyPhotographers,
                 -> {
+                    if (_state.value.isSearchingPhotographer) return
+                    val userLocation = _state.value.userLocation
+                    if (userLocation == null) {
+                        Log.w("QuickShoot", "User location not available yet")
+                        return
+                    }
+                    handleIntent(QuickShootIntent.SetSelectedPhotographerId(null))
+                    handleIntent(QuickShootIntent.SetIsSearchingPhotographer(true))
+                    handleIntent(QuickShootIntent.SetNearbyPhotographerLoadFailed(false))
                     viewModelScope.launch {
-                        val userLocation = _state.value.userLocation
-                        if (userLocation == null) {
-                            Log.w("QuickShoot", "User location not available yet")
-                            return@launch
-                        }
-                        handleIntent(QuickShootIntent.SetSelectedPhotographerId(null))
-                        handleIntent(QuickShootIntent.SetIsSearchingPhotographer(true))
-                        photographerRepository.getNearbyPhotographers(
+                        getNearbyPhotographersUseCase(
                             longitude = userLocation.longitude,
                             latitude = userLocation.latitude,
-                            distance = 2000,
+                            distance = QUICK_SHOOT_RADIUS_METERS,
                         )
                             .onSuccess { nearbyPhotographers ->
                                 handleIntent(QuickShootIntent.SetIsSearchingPhotographer(false))
+                                handleIntent(QuickShootIntent.SetNearbyPhotographerLoadFailed(false))
                                 handleIntent(QuickShootIntent.SetNearbyPhotographers(nearbyPhotographers))
                                 handleIntent(QuickShootIntent.DistributeRandomOffsets(nearbyPhotographers))
                             }
                             .onFailure { error ->
                                 handleIntent(QuickShootIntent.SetIsSearchingPhotographer(false))
+                                handleIntent(QuickShootIntent.SetNearbyPhotographerLoadFailed(true))
                                 Log.e("FetchPhotographers", "작가 목록 로딩 실패", error)
                             }
                     }
+                }
+
+                is QuickShootIntent.SetSelectedPhotographerId -> {
+                    selectPhotographer(intent.photographerId)
                 }
 
                 else -> {
@@ -128,8 +145,104 @@ class QuickShootViewModel
             }
         }
 
+        private fun selectPhotographer(photographerId: Long?) {
+            val currentState = _state.value
+            val shouldClearSelection =
+                photographerId == null || currentState.selectedPhotographerId == photographerId
+            if (shouldClearSelection) {
+                _state.update {
+                    it.copy(
+                        selectedPhotographerId = null,
+                        selectedPhotographerPreview = null,
+                        isLoadingSelectedPhotographer = false,
+                    )
+                }
+                return
+            }
+            val selectedPhotographerId = photographerId ?: return
+
+            val nearbyPhotographer =
+                (currentState.nearbyPhotographers.active + currentState.nearbyPhotographers.inactive)
+                    .find { it.id == selectedPhotographerId }
+                    ?: return
+
+            _state.update {
+                it.copy(
+                    selectedPhotographerId = selectedPhotographerId,
+                    selectedPhotographerPreview = null,
+                    isLoadingSelectedPhotographer = true,
+                )
+            }
+
+            viewModelScope.launch {
+                val detailResult = async { getPhotographerDetailUseCase(selectedPhotographerId) }
+                val portfolioPhotos =
+                    async {
+                        val firstPortfolio =
+                            getPhotographerPortfoliosUseCase(
+                                photographerId = selectedPhotographerId,
+                                size = 1,
+                            ).getOrElse {
+                                return@async emptyList()
+                            }.firstOrNull() ?: return@async emptyList()
+
+                        getPortfolioUseCase(firstPortfolio.id)
+                            .getOrElse {
+                                return@async emptyList()
+                            }
+                            .imageUris
+                            .take(PHOTOGRAPHER_PREVIEW_PHOTO_COUNT)
+                    }
+                delay(PHOTOGRAPHER_PREVIEW_MINIMUM_LOADING_MILLIS)
+                detailResult.await()
+                    .onSuccess { detail ->
+                        updateSelectedPhotographerPreview(
+                            photographerId = selectedPhotographerId,
+                            photographer =
+                                nearbyPhotographer.copy(
+                                    name = detail.profileInfo.name,
+                                    profileImageUri = detail.profileInfo.profileImageUri,
+                                    isActive = detail.profileInfo.isActive,
+                                    photoMoods = detail.profileInfo.keyword,
+                                    activeAreas = detail.profileInfo.workingArea,
+                                    instagram = detail.profileInfo.socialAccount,
+                                    equipment = detail.profileInfo.equipment,
+                                    portfolioPhotos = portfolioPhotos.await(),
+                                ),
+                        )
+                    }
+                    .onFailure { error ->
+                        Log.w("QuickShoot", "작가 프리뷰 로딩 실패", error)
+                        updateSelectedPhotographerPreview(
+                            photographerId = selectedPhotographerId,
+                            photographer = nearbyPhotographer,
+                        )
+                    }
+            }
+        }
+
+        private fun updateSelectedPhotographerPreview(
+            photographerId: Long,
+            photographer: Photographer,
+        ) {
+            _state.update { state ->
+                if (state.selectedPhotographerId != photographerId) {
+                    state
+                } else {
+                    state.copy(
+                        selectedPhotographerPreview = photographer,
+                        isLoadingSelectedPhotographer = false,
+                    )
+                }
+            }
+        }
+
         override fun onCleared() {
             super.onCleared()
             locationService.cleanup()
         }
     }
+
+private const val QUICK_SHOOT_RADIUS_METERS = 2_000L
+private const val PHOTOGRAPHER_PREVIEW_MINIMUM_LOADING_MILLIS = 1_500L
+private const val PHOTOGRAPHER_PREVIEW_PHOTO_COUNT = 3

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/PhotographerSheet.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/PhotographerSheet.kt
@@ -156,7 +156,17 @@ private fun PhotographerAvailability(photographer: Photographer) {
             )
             Spacer(modifier = Modifier.width(5.dp))
         }
-        val areasText = formatActiveAreas(photographer.activeAreas)
+        val remainingAreaCount = (photographer.activeAreas.size - DISPLAY_AREA_COUNT).coerceAtLeast(0)
+        val overflowText =
+            if (remainingAreaCount > 0) {
+                stringResource(
+                    PhotographerR.string.quick_shoot_area_overflow_format,
+                    remainingAreaCount,
+                )
+            } else {
+                null
+            }
+        val areasText = formatActiveAreas(photographer.activeAreas, overflowText)
         if (areasText.isNotEmpty()) {
             Text(
                 text = areasText,
@@ -176,15 +186,13 @@ private fun PhotographerAvailability(photographer: Photographer) {
     }
 }
 
-private fun formatActiveAreas(areas: List<String>): String {
+private fun formatActiveAreas(
+    areas: List<String>,
+    overflowText: String?,
+): String {
     if (areas.isEmpty()) return ""
     val displayed = areas.take(DISPLAY_AREA_COUNT).joinToString(", ", transform = ::formatAreaName)
-    val remaining = areas.size - DISPLAY_AREA_COUNT
-    return if (remaining > 0) {
-        "$displayed 외 ${remaining}개"
-    } else {
-        displayed
-    }
+    return listOfNotNull(displayed, overflowText).joinToString(" ")
 }
 
 private fun formatAreaName(area: String): String {

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/PhotographerSheet.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/PhotographerSheet.kt
@@ -6,13 +6,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -21,14 +20,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.hm.picplz.domain.model.Photographer
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.Pretendard
+import com.hm.picplz.core.ui.R as CoreUiR
+import com.hm.picplz.feature.photographer.R as PhotographerR
 
 @Composable
 fun PhotographerSheet(
@@ -42,90 +45,37 @@ fun PhotographerSheet(
                 .clickable {
                     onNavigateToDetail(photographer.id)
                 }
-                .padding(horizontal = 20.dp, vertical = 12.dp),
+                .padding(bottom = 5.dp),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AsyncImage(
-                model = photographer.profileImageUri,
-                contentDescription = "작가 프로필 이미지",
-                contentScale = ContentScale.Crop,
-                modifier =
-                    Modifier
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .border(1.dp, MainThemeColor.Gray2, CircleShape),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = photographer.name,
-                style =
-                    TextStyle(
-                        fontFamily = Pretendard,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 18.sp,
-                        letterSpacing = 0.sp,
-                    ),
-                color = MainThemeColor.Black,
-            )
+        PhotographerIdentity(photographer)
+        Spacer(modifier = Modifier.height(3.dp))
+        PhotographerAvailability(photographer)
+
+        val tags = photographer.photoMoods.take(1) + photographer.equipment.take(1)
+        if (tags.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(18.dp))
+            VibeTags(tags = tags)
         }
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (photographer.isActive) {
-                ActiveStatusBadge(text = "바로촬영")
-                Spacer(modifier = Modifier.width(6.dp))
-            }
-            val areasText = formatActiveAreas(photographer.activeAreas)
-            if (areasText.isNotEmpty()) {
-                Text(
-                    text = areasText,
-                    style =
-                        TextStyle(
-                            fontFamily = Pretendard,
-                            fontWeight = FontWeight.Normal,
-                            fontSize = 13.sp,
-                            letterSpacing = 0.sp,
-                        ),
-                    color = MainThemeColor.Gray4,
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        VibeTags(
-            tags = photographer.photoMoods,
-        )
-        val instagramHandle = photographer.instagram
-        if (!instagramHandle.isNullOrEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = instagramHandle,
-                style =
-                    TextStyle(
-                        fontFamily = Pretendard,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 13.sp,
-                        letterSpacing = 0.sp,
-                    ),
-                color = MainThemeColor.Gray4,
-            )
-        }
+
         if (photographer.portfolioPhotos.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                items(photographer.portfolioPhotos) { photoUrl ->
+                photographer.portfolioPhotos.take(PREVIEW_PHOTO_COUNT).forEach { photoUrl ->
                     AsyncImage(
                         model = photoUrl,
-                        contentDescription = "포트폴리오 사진",
+                        contentDescription =
+                            stringResource(
+                                PhotographerR.string.quick_shoot_portfolio_image,
+                            ),
                         contentScale = ContentScale.Crop,
                         modifier =
                             Modifier
-                                .size(80.dp)
-                                .clip(RoundedCornerShape(8.dp)),
+                                .weight(1f)
+                                .aspectRatio(1f)
+                                .clip(RoundedCornerShape(5.dp)),
                     )
                 }
             }
@@ -133,14 +83,115 @@ fun PhotographerSheet(
     }
 }
 
+@Composable
+private fun PhotographerIdentity(photographer: Photographer) {
+    Row(
+        verticalAlignment = Alignment.Top,
+    ) {
+        AsyncImage(
+            model = photographer.profileImageUri,
+            contentDescription =
+                stringResource(
+                    PhotographerR.string.quick_shoot_photographer_profile_image,
+                ),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .border(1.dp, MainThemeColor.Gray2, CircleShape),
+        )
+        Spacer(modifier = Modifier.width(3.dp))
+        Text(
+            text =
+                stringResource(
+                    CoreUiR.string.photographer_name_format,
+                    photographer.name,
+                ),
+            style =
+                TextStyle(
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 18.sp,
+                    lineHeight = 18.sp * 1.4,
+                    letterSpacing = 0.sp,
+                ),
+            color = MainThemeColor.Black,
+            maxLines = 1,
+        )
+
+        val instagramHandle = photographer.instagram
+        if (!instagramHandle.isNullOrEmpty()) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text =
+                    stringResource(
+                        PhotographerR.string.quick_shoot_instagram_format,
+                        instagramHandle,
+                    ),
+                style =
+                    TextStyle(
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 12.sp,
+                        lineHeight = 12.sp * 1.4,
+                        letterSpacing = 0.sp,
+                    ),
+                color = MainThemeColor.Black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotographerAvailability(photographer: Photographer) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (photographer.isActive) {
+            ActiveStatusBadge(
+                text = stringResource(PhotographerR.string.quick_shoot_active_status),
+            )
+            Spacer(modifier = Modifier.width(5.dp))
+        }
+        val areasText = formatActiveAreas(photographer.activeAreas)
+        if (areasText.isNotEmpty()) {
+            Text(
+                text = areasText,
+                style =
+                    TextStyle(
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp,
+                        lineHeight = 14.sp * 1.4,
+                        letterSpacing = 0.sp,
+                    ),
+                color = MainThemeColor.Gray4,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
 private fun formatActiveAreas(areas: List<String>): String {
     if (areas.isEmpty()) return ""
-    val displayCount = 3
-    val displayed = areas.take(displayCount).joinToString(", ")
-    val remaining = areas.size - displayCount
+    val displayed = areas.take(DISPLAY_AREA_COUNT).joinToString(", ", transform = ::formatAreaName)
+    val remaining = areas.size - DISPLAY_AREA_COUNT
     return if (remaining > 0) {
         "$displayed 외 ${remaining}개"
     } else {
         displayed
     }
 }
+
+private fun formatAreaName(area: String): String {
+    val segments = area.split(" ")
+    return segments.firstOrNull { it.endsWith("구") }
+        ?: segments.lastOrNull().orEmpty()
+}
+
+private const val DISPLAY_AREA_COUNT = 3
+private const val PREVIEW_PHOTO_COUNT = 3

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/VibeTags.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/composable/VibeTags.kt
@@ -20,7 +20,7 @@ fun VibeTags(
         modifier =
             modifier
                 .height(30.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         itemsIndexed(tags) { index, vibeTag ->
             CommonChip(
@@ -29,7 +29,7 @@ fun VibeTags(
                 initialMode = ChipMode.DEFAULT,
                 isEditable = false,
                 height = ChipHeight.MEDIUM,
-                backgroundColor = MainThemeColor.Gray2,
+                backgroundColor = MainThemeColor.Gray1,
                 unselectedBorderColor = MainThemeColor.Gray2,
             )
         }

--- a/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/handler/PhotographerSearchHandler.kt
+++ b/feature/photographer/src/main/kotlin/com/hm/picplz/ui/screen/quick_shoot/handler/PhotographerSearchHandler.kt
@@ -1,8 +1,10 @@
 package com.hm.picplz.ui.screen.quick_shoot.handler
 
 import androidx.compose.ui.geometry.Offset
+import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.ui.screen.quick_shoot.QuickShootIntent
 import com.hm.picplz.ui.screen.quick_shoot.QuickShootState
+import com.hm.picplz.ui.screen.quick_shoot.composable.QuickShootSortType
 import com.hm.picplz.ui.screen.quick_shoot.util.OffsetGenerator
 
 class PhotographerSearchHandler(
@@ -17,18 +19,14 @@ class PhotographerSearchHandler(
                 state.copy(isSearchingPhotographer = intent.isSearchingPhotographer)
             }
 
-            is QuickShootIntent.SetNearbyPhotographers -> {
-                state.copy(nearbyPhotographers = intent.nearbyPhotographers)
+            is QuickShootIntent.SetNearbyPhotographerLoadFailed -> {
+                state.copy(nearbyPhotographerLoadFailed = intent.failed)
             }
 
-            is QuickShootIntent.SetSelectedPhotographerId -> {
+            is QuickShootIntent.SetNearbyPhotographers -> {
                 state.copy(
-                    selectedPhotographerId =
-                        if (state.selectedPhotographerId == intent.photographerId) {
-                            null
-                        } else {
-                            intent.photographerId
-                        },
+                    nearbyPhotographers =
+                        intent.nearbyPhotographers.sortedBy(state.selectedSortType),
                 )
             }
 
@@ -51,10 +49,26 @@ class PhotographerSearchHandler(
             }
 
             is QuickShootIntent.SelectSortType -> {
-                state.copy(selectedSortType = intent.sortType)
+                state.copy(
+                    selectedSortType = intent.sortType,
+                    nearbyPhotographers = state.nearbyPhotographers.sortedBy(intent.sortType),
+                )
             }
 
             else -> null
         }
     }
 }
+
+private fun FilteredPhotographers.sortedBy(sortType: QuickShootSortType) =
+    when (sortType) {
+        QuickShootSortType.DISTANCE ->
+            copy(
+                active = active.sortedBy { it.distance },
+                inactive = inactive.sortedBy { it.distance },
+            )
+
+        QuickShootSortType.REVIEW_COUNT,
+        QuickShootSortType.RATING,
+        -> this
+    }

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- 빠른촬영 - 공통 -->
     <string name="quick_shoot_active_status">바로촬영</string>
+    <string name="quick_shoot_area_overflow_format">외 %1$d개</string>
     <string name="quick_shoot_instagram_format">@%s</string>
     <string name="quick_shoot_photographer_profile_image">작가 프로필 이미지</string>
     <string name="quick_shoot_portfolio_image">포트폴리오 사진</string>

--- a/feature/photographer/src/main/res/values/strings.xml
+++ b/feature/photographer/src/main/res/values/strings.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- 빠른촬영 - 공통 -->
+    <string name="quick_shoot_active_status">바로촬영</string>
+    <string name="quick_shoot_instagram_format">@%s</string>
+    <string name="quick_shoot_photographer_profile_image">작가 프로필 이미지</string>
+    <string name="quick_shoot_portfolio_image">포트폴리오 사진</string>
     <string name="quick_shoot_loading_location">위치 정보 로딩</string>
+    <string name="quick_shoot_loading_photographers">주변 작가 찾는 중...</string>
+    <string name="quick_shoot_loading_me">나</string>
     <string name="quick_shoot_range_image_desc">범위 지정 이미지</string>
     <string name="quick_shoot_center_char_desc">작가 탐색 중앙 캐릭터</string>
 
@@ -28,6 +34,8 @@
     <string name="quick_shoot_empty_char_desc">주변 작가 없음 캐릭터</string>
     <string name="quick_shoot_empty_guide_prefix">다른 지역으로</string>
     <string name="quick_shoot_empty_guide_suffix">이동해 보는 건 어때요?</string>
+    <string name="quick_shoot_load_error_title">주변 작가 정보를 불러오지 못했어요</string>
+    <string name="quick_shoot_load_error_guide">내 위치 새로고침으로 다시 시도해주세요</string>
 
     <!-- 작가 상세 - 차단 배너 -->
     <string name="blocked_account_message">차단된 계정입니다.</string>

--- a/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/quick_shoot/MainDispatcherRule.kt
+++ b/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/quick_shoot/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.hm.picplz.ui.screen.quick_shoot
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootViewModelTest.kt
+++ b/feature/photographer/src/test/kotlin/com/hm/picplz/ui/screen/quick_shoot/QuickShootViewModelTest.kt
@@ -1,0 +1,335 @@
+package com.hm.picplz.ui.screen.quick_shoot
+
+import android.util.Log
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.provider.TokenManager
+import com.hm.picplz.data.service.KakaoMapService
+import com.hm.picplz.data.service.LocationService
+import com.hm.picplz.domain.model.Area
+import com.hm.picplz.domain.model.FilteredPhotographers
+import com.hm.picplz.domain.model.Photographer
+import com.hm.picplz.domain.model.PhotographerDetail
+import com.hm.picplz.domain.model.PhotographerInfo
+import com.hm.picplz.domain.model.PhotographerReviewData
+import com.hm.picplz.domain.model.PhotographerReviewSummary
+import com.hm.picplz.domain.model.PortfolioDetail
+import com.hm.picplz.domain.model.PortfolioSummary
+import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.repository.PortfolioRepository
+import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerDetailUseCase
+import com.hm.picplz.domain.usecase.GetPhotographerPortfoliosUseCase
+import com.hm.picplz.domain.usecase.GetPortfolioUseCase
+import com.kakao.vectormap.LatLng
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.`when`
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuickShootViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var mockedLog: MockedStatic<Log>
+
+    @Before
+    fun setUp() {
+        mockedLog = mockStatic(Log::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        mockedLog.close()
+    }
+
+    @Test
+    fun `fetch nearby photographers uses current location and quick shoot radius`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    results = ArrayDeque(listOf(Result.success(nearbyPhotographers()))),
+                )
+            val viewModel = createViewModel(repository)
+
+            viewModel.handleIntent(
+                QuickShootIntent.SetCurrentLocation(
+                    LatLng.from(TEST_LATITUDE, TEST_LONGITUDE),
+                ),
+            )
+            viewModel.handleIntent(QuickShootIntent.FetchNearbyPhotographers)
+            advanceUntilIdle()
+
+            assertEquals(TEST_LONGITUDE, repository.lastLongitude ?: 0.0, 0.0)
+            assertEquals(TEST_LATITUDE, repository.lastLatitude ?: 0.0, 0.0)
+            assertEquals(2_000L, repository.lastDistance)
+            assertFalse(viewModel.state.value.isSearchingPhotographer)
+            assertFalse(viewModel.state.value.nearbyPhotographerLoadFailed)
+            assertEquals(listOf(2L, 1L), viewModel.state.value.nearbyPhotographers.active.map { it.id })
+        }
+
+    @Test
+    fun `failed nearby photographer request exposes retry state`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    results = ArrayDeque(listOf(Result.failure(IllegalStateException("network")))),
+                )
+            val viewModel = createViewModel(repository)
+
+            viewModel.handleIntent(
+                QuickShootIntent.SetCurrentLocation(
+                    LatLng.from(TEST_LATITUDE, TEST_LONGITUDE),
+                ),
+            )
+            viewModel.handleIntent(QuickShootIntent.FetchNearbyPhotographers)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.state.value.isSearchingPhotographer)
+            assertTrue(viewModel.state.value.nearbyPhotographerLoadFailed)
+            assertTrue(viewModel.state.value.nearbyPhotographers.active.isEmpty())
+        }
+
+    @Test
+    fun `duplicate nearby photographer request is ignored while loading`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    results = ArrayDeque(listOf(Result.success(nearbyPhotographers()))),
+                )
+            val viewModel = createViewModel(repository)
+            viewModel.handleIntent(
+                QuickShootIntent.SetCurrentLocation(
+                    LatLng.from(TEST_LATITUDE, TEST_LONGITUDE),
+                ),
+            )
+
+            viewModel.handleIntent(QuickShootIntent.FetchNearbyPhotographers)
+            viewModel.handleIntent(QuickShootIntent.RefetchNearbyPhotographers)
+            advanceUntilIdle()
+
+            assertEquals(1, repository.callCount)
+        }
+
+    @Test
+    fun `refetch clears failure after successful response`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    results =
+                        ArrayDeque(
+                            listOf(
+                                Result.failure(IllegalStateException("network")),
+                                Result.success(nearbyPhotographers()),
+                            ),
+                        ),
+                )
+            val viewModel = createViewModel(repository)
+            viewModel.handleIntent(
+                QuickShootIntent.SetCurrentLocation(
+                    LatLng.from(TEST_LATITUDE, TEST_LONGITUDE),
+                ),
+            )
+
+            viewModel.handleIntent(QuickShootIntent.FetchNearbyPhotographers)
+            advanceUntilIdle()
+            viewModel.handleIntent(QuickShootIntent.RefetchNearbyPhotographers)
+            advanceUntilIdle()
+
+            assertEquals(2, repository.callCount)
+            assertFalse(viewModel.state.value.nearbyPhotographerLoadFailed)
+            assertEquals(2, viewModel.state.value.nearbyPhotographers.active.size)
+        }
+
+    @Test
+    fun `selecting a photographer shows loading then exposes api preview`() =
+        runTest {
+            val repository =
+                FakePhotographerRepository(
+                    results = ArrayDeque(listOf(Result.success(nearbyPhotographers()))),
+                    detailResult = Result.success(photographerDetail()),
+                )
+            val viewModel = createViewModel(repository)
+            viewModel.handleIntent(
+                QuickShootIntent.SetCurrentLocation(
+                    LatLng.from(TEST_LATITUDE, TEST_LONGITUDE),
+                ),
+            )
+            viewModel.handleIntent(QuickShootIntent.FetchNearbyPhotographers)
+            advanceUntilIdle()
+
+            viewModel.handleIntent(QuickShootIntent.SetSelectedPhotographerId(1L))
+
+            assertTrue(viewModel.state.value.isLoadingSelectedPhotographer)
+            assertEquals(1L, viewModel.state.value.selectedPhotographerId)
+
+            advanceUntilIdle()
+
+            assertFalse(viewModel.state.value.isLoadingSelectedPhotographer)
+            assertEquals(1, repository.detailCallCount)
+            assertEquals("상세 작가", viewModel.state.value.selectedPhotographerPreview?.name)
+            assertEquals(listOf("마포구"), viewModel.state.value.selectedPhotographerPreview?.activeAreas)
+            assertEquals(
+                listOf("one.jpg", "two.jpg", "three.jpg"),
+                viewModel.state.value.selectedPhotographerPreview?.portfolioPhotos,
+            )
+        }
+
+    private fun createViewModel(repository: PhotographerRepository): QuickShootViewModel {
+        val tokenManager = mock(TokenManager::class.java)
+        `when`(tokenManager.hasRequestedLocationPermission()).thenReturn(true)
+        val portfolioRepository = FakePortfolioRepository()
+        return QuickShootViewModel(
+            getNearbyPhotographersUseCase = GetNearbyPhotographersUseCase(repository),
+            getPhotographerDetailUseCase = GetPhotographerDetailUseCase(repository),
+            getPhotographerPortfoliosUseCase = GetPhotographerPortfoliosUseCase(portfolioRepository),
+            getPortfolioUseCase = GetPortfolioUseCase(portfolioRepository),
+            locationService = mock(LocationService::class.java),
+            kakaoMapService = mock(KakaoMapService::class.java),
+            tokenManager = tokenManager,
+        )
+    }
+}
+
+private class FakePortfolioRepository : PortfolioRepository {
+    override suspend fun getPhotographerPortfolios(
+        photographerId: Long,
+        page: Int,
+        size: Int,
+    ): AppResult<List<PortfolioSummary>> =
+        Result.success(
+            listOf(
+                PortfolioSummary(
+                    id = 1L,
+                    representativeImage = "cover.jpg",
+                    photoCount = 4,
+                    location = null,
+                    uploadDate = null,
+                ),
+            ),
+        )
+
+    override suspend fun getPortfolio(portfolioId: Long): AppResult<PortfolioDetail> =
+        Result.success(
+            PortfolioDetail(
+                id = portfolioId,
+                imageUris = listOf("one.jpg", "two.jpg", "three.jpg", "four.jpg"),
+                location = null,
+                uploadDate = null,
+            ),
+        )
+}
+
+private class FakePhotographerRepository(
+    private val results: ArrayDeque<AppResult<FilteredPhotographers>>,
+    private val detailResult: AppResult<PhotographerDetail> = Result.failure(NotImplementedError()),
+) : PhotographerRepository {
+    var callCount: Int = 0
+        private set
+    var lastLongitude: Double? = null
+        private set
+    var lastLatitude: Double? = null
+        private set
+    var lastDistance: Long? = null
+        private set
+    var detailCallCount: Int = 0
+        private set
+
+    override suspend fun getNearbyPhotographers(
+        longitude: Double,
+        latitude: Double,
+        distance: Long,
+    ): AppResult<FilteredPhotographers> {
+        callCount += 1
+        lastLongitude = longitude
+        lastLatitude = latitude
+        lastDistance = distance
+        return results.removeFirst()
+    }
+
+    override suspend fun getPhotographerDetail(
+        photographerId: Long,
+        reviewSort: String,
+    ): AppResult<PhotographerDetail> {
+        detailCallCount += 1
+        return detailResult
+    }
+
+    override suspend fun getPhotographerMoodKeywords(photographerId: Long): AppResult<List<String>> =
+        Result.failure(NotImplementedError())
+
+    override suspend fun addPhotoMood(photoMood: String): AppResult<Unit> = Result.failure(NotImplementedError())
+
+    override suspend fun deletePhotoMood(photoMood: String): AppResult<Unit> = Result.failure(NotImplementedError())
+
+    override suspend fun getActiveAreas(photographerId: Long): AppResult<List<Area>> =
+        Result.failure(NotImplementedError())
+
+    override suspend fun updateActiveAreas(areas: List<Area>): AppResult<List<Area>> =
+        Result.failure(NotImplementedError())
+}
+
+private fun nearbyPhotographers() =
+    FilteredPhotographers(
+        active =
+            listOf(
+                photographer(id = 1L, distance = 300L),
+                photographer(id = 2L, distance = 100L),
+            ),
+    )
+
+private fun photographer(
+    id: Long,
+    distance: Long,
+) = Photographer(
+    id = id,
+    name = "작가$id",
+    profileImageUri = null,
+    isActive = true,
+    distance = distance,
+    photoMoods = emptyList(),
+)
+
+private fun photographerDetail() =
+    PhotographerDetail(
+        profileInfo =
+            PhotographerInfo(
+                id = 1,
+                name = "상세 작가",
+                socialAccount = "@photographer",
+                infoText = "",
+                isActive = true,
+                isFollow = false,
+                followCount = 0,
+                profileImageUri = "https://example.com/profile.jpg",
+                workingArea = listOf("마포구"),
+                keyword = listOf("캐주얼"),
+                photoPortfolios = emptyList(),
+            ),
+        reviewData =
+            PhotographerReviewData(
+                summary =
+                    PhotographerReviewSummary(
+                        averageRating = 0f,
+                        keywordBars = emptyList(),
+                        totalReviewCount = 0,
+                        totalPhotoReviewCount = 0,
+                        photoReviews = emptyList(),
+                    ),
+                reviews = emptyList(),
+            ),
+        shootingPackages = emptyList(),
+    )
+
+private const val TEST_LATITUDE = 37.406960
+private const val TEST_LONGITUDE = 127.115587


### PR DESCRIPTION
## Summary

- 빠른촬영 화면을 현재 위치와 실제 주변 작가 API에 연결했습니다.
- 주변 작가 탐색, 로딩·실패·빈 결과, 정렬, 바텀시트 단계 전환을 구현했습니다.
- 지도에서 작가를 선택하면 같은 바텀시트 안에서 상세 정보와 실제 포트폴리오 프리뷰를 표시합니다.
- Galaxy S25 Ultra 무선 디버깅 환경에서 실제 테스트 계정과 서버 응답으로 확인했습니다.

Closes #212

## Changes

### quick shoot flow

- 위치 권한 안내 후 현재 위치를 기준으로 반경 2km 주변 작가를 조회합니다.
- 주변 작가를 원형 지도에 배치하고 빠른촬영 가능 상태와 거리를 표시합니다.
- 바텀시트의 기본, 로딩, 목록, 작가 선택 상태를 하나의 sheet 흐름으로 연결했습니다.
- 작가 선택 시 로딩 인디케이터를 표시한 뒤 프로필, Instagram, 활동 지역, 분위기 태그, 장비, 포트폴리오 사진을 노출합니다.
- 선택된 작가의 사진 3장을 동일 너비로 배치하고 하단 내비게이션과 5dp 간격을 유지하도록 peek height를 계산합니다.

### API / data

- 주변 작가: `GET /members/location/nearby`
- 작가 선택 상세: `GET /photographers/{photographerId}/info`
- 포트폴리오 목록/상세: `GET /portfolios?photographerId=...`, `GET /portfolios/{portfolioId}`
- 상품 응답의 실제 `ApiResponse` envelope와 카메라/작가 상세 nullable 필드를 data layer에서 안전하게 매핑합니다.
- 실제 테스트 계정 `reservationTestCustomer1`으로 작가 ID 7의 상세 정보와 포트폴리오 응답을 확인했습니다.

## Pending API contract

현재 주변 작가 `Card` 응답에는 `photographerId`, `nickname`, `profileImage`, `active`, `distance`, `photoMoods`만 있고 `activeAreas`, `reviewCount`, `rating`이 없습니다.

따라서 바텀시트를 완전히 올렸을 때 보이는 **주변 작가 검색 목록의 활동 지역**은 현재 비워 둡니다. 각 행마다 상세 API를 호출하면 N+1 요청이 발생하므로 적용하지 않았습니다. `/members/location/nearby` 응답에 `activeAreas`가 추가되면 후속으로 목록 지역 표시를 활성화합니다.

정렬 UI의 `리뷰 많은 순`, `별점순` 옵션은 디자인 플로우를 유지하기 위해 살려 두되, 현재 응답만으로는 정렬 기준을 계산할 수 없어 선택해도 순서가 바뀌지 않습니다. `거리순`은 실제 `distance` 값으로 동작합니다. 주변 작가 응답에 `reviewCount`, `rating`이 추가되면 두 정렬 옵션을 연결합니다.

작가를 직접 선택한 뒤 보이는 프리뷰의 활동 지역·Instagram·장비는 작가 상세 API에서 정상 표시됩니다.

## Verification

- [x] `./gradlew :core:data:testDebugUnitTest :feature:photographer:testDebugUnitTest`
- [x] `./gradlew :core:data:ktlintCheck :core:domain:ktlintCheck :feature:photographer:ktlintCheck`
- [x] `./gradlew :core:data:detekt :core:domain:detekt :feature:photographer:detekt`
- [x] `./gradlew :app:assembleDevDebug`
- [x] `git diff --check`
- [x] Galaxy S25 Ultra 무선 디버깅 실기기 확인
  - 실제 위치 기반 주변 작가 조회
  - 유가영 작가 선택 및 동일 바텀시트 전환
  - 실제 상세 응답의 `@imdooring`, 활동 지역, 장비 표시
  - 실제 포트폴리오 API의 첫 3개 이미지 표시

## Notes

- 서버 포트폴리오 테스트 데이터의 이미지 원본은 Picsum placeholder입니다. 앱 내부 모킹 이미지는 아닙니다.
- 실기기에서 좌표와 거리 계산은 정상이나 현재 위치의 역지오코딩 문자열은 `대한민국 어딘가` fallback으로 표시됐습니다.
