### PR TITLE
✨ 작가 검색 프리뷰 및 검색 결과 API 연동

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/di/PhotographerModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/PhotographerModule.kt
@@ -1,11 +1,14 @@
 package com.hm.picplz.di
 
 import com.hm.picplz.data.repository.PhotographerRepositoryImpl
+import com.hm.picplz.data.service.PhotographerSearchService
+import com.hm.picplz.data.service.PhotographerSearchServiceImpl
 import com.hm.picplz.data.service.PhotographerService
 import com.hm.picplz.data.service.PhotographerServiceImpl
 import com.hm.picplz.data.source.PhotographerSource
 import com.hm.picplz.data.source.PhotographerSourceImpl
 import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.repository.PhotographerSearchRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -21,6 +24,12 @@ abstract class PhotographerModule {
 
     @Binds
     @Singleton
+    abstract fun bindPhotographerSearchService(
+        photographerSearchServiceImpl: PhotographerSearchServiceImpl,
+    ): PhotographerSearchService
+
+    @Binds
+    @Singleton
     abstract fun bindPhotographerSource(photographerSourceImpl: PhotographerSourceImpl): PhotographerSource
 
     @Binds
@@ -28,4 +37,10 @@ abstract class PhotographerModule {
     abstract fun bindPhotographerRepository(
         photographerRepositoryImpl: PhotographerRepositoryImpl,
     ): PhotographerRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPhotographerSearchRepository(
+        photographerRepositoryImpl: PhotographerRepositoryImpl,
+    ): PhotographerSearchRepository
 }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/PhotographerApi.kt
@@ -5,6 +5,7 @@ import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerDetailDto
+import com.hm.picplz.data.model.PhotographerSearchPageDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.model.UpdateActiveAreaRequest
 import com.hm.picplz.data.model.UpdateActiveAreaResponse
@@ -44,6 +45,14 @@ interface PhotographerApi {
         @Query("latitude") latitude: Double,
         @Query("distance") distance: Long,
     ): Response<ApiResponse<List<NearbyPhotographerCard>>>
+
+    @GET("api/v1/photographers/search")
+    suspend fun searchPhotographers(
+        @Query("keyword") keyword: String,
+        @Query("sortType") sortType: String = "RATING",
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): Response<ApiResponse<PhotographerSearchPageDto>>
 
     @GET("api/v1/photographers/{photographerId}/info")
     suspend fun getPhotographerInfo(

--- a/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mapper/PhotographerMapper.kt
@@ -4,6 +4,8 @@ import com.hm.picplz.common.model.PhotoReview
 import com.hm.picplz.data.model.ActiveAreaResponse
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotographerDetailDto
+import com.hm.picplz.data.model.PhotographerSearchItemDto
+import com.hm.picplz.data.model.PhotographerSearchPageDto
 import com.hm.picplz.data.model.ProductDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.model.ReviewPhotoDto
@@ -11,6 +13,7 @@ import com.hm.picplz.data.model.ReviewSummaryDto
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.Photographer
 import com.hm.picplz.domain.model.PhotographerInfo
+import com.hm.picplz.domain.model.PhotographerPage
 import com.hm.picplz.domain.model.PhotographerReview
 import com.hm.picplz.domain.model.PhotographerReviewData
 import com.hm.picplz.domain.model.PhotographerReviewSummary
@@ -32,6 +35,27 @@ fun NearbyPhotographerCard.toDomain(): Photographer {
 
 fun List<NearbyPhotographerCard>.toDomain(): List<Photographer> {
     return map { it.toDomain() }
+}
+
+fun PhotographerSearchPageDto.toDomain(): PhotographerPage {
+    val currentPage = number ?: 0
+    return PhotographerPage(
+        photographers = content.orEmpty().mapNotNull(PhotographerSearchItemDto::toDomain),
+        page = currentPage,
+        hasNext = last?.not() ?: (currentPage + 1 < (totalPages ?: 0)),
+    )
+}
+
+private fun PhotographerSearchItemDto.toDomain(): Photographer? {
+    val id = photographerId ?: return null
+    return Photographer(
+        id = id,
+        name = nickname.orEmpty(),
+        profileImageUri = profileImage,
+        isActive = isActive == "Y",
+        distance = 0,
+        photoMoods = photoMoods.orEmpty().mapNotNull { it?.takeUnless(String::isBlank) },
+    )
 }
 
 fun PhotographerDetailDto.toPhotographerInfo(): PhotographerInfo {

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerSearchModel.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/PhotographerSearchModel.kt
@@ -1,0 +1,16 @@
+package com.hm.picplz.data.model
+
+data class PhotographerSearchPageDto(
+    val content: List<PhotographerSearchItemDto>?,
+    val number: Int?,
+    val totalPages: Int?,
+    val last: Boolean?,
+)
+
+data class PhotographerSearchItemDto(
+    val photographerId: Long?,
+    val nickname: String?,
+    val profileImage: String?,
+    val isActive: String?,
+    val photoMoods: List<String?>?,
+)

--- a/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/repository/PhotographerRepositoryImpl.kt
@@ -3,12 +3,15 @@ package com.hm.picplz.data.repository
 import com.hm.picplz.common.result.AppResult
 import com.hm.picplz.common.result.runCatchingAppError
 import com.hm.picplz.data.mapper.toShootingPackage
+import com.hm.picplz.data.service.PhotographerSearchService
 import com.hm.picplz.data.service.PhotographerService
 import com.hm.picplz.data.service.ProductService
 import com.hm.picplz.domain.model.Area
 import com.hm.picplz.domain.model.FilteredPhotographers
 import com.hm.picplz.domain.model.PhotographerDetail
+import com.hm.picplz.domain.model.PhotographerPage
 import com.hm.picplz.domain.repository.PhotographerRepository
+import com.hm.picplz.domain.repository.PhotographerSearchRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
@@ -17,13 +20,22 @@ class PhotographerRepositoryImpl
     @Inject
     constructor(
         private val photographerService: PhotographerService,
+        private val photographerSearchService: PhotographerSearchService,
         private val productService: ProductService,
-    ) : PhotographerRepository {
+    ) : PhotographerRepository,
+        PhotographerSearchRepository {
         override suspend fun getNearbyPhotographers(
             longitude: Double,
             latitude: Double,
             distance: Long,
         ): AppResult<FilteredPhotographers> = photographerService.getNearbyPhotographers(longitude, latitude, distance)
+
+        override suspend fun searchPhotographers(
+            keyword: String,
+            sortType: String,
+            page: Int,
+            size: Int,
+        ): AppResult<PhotographerPage> = photographerSearchService.searchPhotographers(keyword, sortType, page, size)
 
         override suspend fun getPhotographerDetail(
             photographerId: Long,

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerSearchService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/PhotographerSearchService.kt
@@ -1,0 +1,30 @@
+package com.hm.picplz.data.service
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.mapper.toDomain
+import com.hm.picplz.data.source.PhotographerSource
+import com.hm.picplz.domain.model.PhotographerPage
+import javax.inject.Inject
+
+interface PhotographerSearchService {
+    suspend fun searchPhotographers(
+        keyword: String,
+        sortType: String,
+        page: Int,
+        size: Int,
+    ): AppResult<PhotographerPage>
+}
+
+class PhotographerSearchServiceImpl
+    @Inject
+    constructor(
+        private val photographerSource: PhotographerSource,
+    ) : PhotographerSearchService {
+        override suspend fun searchPhotographers(
+            keyword: String,
+            sortType: String,
+            page: Int,
+            size: Int,
+        ): AppResult<PhotographerPage> =
+            photographerSource.searchPhotographers(keyword, sortType, page, size).map { it.toDomain() }
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/PhotographerSource.kt
@@ -6,6 +6,7 @@ import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerDetailDto
+import com.hm.picplz.data.model.PhotographerSearchPageDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.model.UpdateActiveAreaRequest
 import com.hm.picplz.data.model.UpdateActiveAreaResponse
@@ -27,6 +28,13 @@ interface PhotographerSource {
         latitude: Double,
         distance: Long,
     ): AppResult<List<NearbyPhotographerCard>>
+
+    suspend fun searchPhotographers(
+        keyword: String,
+        sortType: String,
+        page: Int,
+        size: Int,
+    ): AppResult<PhotographerSearchPageDto>
 
     suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto>
 
@@ -61,6 +69,14 @@ class PhotographerSourceImpl
             distance: Long,
         ): AppResult<List<NearbyPhotographerCard>> =
             safeApiCall({ photographerApi.getNearbyPhotographers(longitude, latitude, distance) }) { it.data }
+
+        override suspend fun searchPhotographers(
+            keyword: String,
+            sortType: String,
+            page: Int,
+            size: Int,
+        ): AppResult<PhotographerSearchPageDto> =
+            safeApiCall({ photographerApi.searchPhotographers(keyword, sortType, page, size) }) { it.data }
 
         override suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto> =
             safeApiCall({ photographerApi.getPhotographerInfo(photographerId) }) { it.data }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/service/SignupServiceMappingTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/service/SignupServiceMappingTest.kt
@@ -144,6 +144,15 @@ class SignupServiceMappingTest {
             throw NotImplementedError("Not used in test")
         }
 
+        override suspend fun searchPhotographers(
+            keyword: String,
+            sortType: String,
+            page: Int,
+            size: Int,
+        ): AppResult<com.hm.picplz.data.model.PhotographerSearchPageDto> {
+            throw NotImplementedError("Not used in test")
+        }
+
         override suspend fun getPhotographerInfo(photographerId: Long): AppResult<PhotographerDetailDto> {
             throw NotImplementedError("Not used in test")
         }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/source/PhotographerSourceTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/source/PhotographerSourceTest.kt
@@ -6,6 +6,8 @@ import com.hm.picplz.data.model.CreatePhotographerRequest
 import com.hm.picplz.data.model.NearbyPhotographerCard
 import com.hm.picplz.data.model.PhotoMoodRequest
 import com.hm.picplz.data.model.PhotographerDetailDto
+import com.hm.picplz.data.model.PhotographerSearchItemDto
+import com.hm.picplz.data.model.PhotographerSearchPageDto
 import com.hm.picplz.data.model.ReviewListDto
 import com.hm.picplz.data.model.UpdateActiveAreaRequest
 import com.hm.picplz.data.model.UpdateActiveAreaResponse
@@ -53,10 +55,56 @@ class PhotographerSourceTest {
             assertEquals(7L, cards.first().photographerId)
             assertEquals("유가영 작가", cards.first().nickname)
         }
+
+    @Test
+    fun `photographer search unwraps paged runtime response`() =
+        runTest {
+            val api =
+                FakePhotographerApi(
+                    searchResponse =
+                        Response.success(
+                            ApiResponse(
+                                timestamp = "2026-07-20T20:00:00",
+                                statusCode = 200,
+                                message = "success",
+                                data =
+                                    PhotographerSearchPageDto(
+                                        content =
+                                            listOf(
+                                                PhotographerSearchItemDto(
+                                                    photographerId = 7L,
+                                                    nickname = "유가영 작가",
+                                                    profileImage = "profile.jpg",
+                                                    isActive = "Y",
+                                                    photoMoods = listOf("필름"),
+                                                ),
+                                            ),
+                                        number = 0,
+                                        totalPages = 2,
+                                        last = false,
+                                    ),
+                            ),
+                        ),
+                )
+            val source = PhotographerSourceImpl(api)
+
+            val page =
+                source.searchPhotographers(
+                    keyword = "",
+                    sortType = "RATING",
+                    page = 0,
+                    size = 5,
+                ).getOrThrow()
+
+            assertEquals(0, page.number)
+            assertEquals(false, page.last)
+            assertEquals(7L, page.content?.single()?.photographerId)
+        }
 }
 
 private class FakePhotographerApi(
-    private val nearbyResponse: Response<ApiResponse<List<NearbyPhotographerCard>>>,
+    private val nearbyResponse: Response<ApiResponse<List<NearbyPhotographerCard>>>? = null,
+    private val searchResponse: Response<ApiResponse<PhotographerSearchPageDto>>? = null,
 ) : PhotographerApi {
     override suspend fun createPhotographer(request: CreatePhotographerRequest): Response<Unit> = error("Not used")
 
@@ -71,7 +119,14 @@ private class FakePhotographerApi(
         longitude: Double,
         latitude: Double,
         distance: Long,
-    ): Response<ApiResponse<List<NearbyPhotographerCard>>> = nearbyResponse
+    ): Response<ApiResponse<List<NearbyPhotographerCard>>> = checkNotNull(nearbyResponse)
+
+    override suspend fun searchPhotographers(
+        keyword: String,
+        sortType: String,
+        page: Int,
+        size: Int,
+    ): Response<ApiResponse<PhotographerSearchPageDto>> = checkNotNull(searchResponse)
 
     override suspend fun getPhotographerInfo(
         photographerId: Long,

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Photographer.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Photographer.kt
@@ -16,3 +16,9 @@ data class FilteredPhotographers(
     val active: List<Photographer> = emptyList(),
     val inactive: List<Photographer> = emptyList(),
 )
+
+data class PhotographerPage(
+    val photographers: List<Photographer>,
+    val page: Int,
+    val hasNext: Boolean,
+)

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerSearchRepository.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/repository/PhotographerSearchRepository.kt
@@ -1,0 +1,13 @@
+package com.hm.picplz.domain.repository
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.PhotographerPage
+
+interface PhotographerSearchRepository {
+    suspend fun searchPhotographers(
+        keyword: String,
+        sortType: String,
+        page: Int,
+        size: Int,
+    ): AppResult<PhotographerPage>
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/SearchPhotographersUseCase.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/usecase/SearchPhotographersUseCase.kt
@@ -1,0 +1,25 @@
+package com.hm.picplz.domain.usecase
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.domain.model.PhotographerPage
+import com.hm.picplz.domain.repository.PhotographerSearchRepository
+import javax.inject.Inject
+
+class SearchPhotographersUseCase
+    @Inject
+    constructor(
+        private val photographerSearchRepository: PhotographerSearchRepository,
+    ) {
+        suspend operator fun invoke(
+            keyword: String,
+            sortType: String,
+            page: Int,
+            size: Int,
+        ): AppResult<PhotographerPage> =
+            photographerSearchRepository.searchPhotographers(
+                keyword = keyword,
+                sortType = sortType,
+                page = page,
+                size = size,
+            )
+    }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchDevFixtures.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchDevFixtures.kt
@@ -5,14 +5,14 @@ internal fun devMainSearchPreviewState(): MainSearchState =
         query = "유가영",
         hasSearched = true,
         results = devSearchPreviewPhotographers(),
-        nearbyPhotographers = devSearchPreviewPhotographers(),
+        suggestions = devSearchPreviewPhotographers(),
     )
 
 internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
     listOf(
         MainSearchPhotographerItem(
             id = "dev-search-active",
-            name = "유가영 작가",
+            name = "유가영",
             profileImageUri = "https://picsum.photos/seed/picplz-search-1/240",
             areaSummary = "마포구, 서대문구",
             isAvailableNow = true,
@@ -21,7 +21,7 @@ internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
         ),
         MainSearchPhotographerItem(
             id = "dev-search-yeongdeungpo",
-            name = "유가영 작가",
+            name = "유가영",
             profileImageUri = "https://picsum.photos/seed/picplz-search-2/240",
             areaSummary = "동작구, 영등포구",
             isAvailableNow = false,
@@ -30,7 +30,7 @@ internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
         ),
         MainSearchPhotographerItem(
             id = "dev-search-default",
-            name = "유가영 작가",
+            name = "유가영",
             profileImageUri = null,
             areaSummary = "마포구, 망구",
             isAvailableNow = false,
@@ -39,7 +39,7 @@ internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
         ),
         MainSearchPhotographerItem(
             id = "dev-search-gangnam",
-            name = "유가영 작가",
+            name = "유가영",
             profileImageUri = "https://picsum.photos/seed/picplz-search-4/240",
             areaSummary = "강남구, 강북구, 동대문구 외 3개",
             isAvailableNow = false,
@@ -48,7 +48,7 @@ internal fun devSearchPreviewPhotographers(): List<MainSearchPhotographerItem> =
         ),
         MainSearchPhotographerItem(
             id = "dev-search-gangdong",
-            name = "유가영 작가",
+            name = "유가영",
             profileImageUri = "https://picsum.photos/seed/picplz-search-5/240",
             areaSummary = "강동구",
             isAvailableNow = false,

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchIntent.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchIntent.kt
@@ -9,11 +9,31 @@ sealed interface MainSearchIntent {
 
     data class SearchSubmitted(val query: String) : MainSearchIntent
 
-    data class NearbyPhotographersLoaded(val photographers: List<MainSearchPhotographerItem>) : MainSearchIntent
+    data class PreviewLoading(val query: String) : MainSearchIntent
 
-    data object SearchLoadFailed : MainSearchIntent
+    data class PreviewLoaded(
+        val query: String,
+        val photographers: List<MainSearchPhotographerItem>,
+    ) : MainSearchIntent
+
+    data class PreviewLoadFailed(val query: String) : MainSearchIntent
+
+    data class SearchLoading(val append: Boolean) : MainSearchIntent
+
+    data class SearchPageLoaded(
+        val query: String,
+        val sortType: SortType,
+        val page: Int,
+        val photographers: List<MainSearchPhotographerItem>,
+        val hasNextPage: Boolean,
+        val append: Boolean,
+    ) : MainSearchIntent
+
+    data class SearchLoadFailed(val append: Boolean) : MainSearchIntent
 
     data class SortSelected(val sortType: SortType) : MainSearchIntent
+
+    data object LoadNextPage : MainSearchIntent
 
     data class RecentSearchRemoved(val query: String) : MainSearchIntent
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchPhotographerListItem.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchPhotographerListItem.kt
@@ -92,7 +92,7 @@ internal fun PhotographerListItem(
                     verticalArrangement = Arrangement.spacedBy(PhotographerListItemDefaults.TitleAreaGap),
                 ) {
                     Text(
-                        text = item.name,
+                        text = stringResource(R.string.main_photographer_name_format, item.name),
                         style = MainThemeFont.BodyLarge.copy(fontWeight = FontWeight.SemiBold),
                         color = MainThemeColor.Black,
                         maxLines = 1,

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducer.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducer.kt
@@ -1,7 +1,5 @@
 package com.hm.picplz.ui.screen.main
 
-import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
-
 object MainSearchReducer {
     fun reduce(
         state: MainSearchState,
@@ -12,6 +10,14 @@ object MainSearchReducer {
                 state.copy(
                     query = intent.query,
                     hasSearched = false,
+                    isPreviewLoading = intent.query.isNotBlank(),
+                    isLoading = false,
+                    searchFailed = false,
+                    isLoadingMore = false,
+                    hasNextPage = false,
+                    nextPage = 0,
+                    loadMoreFailed = false,
+                    suggestions = emptyList(),
                     results = emptyList(),
                 )
             }
@@ -26,34 +32,125 @@ object MainSearchReducer {
                     query = submittedQuery,
                     isFocused = false,
                     hasSearched = true,
+                    isPreviewLoading = false,
                     isLoading = submittedQuery.isNotBlank(),
+                    searchFailed = false,
+                    isLoadingMore = false,
+                    hasNextPage = false,
+                    nextPage = 0,
+                    loadMoreFailed = false,
                     recentSearchQueries = state.recentSearchQueries.withSubmittedQuery(submittedQuery),
-                    results = state.nearbyPhotographers.searchResultsFor(submittedQuery, state.selectedSortType),
-                )
-            }
-
-            is MainSearchIntent.NearbyPhotographersLoaded -> {
-                val nearbyPhotographers = intent.photographers
-                state.copy(
-                    isLoading = false,
-                    nearbyPhotographers = nearbyPhotographers,
-                    results = nearbyPhotographers.searchResultsFor(state.query, state.selectedSortType),
-                )
-            }
-
-            MainSearchIntent.SearchLoadFailed -> {
-                state.copy(
-                    isLoading = false,
+                    suggestions = emptyList(),
                     results = emptyList(),
                 )
+            }
+
+            is MainSearchIntent.PreviewLoading -> {
+                if (state.hasSearched || state.query.trim() != intent.query) {
+                    state
+                } else {
+                    state.copy(isPreviewLoading = true)
+                }
+            }
+
+            is MainSearchIntent.PreviewLoaded -> {
+                if (state.hasSearched || state.query.trim() != intent.query) {
+                    state
+                } else {
+                    state.copy(
+                        isPreviewLoading = false,
+                        suggestions = intent.photographers,
+                    )
+                }
+            }
+
+            is MainSearchIntent.PreviewLoadFailed -> {
+                if (state.hasSearched || state.query.trim() != intent.query) {
+                    state
+                } else {
+                    state.copy(
+                        isPreviewLoading = false,
+                        suggestions = emptyList(),
+                    )
+                }
+            }
+
+            is MainSearchIntent.SearchLoading -> {
+                if (intent.append) {
+                    state.copy(
+                        isLoadingMore = true,
+                        loadMoreFailed = false,
+                    )
+                } else {
+                    state.copy(
+                        isLoading = true,
+                        searchFailed = false,
+                        isLoadingMore = false,
+                        hasNextPage = false,
+                        nextPage = 0,
+                        loadMoreFailed = false,
+                        results = emptyList(),
+                    )
+                }
+            }
+
+            is MainSearchIntent.SearchPageLoaded -> {
+                if (
+                    !state.hasSearched ||
+                    state.query != intent.query ||
+                    state.selectedSortType != intent.sortType
+                ) {
+                    state
+                } else {
+                    val results =
+                        if (intent.append) {
+                            (state.results + intent.photographers).distinctBy(MainSearchPhotographerItem::id)
+                        } else {
+                            intent.photographers.distinctBy(MainSearchPhotographerItem::id)
+                        }
+                    state.copy(
+                        isLoading = false,
+                        searchFailed = false,
+                        isLoadingMore = false,
+                        hasNextPage = intent.hasNextPage,
+                        nextPage = intent.page + 1,
+                        loadMoreFailed = false,
+                        results = results,
+                    )
+                }
+            }
+
+            is MainSearchIntent.SearchLoadFailed -> {
+                if (intent.append) {
+                    state.copy(
+                        isLoadingMore = false,
+                        loadMoreFailed = true,
+                    )
+                } else {
+                    state.copy(
+                        isLoading = false,
+                        searchFailed = true,
+                        isLoadingMore = false,
+                        hasNextPage = false,
+                        results = emptyList(),
+                    )
+                }
             }
 
             is MainSearchIntent.SortSelected -> {
                 state.copy(
                     selectedSortType = intent.sortType,
-                    results = state.results.sortedBy(intent.sortType),
+                    isLoading = state.hasSearched && state.query.isNotBlank(),
+                    searchFailed = false,
+                    isLoadingMore = false,
+                    hasNextPage = false,
+                    nextPage = 0,
+                    loadMoreFailed = false,
+                    results = if (state.hasSearched) emptyList() else state.results,
                 )
             }
+
+            MainSearchIntent.LoadNextPage -> state
 
             is MainSearchIntent.RecentSearchRemoved -> {
                 state.copy(recentSearchQueries = state.recentSearchQueries - intent.query)
@@ -68,30 +165,4 @@ object MainSearchReducer {
         if (query.isBlank() || query in this) return this
         return listOf(query) + this
     }
-
-    private fun List<MainSearchPhotographerItem>.searchResultsFor(
-        query: String,
-        sortType: SortType,
-    ): List<MainSearchPhotographerItem> {
-        if (query.isBlank()) return emptyList()
-
-        val normalizedQuery = query.lowercase()
-        return filter { item ->
-            item.id.lowercase().contains(normalizedQuery) ||
-                item.areaSummary.lowercase().contains(normalizedQuery) ||
-                item.name.lowercase().contains(normalizedQuery) ||
-                item.moodTags.any { it.lowercase().contains(normalizedQuery) }
-        }.sortedBy(sortType)
-    }
-
-    private fun List<MainSearchPhotographerItem>.sortedBy(sortType: SortType): List<MainSearchPhotographerItem> =
-        when (sortType) {
-            SortType.POPULAR ->
-                sortedWith(
-                    compareByDescending<MainSearchPhotographerItem> { it.isAvailableNow }
-                        .thenBy { it.distance },
-                )
-            SortType.RATING -> sortedByDescending { it.moodTags.size }
-            SortType.FOLLOWER -> sortedBy { it.distance }
-        }
 }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchResultSection.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchResultSection.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hm.picplz.feature.main.R
 import com.hm.picplz.ui.screen.main.modalBottomSheet.SortFilterModalBottomSheet
@@ -44,17 +48,33 @@ private object SearchResultDefaults {
 
 @Composable
 fun SearchResultSection(
-    results: List<MainSearchPhotographerItem>,
-    isLoading: Boolean,
-    selectedSortType: SortType,
+    state: MainSearchState,
     onSortSelected: (SortType) -> Unit,
     onPhotographerClick: (MainSearchPhotographerItem) -> Unit,
+    onLoadNextPage: () -> Unit,
+    onRetrySearch: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var visibleSortFilter by remember { mutableStateOf(false) }
-    val selectedSortLabel = stringResource(selectedSortType.labelResId)
+    val selectedSortLabel = stringResource(state.selectedSortType.labelResId)
+    val listState = rememberLazyListState()
+    val shouldLoadNextPage by remember {
+        derivedStateOf {
+            val lastVisibleIndex =
+                listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                    ?: return@derivedStateOf false
+            lastVisibleIndex >= listState.layoutInfo.totalItemsCount - 2
+        }
+    }
+
+    LaunchedEffect(shouldLoadNextPage, state.hasNextPage, state.isLoadingMore, state.loadMoreFailed) {
+        if (shouldLoadNextPage && state.hasNextPage && !state.isLoadingMore && !state.loadMoreFailed) {
+            onLoadNextPage()
+        }
+    }
 
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         SortButton(
             label = selectedSortLabel,
@@ -62,25 +82,63 @@ fun SearchResultSection(
             modifier = Modifier.padding(horizontal = SearchResultDefaults.HorizontalPadding),
         )
 
-        if (isLoading) {
+        if (state.isLoading) {
             SearchLoadingResult()
-        } else if (results.isEmpty()) {
+        } else if (state.searchFailed) {
+            SearchErrorResult(onRetry = onRetrySearch)
+        } else if (state.results.isEmpty()) {
             SearchEmptyResult()
         } else {
-            LazyColumn {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
                 itemsIndexed(
-                    items = results,
+                    items = state.results,
                     key = { _, item -> item.id },
                 ) { index, item ->
                     PhotographerListItem(
                         item = item,
                         onClick = { onPhotographerClick(item) },
                     )
-                    if (index < results.lastIndex) {
+                    if (index < state.results.lastIndex) {
                         HorizontalDivider(
                             modifier = Modifier.padding(horizontal = SearchResultDefaults.HorizontalPadding),
                             color = MainThemeColor.Gray2,
                             thickness = 1.dp,
+                        )
+                    }
+                }
+
+                if (state.isLoadingMore) {
+                    item(key = "search-result-loading") {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 12.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(28.dp),
+                                color = MainThemeColor.Black,
+                            )
+                        }
+                    }
+                }
+
+                if (state.loadMoreFailed) {
+                    item(key = "search-result-retry") {
+                        Text(
+                            text = stringResource(R.string.main_search_load_more_retry),
+                            style = MainThemeFont.BodyBold,
+                            color = MainThemeColor.Black,
+                            textAlign = TextAlign.Center,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable(onClick = onLoadNextPage)
+                                    .padding(vertical = 16.dp),
                         )
                     }
                 }
@@ -92,6 +150,31 @@ fun SearchResultSection(
             visible = visibleSortFilter,
             onSelect = onSortSelected,
         )
+    }
+}
+
+@Composable
+private fun SearchErrorResult(onRetry: () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(top = 163.dp),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.main_search_load_failed),
+                style = MainThemeFont.TitleSmall,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.main_retry_button),
+                style = MainThemeFont.BodyBold,
+                color = MainThemeColor.Black,
+                modifier = Modifier.clickable(onClick = onRetry).padding(12.dp),
+            )
+        }
     }
 }
 

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchScreen.kt
@@ -1,6 +1,5 @@
 package com.hm.picplz.ui.screen.main
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,6 +21,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import coil.compose.AsyncImage
 import com.hm.picplz.feature.main.R
 import com.hm.picplz.navigation.model.DetailPhotographer
 import com.hm.picplz.ui.screen.common.AreaTag
@@ -240,20 +241,22 @@ fun PopularSpotSection(
 
 @Composable
 fun TypingResultSection(
-    query: String,
-    onSuggestionClick: (String) -> Unit,
+    suggestions: List<MainSearchPhotographerItem>,
+    isLoading: Boolean,
+    onSuggestionClick: (MainSearchPhotographerItem) -> Unit,
 ) {
-    val trimmedQuery = query.trim()
-    if (trimmedQuery.isBlank()) return
-
-    val photographerSuggestions =
-        listOf(
-            stringResource(R.string.main_search_suggestion_photographer_kang_jueun),
-            stringResource(R.string.main_search_suggestion_photographer_dog),
-            stringResource(R.string.main_search_suggestion_photographer_dog),
-            stringResource(R.string.main_search_suggestion_photographer_dog),
-            stringResource(R.string.main_search_suggestion_photographer_dog),
-        ).filter { it.contains(trimmedQuery, ignoreCase = true) }
+    if (isLoading && suggestions.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                color = MainThemeColor.Black,
+            )
+        }
+        return
+    }
 
     LazyColumn(
         modifier =
@@ -261,7 +264,10 @@ fun TypingResultSection(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
     ) {
-        itemsIndexed(photographerSuggestions) { index, photographer ->
+        itemsIndexed(
+            items = suggestions,
+            key = { _, photographer -> photographer.id },
+        ) { index, photographer ->
             Row(
                 modifier =
                     Modifier
@@ -271,20 +277,27 @@ fun TypingResultSection(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Image(
-                    painter = painterResource(id = CoreR.drawable.user_undefined),
-                    contentDescription = null,
+                AsyncImage(
+                    model = photographer.profileImageUri,
+                    placeholder = painterResource(id = CoreR.drawable.user_undefined),
+                    error = painterResource(id = CoreR.drawable.user_undefined),
+                    fallback = painterResource(id = CoreR.drawable.user_undefined),
+                    contentDescription =
+                        stringResource(
+                            R.string.main_search_photographer_profile_content_description,
+                            photographer.name,
+                        ),
                     modifier =
                         Modifier
                             .size(20.dp)
                             .clip(CircleShape),
                 )
                 Text(
-                    text = photographer,
+                    text = stringResource(R.string.main_photographer_name_format, photographer.name),
                     style = MainThemeFont.BodyBold,
                 )
             }
-            if (index < photographerSuggestions.lastIndex) {
+            if (index < suggestions.lastIndex) {
                 HorizontalDivider(thickness = 1.dp, color = MainThemeColor.Gray2)
             }
         }
@@ -359,15 +372,16 @@ fun MainSearchScreen(
                     Spacer(modifier = Modifier.height(20.dp))
 
                     SearchResultSection(
-                        results = state.results,
-                        isLoading = state.isLoading,
-                        selectedSortType = state.selectedSortType,
+                        state = state,
                         onSortSelected = { sortType ->
                             if (devMockResults) {
                                 devPreviewState =
                                     MainSearchReducer.reduce(
                                         devPreviewState,
                                         MainSearchIntent.SortSelected(sortType),
+                                    ).copy(
+                                        isLoading = false,
+                                        results = devSearchPreviewPhotographers(),
                                     )
                             } else {
                                 viewModel.handleIntent(MainSearchIntent.SortSelected(sortType))
@@ -378,6 +392,13 @@ fun MainSearchScreen(
                                 navController.navigate(DetailPhotographer(photographerId))
                             }
                         },
+                        onLoadNextPage = {
+                            if (!devMockResults) {
+                                viewModel.handleIntent(MainSearchIntent.LoadNextPage)
+                            }
+                        },
+                        onRetrySearch = { doSearch(state.query) },
+                        modifier = Modifier.weight(1f),
                     )
                 }
 
@@ -385,8 +406,9 @@ fun MainSearchScreen(
                     Spacer(modifier = Modifier.height(10.dp))
 
                     TypingResultSection(
-                        query = state.query,
-                        onSuggestionClick = { sug -> doSearch(sug) },
+                        suggestions = state.suggestions,
+                        isLoading = state.isPreviewLoading,
+                        onSuggestionClick = { suggestion -> doSearch(suggestion.name) },
                     )
                 }
             }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchState.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchState.kt
@@ -6,11 +6,17 @@ data class MainSearchState(
     val query: String = "",
     val isFocused: Boolean = false,
     val hasSearched: Boolean = false,
+    val isPreviewLoading: Boolean = false,
     val isLoading: Boolean = false,
+    val searchFailed: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hasNextPage: Boolean = false,
+    val nextPage: Int = 0,
+    val loadMoreFailed: Boolean = false,
     val recentSearchQueries: List<String> = defaultRecentSearchQueries,
     val popularSpots: List<String> = defaultPopularSpots,
     val selectedSortType: SortType = SortType.POPULAR,
-    val nearbyPhotographers: List<MainSearchPhotographerItem> = emptyList(),
+    val suggestions: List<MainSearchPhotographerItem> = emptyList(),
     val results: List<MainSearchPhotographerItem> = emptyList(),
 ) {
     val uiState: SearchUiState

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
@@ -2,14 +2,12 @@ package com.hm.picplz.ui.screen.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hm.picplz.domain.model.FilteredPhotographers
-import com.hm.picplz.domain.model.LocationCoordinate
 import com.hm.picplz.domain.model.Photographer
-import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
-import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
-import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
-import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import com.hm.picplz.domain.usecase.SearchPhotographersUseCase
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,63 +19,135 @@ import javax.inject.Inject
 class MainSearchViewModel
     @Inject
     constructor(
-        private val getCurrentLocationUseCase: GetCurrentLocationUseCase,
-        private val getCurrentMemberIdUseCase: GetCurrentMemberIdUseCase,
-        private val updateMemberLocationUseCase: UpdateMemberLocationUseCase,
-        private val getNearbyPhotographersUseCase: GetNearbyPhotographersUseCase,
+        private val searchPhotographersUseCase: SearchPhotographersUseCase,
     ) : ViewModel() {
         private val _state = MutableStateFlow(MainSearchState.idle())
         val state: StateFlow<MainSearchState> = _state.asStateFlow()
+        private var previewJob: Job? = null
+        private var searchJob: Job? = null
 
         fun handleIntent(intent: MainSearchIntent) {
-            _state.update { MainSearchReducer.reduce(it, intent) }
+            when (intent) {
+                is MainSearchIntent.QueryChanged -> {
+                    searchJob?.cancel()
+                    _state.reduce(intent)
+                    requestPreview(intent.query)
+                }
 
-            if (intent is MainSearchIntent.SearchSubmitted && intent.query.isNotBlank()) {
-                loadCurrentNearbyPhotographers()
+                is MainSearchIntent.FocusChanged -> {
+                    _state.reduce(intent)
+                    if (!intent.isFocused) previewJob?.cancel()
+                }
+
+                is MainSearchIntent.SearchSubmitted -> {
+                    previewJob?.cancel()
+                    searchJob?.cancel()
+                    _state.reduce(intent)
+                    intent.query.trim().takeIf(String::isNotBlank)?.let { query ->
+                        loadSearchPage(
+                            query = query,
+                            sortType = _state.value.selectedSortType,
+                            page = 0,
+                            append = false,
+                        )
+                    }
+                }
+
+                is MainSearchIntent.SortSelected -> {
+                    searchJob?.cancel()
+                    _state.reduce(intent)
+                    val currentState = _state.value
+                    if (currentState.hasSearched && currentState.query.isNotBlank()) {
+                        loadSearchPage(
+                            query = currentState.query,
+                            sortType = intent.sortType,
+                            page = 0,
+                            append = false,
+                        )
+                    }
+                }
+
+                MainSearchIntent.LoadNextPage -> loadNextPage()
+                else -> _state.reduce(intent)
             }
         }
 
-        private fun loadCurrentNearbyPhotographers() {
-            getCurrentLocationUseCase(
-                onLocationReceived = ::loadNearbyPhotographers,
-                onPermissionDenied = {
-                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
-                },
+        private fun requestPreview(rawQuery: String) {
+            previewJob?.cancel()
+            val query = rawQuery.trim()
+            if (query.isBlank()) return
+
+            previewJob =
+                viewModelScope.launch {
+                    delay(PREVIEW_DEBOUNCE_MILLIS)
+                    _state.reduce(MainSearchIntent.PreviewLoading(query))
+                    searchPhotographersUseCase(
+                        keyword = query,
+                        sortType = _state.value.selectedSortType.apiValue,
+                        page = 0,
+                        size = PREVIEW_PAGE_SIZE,
+                    ).onSuccess { page ->
+                        _state.reduce(
+                            MainSearchIntent.PreviewLoaded(
+                                query = query,
+                                photographers = page.photographers.map { it.toSearchItem() },
+                            ),
+                        )
+                    }.onFailure {
+                        _state.reduce(MainSearchIntent.PreviewLoadFailed(query))
+                    }
+                }
+        }
+
+        private fun loadNextPage() {
+            val currentState = _state.value
+            if (
+                currentState.isLoading ||
+                currentState.isLoadingMore ||
+                !currentState.hasNextPage ||
+                currentState.query.isBlank()
+            ) {
+                return
+            }
+
+            loadSearchPage(
+                query = currentState.query,
+                sortType = currentState.selectedSortType,
+                page = currentState.nextPage,
+                append = true,
             )
         }
 
-        private fun loadNearbyPhotographers(location: LocationCoordinate) {
-            viewModelScope.launch {
-                val memberId = getCurrentMemberIdUseCase()
-                if (memberId == null) {
-                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
-                    return@launch
-                }
-
-                updateMemberLocationUseCase(
-                    memberId = memberId,
-                    location = location,
-                )
-
-                getNearbyPhotographersUseCase(
-                    longitude = location.longitude,
-                    latitude = location.latitude,
-                    distance = 2_000L,
-                ).onSuccess { filtered ->
-                    _state.update {
-                        MainSearchReducer.reduce(
-                            it,
-                            MainSearchIntent.NearbyPhotographersLoaded(filtered.toSearchItems()),
+        private fun loadSearchPage(
+            query: String,
+            sortType: SortType,
+            page: Int,
+            append: Boolean,
+        ) {
+            _state.reduce(MainSearchIntent.SearchLoading(append))
+            searchJob =
+                viewModelScope.launch {
+                    searchPhotographersUseCase(
+                        keyword = query,
+                        sortType = sortType.apiValue,
+                        page = page,
+                        size = SEARCH_PAGE_SIZE,
+                    ).onSuccess { result ->
+                        _state.reduce(
+                            MainSearchIntent.SearchPageLoaded(
+                                query = query,
+                                sortType = sortType,
+                                page = result.page,
+                                photographers = result.photographers.map { it.toSearchItem() },
+                                hasNextPage = result.hasNext,
+                                append = append,
+                            ),
                         )
+                    }.onFailure {
+                        _state.reduce(MainSearchIntent.SearchLoadFailed(append))
                     }
-                }.onFailure {
-                    _state.update { MainSearchReducer.reduce(it, MainSearchIntent.SearchLoadFailed) }
                 }
-            }
         }
-
-        private fun FilteredPhotographers.toSearchItems(): List<MainSearchPhotographerItem> =
-            (active + inactive).map { it.toSearchItem() }
 
         private fun Photographer.toSearchItem(): MainSearchPhotographerItem =
             MainSearchPhotographerItem(
@@ -89,4 +159,22 @@ class MainSearchViewModel
                 moodTags = photoMoods,
                 distance = distance,
             )
+
+        private fun MutableStateFlow<MainSearchState>.reduce(intent: MainSearchIntent) {
+            update { MainSearchReducer.reduce(it, intent) }
+        }
+
+        private val SortType.apiValue: String
+            get() =
+                when (this) {
+                    SortType.POPULAR -> "REVIEW"
+                    SortType.RATING -> "RATING"
+                    SortType.FOLLOWER -> "FOLLOWER"
+                }
+
+        private companion object {
+            const val PREVIEW_DEBOUNCE_MILLIS = 300L
+            const val PREVIEW_PAGE_SIZE = 5
+            const val SEARCH_PAGE_SIZE = 20
+        }
     }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModel.kt
@@ -36,7 +36,26 @@ class MainSearchViewModel
 
                 is MainSearchIntent.FocusChanged -> {
                     _state.reduce(intent)
-                    if (!intent.isFocused) previewJob?.cancel()
+                    val currentState = _state.value
+                    if (intent.isFocused) {
+                        if (
+                            !currentState.hasSearched &&
+                            currentState.query.isNotBlank() &&
+                            currentState.suggestions.isEmpty() &&
+                            !currentState.isPreviewLoading
+                        ) {
+                            val query = currentState.query.trim()
+                            _state.reduce(MainSearchIntent.PreviewLoading(query))
+                            requestPreview(query)
+                        }
+                    } else {
+                        val wasPreviewLoading = previewJob?.isActive == true
+                        previewJob?.cancel()
+                        previewJob = null
+                        if (wasPreviewLoading) {
+                            _state.reduce(MainSearchIntent.PreviewLoadFailed(currentState.query.trim()))
+                        }
+                    }
                 }
 
                 is MainSearchIntent.SearchSubmitted -> {

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="main_search_sort_popular">인기순</string>
     <string name="main_search_sort_rating">별점순</string>
     <string name="main_search_sort_follower">팔로워순</string>
+    <string name="main_search_load_more_retry">검색 결과를 더 불러오지 못했어요. 다시 시도</string>
+    <string name="main_search_load_failed">검색 결과를 불러오지 못했어요</string>
     <string name="main_home_title">홈</string>
     <string name="main_region_all_seoul">서울 전체</string>
     <string name="main_region_all_format">%1$s 전체</string>

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducerTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchReducerTest.kt
@@ -18,157 +18,166 @@ class MainSearchReducerTest {
     }
 
     @Test
-    fun `query change with non-empty focused text moves to typing and clears prior searched state`() {
-        val searchedState =
-            MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("연남동"),
-            )
-
+    fun `query change moves to typing and clears prior search`() {
         val state =
             MainSearchReducer.reduce(
-                searchedState.copy(isFocused = true),
-                MainSearchIntent.QueryChanged("성수"),
-            )
+                searchedState(),
+                MainSearchIntent.QueryChanged("유가"),
+            ).copy(isFocused = true)
 
         assertEquals(SearchUiState.Typing, state.uiState)
-        assertEquals("성수", state.query)
-        assertFalse(state.hasSearched)
+        assertEquals("유가", state.query)
+        assertTrue(state.isPreviewLoading)
+        assertTrue(state.results.isEmpty())
     }
 
     @Test
-    fun `search submit with non-blank query moves to complete and adds recent once`() {
-        val state =
+    fun `preview result is applied only to current typing query`() {
+        val typingState = MainSearchState.idle().copy(query = "유가", isFocused = true)
+        val stale =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("도곡동"),
+                typingState,
+                MainSearchIntent.PreviewLoaded("유", listOf(item(1))),
+            )
+        val current =
+            MainSearchReducer.reduce(
+                stale,
+                MainSearchIntent.PreviewLoaded("유가", listOf(item(2))),
             )
 
-        assertEquals(SearchUiState.Complete(query = "도곡동", hasResults = true), state.uiState)
+        assertTrue(stale.suggestions.isEmpty())
+        assertEquals(listOf("2"), current.suggestions.map(MainSearchPhotographerItem::id))
+    }
+
+    @Test
+    fun `preview result accepts trimmed typing query`() {
+        val state =
+            MainSearchReducer.reduce(
+                MainSearchState.idle().copy(query = "유가 ", isFocused = true),
+                MainSearchIntent.PreviewLoaded("유가", listOf(item(1))),
+            )
+
+        assertEquals(listOf("1"), state.suggestions.map(MainSearchPhotographerItem::id))
+        assertFalse(state.isPreviewLoading)
+    }
+
+    @Test
+    fun `search submit trims query and starts first page loading`() {
+        val state =
+            MainSearchReducer.reduce(
+                MainSearchState.idle(),
+                MainSearchIntent.SearchSubmitted(" 도곡동 "),
+            )
+
+        assertEquals(SearchUiState.Complete("도곡동", hasResults = false), state.uiState)
         assertEquals("도곡동", state.query)
-        assertTrue(state.hasSearched)
-        assertEquals(
-            listOf("도곡동", "연희동", "성수", "홍익대", "연남동", "송파구"),
-            state.recentSearchQueries,
-        )
+        assertTrue(state.isLoading)
+        assertEquals("도곡동", state.recentSearchQueries.first())
     }
 
     @Test
-    fun `search submit with duplicate query does not duplicate recent`() {
+    fun `first search page replaces results and exposes next page`() {
         val state =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("성수"),
+                MainSearchState.idle().copy(
+                    query = "작가",
+                    hasSearched = true,
+                    isLoading = true,
+                ),
+                MainSearchIntent.SearchPageLoaded(
+                    query = "작가",
+                    sortType = SortType.POPULAR,
+                    page = 0,
+                    photographers = listOf(item(1)),
+                    hasNextPage = true,
+                    append = false,
+                ),
             )
 
-        assertEquals(1, state.recentSearchQueries.count { it == "성수" })
-        assertEquals(listOf("연희동", "성수", "홍익대", "연남동", "송파구"), state.recentSearchQueries)
+        assertEquals(SearchUiState.Complete("작가", hasResults = true), state.uiState)
+        assertEquals(listOf("1"), state.results.map(MainSearchPhotographerItem::id))
+        assertEquals(1, state.nextPage)
+        assertTrue(state.hasNextPage)
+        assertFalse(state.isLoading)
     }
 
     @Test
-    fun `blank search moves to no-result complete without adding blank recent`() {
+    fun `additional page deduplicates photographers`() {
         val state =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("   "),
+                searchedState(),
+                MainSearchIntent.SearchPageLoaded(
+                    query = "작가",
+                    sortType = SortType.POPULAR,
+                    page = 1,
+                    photographers = listOf(item(1), item(2)),
+                    hasNextPage = false,
+                    append = true,
+                ),
             )
 
-        assertEquals(SearchUiState.Complete(query = "", hasResults = false), state.uiState)
-        assertTrue(state.hasSearched)
-        assertFalse(state.recentSearchQueries.any { it.isBlank() })
-        assertEquals(listOf("연희동", "성수", "홍익대", "연남동", "송파구"), state.recentSearchQueries)
+        assertEquals(listOf("1", "2"), state.results.map(MainSearchPhotographerItem::id))
+        assertFalse(state.hasNextPage)
+        assertEquals(2, state.nextPage)
     }
 
     @Test
-    fun `non-empty search exposes deterministic photographer results`() {
+    fun `additional load failure keeps existing results`() {
         val state =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("강남"),
+                searchedState().copy(isLoadingMore = true),
+                MainSearchIntent.SearchLoadFailed(append = true),
             )
 
-        assertTrue(state.uiState is SearchUiState.Complete)
-        assertEquals(3, state.results.size)
-        assertTrue(state.results.all { it.name.endsWith("작가") })
+        assertEquals(listOf("1"), state.results.map(MainSearchPhotographerItem::id))
+        assertTrue(state.loadMoreFailed)
+        assertFalse(state.isLoadingMore)
     }
 
     @Test
-    fun `ascii gangnam search exposes deterministic photographer results for adb input`() {
+    fun `initial load failure exposes retry state`() {
         val state =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("gangnam"),
+                searchedState().copy(isLoading = true),
+                MainSearchIntent.SearchLoadFailed(append = false),
             )
 
-        assertEquals(SearchUiState.Complete(query = "gangnam", hasResults = true), state.uiState)
-        assertEquals(3, state.results.size)
+        assertTrue(state.searchFailed)
+        assertFalse(state.isLoading)
+        assertTrue(state.results.isEmpty())
     }
 
     @Test
-    fun `no-match search exposes only empty result state`() {
+    fun `sort selection resets result pagination for server reload`() {
         val state =
             MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("ㅁㄴㅇㄹ없는검색어"),
-            )
-
-        assertEquals(SearchUiState.Complete(query = "ㅁㄴㅇㄹ없는검색어", hasResults = false), state.uiState)
-        assertEquals(emptyList<MainSearchPhotographerItem>(), state.results)
-    }
-
-    @Test
-    fun `sort selection changes deterministic result order`() {
-        val searchedState =
-            MainSearchReducer.reduce(
-                stateWithNearbyPhotographers(),
-                MainSearchIntent.SearchSubmitted("강남"),
-            )
-
-        val followerSortedState =
-            MainSearchReducer.reduce(
-                searchedState,
+                searchedState(),
                 MainSearchIntent.SortSelected(SortType.FOLLOWER),
             )
 
-        assertEquals(SortType.FOLLOWER, followerSortedState.selectedSortType)
-        assertEquals(
-            followerSortedState.results.minBy { it.distance }.name,
-            followerSortedState.results.first().name,
-        )
-        assertFalse(searchedState.results.first().name == followerSortedState.results.first().name)
+        assertEquals(SortType.FOLLOWER, state.selectedSortType)
+        assertTrue(state.isLoading)
+        assertTrue(state.results.isEmpty())
+        assertEquals(0, state.nextPage)
     }
 
-    private fun stateWithNearbyPhotographers(): MainSearchState =
+    private fun searchedState() =
         MainSearchState.idle().copy(
-            nearbyPhotographers =
-                listOf(
-                    MainSearchPhotographerItem(
-                        id = "gangnam-studio",
-                        name = "윤서 작가",
-                        profileImageUri = null,
-                        areaSummary = "서울 강남구 도곡동",
-                        isAvailableNow = true,
-                        moodTags = listOf("도시 감성", "프로필"),
-                        distance = 300,
-                    ),
-                    MainSearchPhotographerItem(
-                        id = "gangnam-film",
-                        name = "민재 작가",
-                        profileImageUri = null,
-                        areaSummary = "서울 강남구 역삼동",
-                        isAvailableNow = false,
-                        moodTags = listOf("필름 무드", "커플"),
-                        distance = 120,
-                    ),
-                    MainSearchPhotographerItem(
-                        id = "gangnam-pet",
-                        name = "가은 작가",
-                        profileImageUri = null,
-                        areaSummary = "서울 강남구 신사동",
-                        isAvailableNow = true,
-                        moodTags = listOf("반려동물", "자연광"),
-                        distance = 520,
-                    ),
-                ),
+            query = "작가",
+            hasSearched = true,
+            results = listOf(item(1)),
+            hasNextPage = true,
+            nextPage = 1,
+        )
+
+    private fun item(id: Int) =
+        MainSearchPhotographerItem(
+            id = id.toString(),
+            name = "작가 $id",
+            profileImageUri = null,
+            areaSummary = "",
+            isAvailableNow = true,
+            moodTags = listOf("필름"),
+            distance = 0,
         )
 }

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
@@ -1,25 +1,19 @@
 package com.hm.picplz.ui.screen.main
 
-import android.content.Context
 import com.hm.picplz.common.result.AppResult
-import com.hm.picplz.domain.model.FilteredPhotographers
-import com.hm.picplz.domain.model.KaKaoLoginResponse
-import com.hm.picplz.domain.model.KakaoUserInfo
-import com.hm.picplz.domain.model.LocationCoordinate
 import com.hm.picplz.domain.model.Photographer
-import com.hm.picplz.domain.repository.AuthRepository
-import com.hm.picplz.domain.repository.LocationRepository
-import com.hm.picplz.domain.repository.MemberRepository
-import com.hm.picplz.domain.repository.PhotographerRepository
-import com.hm.picplz.domain.usecase.GetCurrentLocationUseCase
-import com.hm.picplz.domain.usecase.GetCurrentMemberIdUseCase
-import com.hm.picplz.domain.usecase.GetNearbyPhotographersUseCase
-import com.hm.picplz.domain.usecase.UpdateMemberLocationUseCase
+import com.hm.picplz.domain.model.PhotographerPage
+import com.hm.picplz.domain.repository.PhotographerSearchRepository
+import com.hm.picplz.domain.usecase.SearchPhotographersUseCase
+import com.hm.picplz.ui.screen.main.modalBottomSheet.SortType
 import com.hm.picplz.ui.screen.photographer_main.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -29,180 +23,181 @@ class MainSearchViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `query change keeps typing state without area lookup`() =
+    fun `typing query loads API preview after debounce`() =
         runTest {
-            val viewModel = createViewModel()
+            val repository = FakeSearchPhotographerRepository()
+            val viewModel = createViewModel(repository)
 
             viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
-            viewModel.handleIntent(MainSearchIntent.QueryChanged("강"))
+            viewModel.handleIntent(MainSearchIntent.QueryChanged("유가"))
+
+            advanceTimeBy(299)
+            assertTrue(repository.requests.isEmpty())
+
+            advanceTimeBy(1)
             advanceUntilIdle()
 
-            assertEquals("강", viewModel.state.value.query)
+            assertEquals(SearchRequest("유가", "REVIEW", 0, 5), repository.requests.single())
             assertEquals(SearchUiState.Typing, viewModel.state.value.uiState)
+            assertEquals("유가영", viewModel.state.value.suggestions.single().name)
+            assertFalse(viewModel.state.value.isPreviewLoading)
         }
 
     @Test
-    fun `blank query change keeps empty state`() =
+    fun `new typing query cancels previous preview request`() =
         runTest {
-            val viewModel = createViewModel()
+            val repository = FakeSearchPhotographerRepository()
+            val viewModel = createViewModel(repository)
 
             viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
-            viewModel.handleIntent(MainSearchIntent.QueryChanged(""))
+            viewModel.handleIntent(MainSearchIntent.QueryChanged("유"))
+            advanceTimeBy(200)
+            viewModel.handleIntent(MainSearchIntent.QueryChanged("유가"))
+            advanceTimeBy(300)
             advanceUntilIdle()
 
-            assertEquals(SearchUiState.Empty, viewModel.state.value.uiState)
+            assertEquals(listOf(SearchRequest("유가", "REVIEW", 0, 5)), repository.requests)
         }
 
     @Test
-    fun `search submit loads nearby photographers and filters results`() =
+    fun `search submit loads first page from API`() =
         runTest {
-            val viewModel =
-                createViewModel(
-                    locationRepository = FakeSearchLocationRepository(location = LocationCoordinate(37.5, 127.0)),
-                    photographerRepository =
-                        FakeSearchPhotographerRepository(
-                            nearbyResult =
-                                Result.success(
-                                    FilteredPhotographers(
-                                        active =
-                                            listOf(
-                                                Photographer(
-                                                    id = 1L,
-                                                    name = "유가영 작가",
-                                                    profileImageUri = null,
-                                                    isActive = true,
-                                                    distance = 100,
-                                                    photoMoods = listOf("필름"),
-                                                    activeAreas = listOf("서울 강남구 도곡동"),
-                                                ),
-                                            ),
-                                    ),
-                                ),
-                        ),
-                )
+            val repository = FakeSearchPhotographerRepository()
+            val viewModel = createViewModel(repository)
 
-            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("강남"))
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted(" 유가영 "))
             advanceUntilIdle()
 
-            assertEquals(SearchUiState.Complete(query = "강남", hasResults = true), viewModel.state.value.uiState)
-            assertEquals("유가영 작가", viewModel.state.value.results.single().name)
+            assertEquals(SearchRequest("유가영", "REVIEW", 0, 20), repository.requests.single())
+            assertEquals(SearchUiState.Complete("유가영", hasResults = true), viewModel.state.value.uiState)
+            assertEquals("유가영", viewModel.state.value.results.single().name)
+            assertEquals(1, viewModel.state.value.nextPage)
+            assertTrue(viewModel.state.value.hasNextPage)
         }
 
     @Test
-    fun `search submit continues nearby lookup when member location update fails`() =
+    fun `sort selection reloads first page with server sort`() =
         runTest {
-            val viewModel =
-                createViewModel(
-                    locationRepository = FakeSearchLocationRepository(location = LocationCoordinate(37.5, 127.0)),
-                    memberRepository =
-                        FakeSearchMemberRepository(
-                            updateLocationResult = Result.failure(IllegalStateException()),
-                        ),
-                    photographerRepository =
-                        FakeSearchPhotographerRepository(
-                            nearbyResult =
-                                Result.success(
-                                    FilteredPhotographers(
-                                        active =
-                                            listOf(
-                                                Photographer(
-                                                    id = 1L,
-                                                    name = "유가영 작가",
-                                                    profileImageUri = null,
-                                                    isActive = true,
-                                                    distance = 100,
-                                                    photoMoods = listOf("필름"),
-                                                    activeAreas = listOf("서울 강남구 도곡동"),
-                                                ),
-                                            ),
-                                    ),
-                                ),
-                        ),
-                )
+            val repository = FakeSearchPhotographerRepository()
+            val viewModel = createViewModel(repository)
 
-            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("강남"))
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("유가영"))
+            advanceUntilIdle()
+            viewModel.handleIntent(MainSearchIntent.SortSelected(SortType.RATING))
             advanceUntilIdle()
 
-            assertEquals(SearchUiState.Complete(query = "강남", hasResults = true), viewModel.state.value.uiState)
-            assertEquals("유가영 작가", viewModel.state.value.results.single().name)
+            assertEquals(
+                listOf(
+                    SearchRequest("유가영", "REVIEW", 0, 20),
+                    SearchRequest("유가영", "RATING", 0, 20),
+                ),
+                repository.requests,
+            )
+            assertEquals(SortType.RATING, viewModel.state.value.selectedSortType)
         }
 
-    private fun createViewModel(
-        locationRepository: LocationRepository = FakeSearchLocationRepository(),
-        authRepository: AuthRepository = FakeSearchAuthRepository(),
-        memberRepository: MemberRepository = FakeSearchMemberRepository(),
-        photographerRepository: PhotographerRepository = FakeSearchPhotographerRepository(),
-    ): MainSearchViewModel =
-        MainSearchViewModel(
-            getCurrentLocationUseCase = GetCurrentLocationUseCase(locationRepository),
-            getCurrentMemberIdUseCase = GetCurrentMemberIdUseCase(authRepository),
-            updateMemberLocationUseCase = UpdateMemberLocationUseCase(memberRepository),
-            getNearbyPhotographersUseCase = GetNearbyPhotographersUseCase(photographerRepository),
-        )
+    @Test
+    fun `next page appends unique photographers and stops at last page`() =
+        runTest {
+            val repository =
+                FakeSearchPhotographerRepository { request ->
+                    if (request.page == 0) {
+                        Result.success(page(0, hasNext = true, photographer(1)))
+                    } else {
+                        Result.success(page(1, hasNext = false, photographer(1), photographer(2)))
+                    }
+                }
+            val viewModel = createViewModel(repository)
+
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("작가"))
+            advanceUntilIdle()
+            viewModel.handleIntent(MainSearchIntent.LoadNextPage)
+            advanceUntilIdle()
+            viewModel.handleIntent(MainSearchIntent.LoadNextPage)
+            advanceUntilIdle()
+
+            assertEquals(listOf(1L, 2L), viewModel.state.value.results.map { it.id.toLong() })
+            assertFalse(viewModel.state.value.hasNextPage)
+            assertEquals(2, repository.requests.size)
+        }
+
+    @Test
+    fun `additional load failure keeps results and can retry`() =
+        runTest {
+            var additionalAttempt = 0
+            val repository =
+                FakeSearchPhotographerRepository { request ->
+                    if (request.page == 0) {
+                        Result.success(page(0, hasNext = true, photographer(1)))
+                    } else if (additionalAttempt++ == 0) {
+                        Result.failure(IllegalStateException("temporary"))
+                    } else {
+                        Result.success(page(1, hasNext = false, photographer(2)))
+                    }
+                }
+            val viewModel = createViewModel(repository)
+
+            viewModel.handleIntent(MainSearchIntent.SearchSubmitted("작가"))
+            advanceUntilIdle()
+            viewModel.handleIntent(MainSearchIntent.LoadNextPage)
+            advanceUntilIdle()
+
+            assertEquals(listOf("1"), viewModel.state.value.results.map(MainSearchPhotographerItem::id))
+            assertTrue(viewModel.state.value.loadMoreFailed)
+
+            viewModel.handleIntent(MainSearchIntent.LoadNextPage)
+            advanceUntilIdle()
+
+            assertEquals(listOf("1", "2"), viewModel.state.value.results.map(MainSearchPhotographerItem::id))
+            assertFalse(viewModel.state.value.loadMoreFailed)
+        }
+
+    private fun createViewModel(repository: PhotographerSearchRepository = FakeSearchPhotographerRepository()) =
+        MainSearchViewModel(SearchPhotographersUseCase(repository))
 }
 
-private class FakeSearchLocationRepository(
-    private val location: LocationCoordinate? = null,
-) : LocationRepository {
-    override fun getCurrentLocation(
-        onLocationReceived: (LocationCoordinate) -> Unit,
-        onPermissionDenied: () -> Unit,
-    ) {
-        location?.let(onLocationReceived) ?: onPermissionDenied()
+private data class SearchRequest(
+    val keyword: String,
+    val sortType: String,
+    val page: Int,
+    val size: Int,
+)
+
+private class FakeSearchPhotographerRepository(
+    private val result: suspend (SearchRequest) -> AppResult<PhotographerPage> = {
+        Result.success(page(0, hasNext = true, photographer(1)))
+    },
+) : PhotographerSearchRepository {
+    val requests = mutableListOf<SearchRequest>()
+
+    override suspend fun searchPhotographers(
+        keyword: String,
+        sortType: String,
+        page: Int,
+        size: Int,
+    ): AppResult<PhotographerPage> {
+        val request = SearchRequest(keyword, sortType, page, size)
+        requests += request
+        return result(request)
     }
 }
 
-private class FakeSearchPhotographerRepository(
-    private val nearbyResult: AppResult<FilteredPhotographers> = Result.success(FilteredPhotographers()),
-) : PhotographerRepository {
-    override suspend fun getNearbyPhotographers(
-        longitude: Double,
-        latitude: Double,
-        distance: Long,
-    ): AppResult<FilteredPhotographers> = nearbyResult
+private fun page(
+    page: Int,
+    hasNext: Boolean,
+    vararg photographers: Photographer,
+) = PhotographerPage(
+    photographers = photographers.toList(),
+    page = page,
+    hasNext = hasNext,
+)
 
-    override suspend fun getPhotographerDetail(
-        photographerId: Long,
-        reviewSort: String,
-    ) = error("Not used")
-
-    override suspend fun getPhotographerMoodKeywords(photographerId: Long) = error("Not used")
-
-    override suspend fun addPhotoMood(photoMood: String) = error("Not used")
-
-    override suspend fun deletePhotoMood(photoMood: String) = error("Not used")
-
-    override suspend fun getActiveAreas(photographerId: Long) = error("Not used")
-
-    override suspend fun updateActiveAreas(areas: List<com.hm.picplz.domain.model.Area>) = error("Not used")
-}
-
-private class FakeSearchAuthRepository(
-    private val memberId: Long? = 3L,
-) : AuthRepository {
-    override suspend fun loginWithKakao(context: Context): AppResult<KaKaoLoginResponse> = error("Not used")
-
-    override suspend fun getKakaoUserInfo(): AppResult<KakaoUserInfo> = error("Not used")
-
-    override suspend fun unlinkKakao(): AppResult<Unit> = error("Not used")
-
-    override fun isKakaoTalkLoginAvailable(context: Context): Boolean = error("Not used")
-
-    override fun getCurrentMemberId(): Long? = memberId
-}
-
-private class FakeSearchMemberRepository(
-    private val updateLocationResult: AppResult<Unit> = Result.success(Unit),
-) : MemberRepository {
-    override suspend fun checkNicknameAvailable(nickname: String) = error("Not used")
-
-    override suspend fun getMemberProfile(memberId: Long) = error("Not used")
-
-    override suspend fun updateMemberProfile(command: com.hm.picplz.domain.model.UpdateMemberProfileCommand) =
-        error("Not used")
-
-    override suspend fun updateMemberLocation(
-        memberId: Long,
-        location: LocationCoordinate,
-    ): AppResult<Unit> = updateLocationResult
-}
+private fun photographer(id: Long) =
+    Photographer(
+        id = id,
+        name = if (id == 1L) "유가영" else "강주은",
+        profileImageUri = null,
+        isActive = id == 1L,
+        distance = 0,
+        photoMoods = listOf("필름"),
+    )

--- a/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
+++ b/feature/main/src/test/kotlin/com/hm/picplz/ui/screen/main/MainSearchViewModelTest.kt
@@ -60,6 +60,30 @@ class MainSearchViewModelTest {
         }
 
     @Test
+    fun `refocusing after preview cancellation restarts request`() =
+        runTest {
+            val repository = FakeSearchPhotographerRepository()
+            val viewModel = createViewModel(repository)
+
+            viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
+            viewModel.handleIntent(MainSearchIntent.QueryChanged("유가"))
+            advanceTimeBy(100)
+            viewModel.handleIntent(MainSearchIntent.FocusChanged(false))
+
+            assertFalse(viewModel.state.value.isPreviewLoading)
+            assertTrue(repository.requests.isEmpty())
+
+            viewModel.handleIntent(MainSearchIntent.FocusChanged(true))
+            assertTrue(viewModel.state.value.isPreviewLoading)
+            advanceTimeBy(300)
+            advanceUntilIdle()
+
+            assertEquals(listOf(SearchRequest("유가", "REVIEW", 0, 5)), repository.requests)
+            assertEquals("유가영", viewModel.state.value.suggestions.single().name)
+            assertFalse(viewModel.state.value.isPreviewLoading)
+        }
+
+    @Test
     fun `search submit loads first page from API`() =
         runTest {
             val repository = FakeSearchPhotographerRepository()


### PR DESCRIPTION
## Summary

- 고객 메인 검색 화면의 입력 중 작가 프리뷰와 검색 제출 후 결과 목록을 실제 작가 검색 API에 연결했습니다.
- 검색어 입력 디바운스와 이전 요청 취소를 적용하고, 프리뷰 재진입 시 로딩이 멈추지 않도록 상태를 복구했습니다.
- 검색 결과의 서버 페이지네이션, 중복 요청 방지, 실패 후 재시도 상태를 구현했습니다.
- 별점순·리뷰순·팔로워순 정렬을 서버 `sortType` 계약에 연결했습니다.

Closes #205

## Changes

### search flow

- 검색어 입력 중 디바운스된 작가 프리뷰를 조회합니다.
- 검색 제출 시 첫 페이지부터 다시 조회하고, 목록 하단 도달 시 다음 페이지를 불러옵니다.
- 진행 중인 프리뷰 요청은 포커스 해제 또는 새 검색어 입력 시 취소합니다.
- 최초 로딩, 추가 로딩, 빈 결과, 실패 및 재시도 상태를 구분합니다.
- 작가 프로필 이미지, 활동 상태, 분위기 태그를 검색 카드와 프리뷰에 표시합니다.

### API / data

- `GET /photographers/search`
- query: `keyword`, `sortType`, `page`, `size`
- sortType: `RATING`, `REVIEW`, `FOLLOWER`
- 검색 DTO는 `core:data`에 유지하고 mapper를 통해 domain model로 변환합니다.
- Source → Service → Repository → UseCase → ViewModel 경계로 검색 흐름을 연결했습니다.
- 검색 응답과 페이지 메타데이터 파싱을 Source 테스트로 고정했습니다.

## Pending API contract

현재 작가 검색 응답에는 활동 지역 정보가 없어 검색 결과의 지역 표시는 비워 둡니다. 주변 작가 API를 추가 호출해 보강하면 행별 N+1 요청이 발생하므로 적용하지 않았습니다.

서버 계약에 없는 지역·촬영기기·분위기 필터도 이번 범위에서는 추가하지 않았습니다. 검색 응답 계약이 확장되면 후속으로 연결합니다.

## Verification

- [x] `./gradlew :core:data:testDebugUnitTest :feature:main:testDebugUnitTest`
- [x] `./gradlew :core:data:ktlintCheck :feature:main:ktlintCheck`
- [x] `./gradlew :core:data:detekt :feature:main:detekt`
- [x] `./gradlew :app:assembleDevDebug`
- [x] `git diff --check`
- [x] 에뮬레이터에서 실제 API 프리뷰·검색 결과·정렬 확인
- [ ] 실제 20개 초과 데이터의 실기기 무한 스크롤 확인
