### PR TITLE
✨ 예약 API 데이터 계층 구축 및 상태 전이 연동

### DIFF
--- a/app/src/main/kotlin/com/hm/picplz/di/ReservationModule.kt
+++ b/app/src/main/kotlin/com/hm/picplz/di/ReservationModule.kt
@@ -1,0 +1,39 @@
+package com.hm.picplz.di
+
+import com.hm.picplz.data.api.ReservationApi
+import com.hm.picplz.data.service.ReservationService
+import com.hm.picplz.data.service.ReservationServiceImpl
+import com.hm.picplz.data.source.ReservationSource
+import com.hm.picplz.data.source.ReservationSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReservationModule {
+    @Binds
+    @Singleton
+    abstract fun bindReservationService(reservationServiceImpl: ReservationServiceImpl): ReservationService
+
+    @Binds
+    @Singleton
+    abstract fun bindReservationSource(reservationSourceImpl: ReservationSourceImpl): ReservationSource
+
+    companion object {
+        /**
+         * 다른 Api 는 `NetworkModule` 에서 제공하지만 이 모듈에 둡니다.
+         * `NetworkModule` 은 @Provides 가 14개라, 하나 더 넣으면 detekt `TooManyFunctions`
+         * (thresholdInObjects = 15) 한계에 정확히 걸려 다음 API 추가가 막힙니다.
+         */
+        @Provides
+        @Singleton
+        fun provideReservationApi(
+            @PicplzApi retrofit: Retrofit,
+        ): ReservationApi = retrofit.create(ReservationApi::class.java)
+    }
+}

--- a/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/hm/picplz/navigation/graph/MainNavGraph.kt
@@ -83,6 +83,14 @@ import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejec
 import com.hm.picplz.ui.screen.reservation.ReservationScreen
 import com.hm.picplz.ui.screen.write_review.WriteReviewScreen
 
+/**
+ * 채팅방의 "예약 정보 확인" 카드가 아직 더미 메시지라 실제 예약 id를 넘겨주지 못합니다.
+ * 화면 진입 자체는 막지 않도록 임시 값을 씁니다.
+ *
+ * TODO: 채팅 메시지에 reservationId가 실리면 제거 (#169, #196)
+ */
+private const val FALLBACK_RESERVATION_ID = 0L
+
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
     composable<Dev> {
         val tokenManager = (LocalContext.current.applicationContext as MyApplication).tokenManager
@@ -138,7 +146,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 navController.popBackStack()
             },
             onNavigatePhotographerDetailReservation = {
-                navController.navigate(PhotographerDetailReservation)
+                navController.navigate(PhotographerDetailReservation(reservationId = FALLBACK_RESERVATION_ID))
             },
             _roomId = args.roomId,
         )
@@ -315,14 +323,15 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateBack = {
                 navController.popBackStack()
             },
-            onNavigateToCancelReservation = { orderId ->
-                navController.navigate(CancelReservation(orderId = orderId))
+            onNavigateToCancelReservation = { reservationId ->
+                navController.navigate(CancelReservation(reservationId = reservationId))
             },
-            onNavigateToOrderDetail = { orderId ->
-                navController.navigate(OrderDetail(orderId = orderId))
+            onNavigateToOrderDetail = { reservationId ->
+                navController.navigate(OrderDetail(reservationId = reservationId))
             },
-            onNavigateToWriteReview = { orderId ->
-                navController.navigate(WriteReview(orderId = orderId))
+            // 리뷰 작성은 #217 범위라 라우트 파라미터가 아직 String 입니다.
+            onNavigateToWriteReview = { reservationId ->
+                navController.navigate(WriteReview(orderId = reservationId.toString()))
             },
         )
     }
@@ -352,11 +361,11 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
             onNavigateBack = {
                 navController.popBackStack()
             },
-            onNavigateToRejectReason = { orderId ->
-                navController.navigate(PhotographerRejectReservation(orderId = orderId))
+            onNavigateToRejectReason = { reservationId ->
+                navController.navigate(PhotographerRejectReservation(reservationId = reservationId))
             },
-            onNavigateToCancelReservation = { orderId ->
-                navController.navigate(PhotographerCancelReservation(orderId = orderId))
+            onNavigateToCancelReservation = { reservationId ->
+                navController.navigate(PhotographerCancelReservation(reservationId = reservationId))
             },
         )
     }
@@ -406,7 +415,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 navController.popBackStack()
             },
             onNavigateNextStep = {
-                navController.navigate(CancelReservation(orderId = args.orderId))
+                navController.navigate(CancelReservation(reservationId = args.reservationId))
             },
         )
     }

--- a/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/common/util/DateTimeUtil.kt
@@ -1,9 +1,12 @@
 package com.hm.picplz.common.util
 
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+
+private const val SERVER_DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss"
 
 object DateTimeUtil {
     private val timeFormat = SimpleDateFormat("a h:mm", Locale.KOREA)
@@ -131,5 +134,30 @@ object DateTimeUtil {
                 add(Calendar.DAY_OF_MONTH, days)
             }
             .timeInMillis
+    }
+
+    /**
+     * 서버가 내려주는 ISO-8601 local date-time 문자열을 millisecond 로 변환합니다.
+     *
+     * 예: `"2026-09-01T14:00:00"` · 초 단위 소수점(`.123456`)이 붙어 오는 응답도 있어 잘라냅니다.
+     * 타임존 정보가 없는 값이라 기기 로컬 타임존 기준으로 해석합니다.
+     *
+     * minSdk 24 + core library desugaring 미사용이라 `java.time` 을 쓸 수 없어
+     * [SimpleDateFormat] 으로 파싱합니다. 스레드 안전을 위해 호출마다 인스턴스를 만듭니다.
+     * 서버 계약이 바뀌어 형식이 어긋나면 화면이 죽는 대신 null 로 떨어집니다.
+     *
+     * @return 파싱 실패 시 null
+     */
+    fun parseServerDateTime(raw: String?): Long? {
+        val trimmed = raw?.substringBefore('.')?.trim().orEmpty()
+        if (trimmed.isEmpty()) return null
+        return try {
+            SimpleDateFormat(SERVER_DATE_TIME_PATTERN, Locale.US)
+                .apply { isLenient = false }
+                .parse(trimmed)
+                ?.time
+        } catch (error: ParseException) {
+            null
+        }
     }
 }

--- a/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
+++ b/core/common/src/main/kotlin/com/hm/picplz/navigation/model/RouteModels.kt
@@ -168,27 +168,29 @@ data class DetailPhotographerSingleReview(
 data class DetailPhotographerPortfolioDetail(val portfolioId: Int, val photoIndex: Int) : NavigationRoute
 
 // === Reservation Screens ===
+// 예약 id는 서버 계약(integer)에 맞춰 Long 을 씁니다.
 @Serializable
-data object DetailReservation : NavigationRoute
+data class DetailReservation(val reservationId: Long) : NavigationRoute
 
 @Serializable
-data object PhotographerDetailReservation : NavigationRoute
+data class PhotographerDetailReservation(val reservationId: Long) : NavigationRoute
 
 @Serializable
-data class PhotographerRejectReservation(val orderId: String) : NavigationRoute
+data class PhotographerRejectReservation(val reservationId: Long) : NavigationRoute
 
 @Serializable
 data class CancelReservationConfirm(val isPhotographer: Boolean = false) : NavigationRoute
 
 @Serializable
-data class OrderDetail(val orderId: String) : NavigationRoute
+data class OrderDetail(val reservationId: Long) : NavigationRoute
 
 @Serializable
-data class CancelReservation(val orderId: String) : NavigationRoute
+data class CancelReservation(val reservationId: Long) : NavigationRoute
 
 @Serializable
-data class PhotographerCancelReservation(val orderId: String) : NavigationRoute
+data class PhotographerCancelReservation(val reservationId: Long) : NavigationRoute
 
+/** 리뷰 작성은 #217에서 다루므로 String 파라미터를 유지합니다. */
 @Serializable
 data class WriteReview(val orderId: String) : NavigationRoute
 

--- a/core/data/src/main/kotlin/com/hm/picplz/data/api/ReservationApi.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/api/ReservationApi.kt
@@ -1,0 +1,52 @@
+package com.hm.picplz.data.api
+
+import com.hm.picplz.data.model.ApiResponse
+import com.hm.picplz.data.model.CancelReservationRequest
+import com.hm.picplz.data.model.RejectReservationRequest
+import com.hm.picplz.data.model.ReservationDetailDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+
+/**
+ * 예약 API.
+ *
+ * 상태 전이는 `PENDING` --(작가 accept)--> `ACCEPTED` --(고객 confirm)--> `CONFIRMED` 순서이고,
+ * 취소는 어느 단계에서든 가능합니다. 각 엔드포인트는 호출자 역할을 검증하므로
+ * 작가 전용 API를 고객 토큰으로 부르면 `404 PHOTOGRAPHER_404_1` 이 돌아옵니다.
+ *
+ * 고객의 일자 확정(`PATCH .../confirm`)은 별도 화면이 필요해 이 인터페이스에 아직 없습니다.
+ */
+interface ReservationApi {
+    /** 작가 전용. 고객용 예약 상세 조회 API는 서버에 아직 없습니다. */
+    @GET("api/v1/reservations/{reservationId}")
+    suspend fun getReservation(
+        @Path("reservationId") reservationId: Long,
+    ): Response<ApiResponse<ReservationDetailDto>>
+
+    /** 작가가 받은 예약 목록. */
+    @GET("api/v1/photographers/reservations")
+    suspend fun getPhotographerReservations(): Response<ApiResponse<List<ReservationDetailDto>>>
+
+    /** 작가의 예약 승인. 요청 본문이 없습니다. */
+    @PATCH("api/v1/reservations/{reservationId}/accept")
+    suspend fun acceptReservation(
+        @Path("reservationId") reservationId: Long,
+    ): Response<Unit>
+
+    /** 작가의 예약 거절. */
+    @PATCH("api/v1/reservations/{reservationId}/reject")
+    suspend fun rejectReservation(
+        @Path("reservationId") reservationId: Long,
+        @Body request: RejectReservationRequest,
+    ): Response<Unit>
+
+    /** 고객·작가 공용 예약 취소. */
+    @PATCH("api/v1/reservations/{reservationId}/cancel")
+    suspend fun cancelReservation(
+        @Path("reservationId") reservationId: Long,
+        @Body request: CancelReservationRequest,
+    ): Response<Unit>
+}

--- a/core/data/src/main/kotlin/com/hm/picplz/data/mapper/ReservationMapper.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/mapper/ReservationMapper.kt
@@ -1,0 +1,22 @@
+package com.hm.picplz.data.mapper
+
+import com.hm.picplz.common.util.DateTimeUtil
+import com.hm.picplz.data.model.ReservationDetailDto
+import com.hm.picplz.domain.model.ReservationDetail
+import com.hm.picplz.domain.model.ReservationStatusCode
+
+private const val EDITED_YES = "Y"
+
+fun ReservationDetailDto.toReservationDetail(): ReservationDetail =
+    ReservationDetail(
+        reservationId = reservationId,
+        packageName = packageName.orEmpty(),
+        productPrice = productPrice ?: 0,
+        editPrice = editPrice ?: 0,
+        shootingDateTimeMillis = DateTimeUtil.parseServerDateTime(reservationTime),
+        place = place.orEmpty(),
+        photoAmount = photoAmount ?: 0,
+        isEdited = editedYn == EDITED_YES,
+        reservationNumber = reservationNumber.orEmpty(),
+        status = ReservationStatusCode.from(status),
+    )

--- a/core/data/src/main/kotlin/com/hm/picplz/data/model/ReservationDto.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/model/ReservationDto.kt
@@ -1,0 +1,43 @@
+package com.hm.picplz.data.model
+
+/**
+ * 예약 상세 응답.
+ *
+ * `GET /api/v1/reservations/{reservationId}` 와 `GET /api/v1/photographers/reservations` 가
+ * 같은 형태를 사용합니다. 둘 다 **작가 전용** 엔드포인트로, 고객 토큰으로 호출하면
+ * `404 PHOTOGRAPHER_404_1` 이 떨어집니다.
+ *
+ * 응답에 고객 정보(이름/프로필)와 확정 시각이 없어, 화면에서 필요한 값은 아직 더미로 남아 있습니다.
+ */
+data class ReservationDetailDto(
+    val reservationId: Long,
+    val packageName: String?,
+    val productPrice: Int?,
+    val editPrice: Int?,
+    /** ISO-8601 local date-time. 예: `2026-09-01T14:00:00` */
+    val reservationTime: String?,
+    val place: String?,
+    val photoAmount: Int?,
+    /** `"Y"` / `"N"` */
+    val editedYn: String?,
+    val reservationNumber: String?,
+    /** `PENDING` / `ACCEPTED` / `CONFIRMED` / `REJECTED` / `CANCELED` */
+    val status: String?,
+)
+
+/**
+ * 예약 취소 요청. 고객·작가 공용 엔드포인트입니다.
+ *
+ * [cancelReasons] 는 서버 enum 이름 목록입니다. 앱의 사유 enum → 서버 문자열 변환은
+ * `feature/reservation` 의 매퍼가 담당합니다(사유 enum이 UI 계층에 있어 data 모듈에서 참조 불가).
+ */
+data class CancelReservationRequest(
+    val cancelReasons: List<String>,
+    val cancelReasonDetail: String?,
+)
+
+/** 예약 거절 요청. 작가 전용입니다. */
+data class RejectReservationRequest(
+    val rejectReasons: List<String>,
+    val rejectReasonDetail: String?,
+)

--- a/core/data/src/main/kotlin/com/hm/picplz/data/service/ReservationService.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/service/ReservationService.kt
@@ -1,0 +1,82 @@
+package com.hm.picplz.data.service
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.mapper.toReservationDetail
+import com.hm.picplz.data.model.CancelReservationRequest
+import com.hm.picplz.data.model.RejectReservationRequest
+import com.hm.picplz.data.source.ReservationSource
+import com.hm.picplz.domain.model.ReservationDetail
+import javax.inject.Inject
+
+interface ReservationService {
+    suspend fun getReservation(reservationId: Long): AppResult<ReservationDetail>
+
+    suspend fun getPhotographerReservations(): AppResult<List<ReservationDetail>>
+
+    suspend fun acceptReservation(reservationId: Long): AppResult<Unit>
+
+    /**
+     * @param reasons 서버 enum 이름 목록 (예: `REGION_UNAVAILABLE`)
+     * @param reasonDetail 직접 입력 문구. 비어 있으면 null 로 보냅니다.
+     */
+    suspend fun rejectReservation(
+        reservationId: Long,
+        reasons: List<String>,
+        reasonDetail: String?,
+    ): AppResult<Unit>
+
+    /**
+     * 고객·작가 공용 취소.
+     *
+     * @param reasons 서버 enum 이름 목록 (예: `CHANGE_OF_MIND`)
+     * @param reasonDetail 직접 입력 문구. 비어 있으면 null 로 보냅니다.
+     */
+    suspend fun cancelReservation(
+        reservationId: Long,
+        reasons: List<String>,
+        reasonDetail: String?,
+    ): AppResult<Unit>
+}
+
+class ReservationServiceImpl
+    @Inject
+    constructor(
+        private val reservationSource: ReservationSource,
+    ) : ReservationService {
+        override suspend fun getReservation(reservationId: Long): AppResult<ReservationDetail> =
+            reservationSource.getReservation(reservationId).map { it.toReservationDetail() }
+
+        override suspend fun getPhotographerReservations(): AppResult<List<ReservationDetail>> =
+            reservationSource.getPhotographerReservations().map { reservations ->
+                reservations.map { it.toReservationDetail() }
+            }
+
+        override suspend fun acceptReservation(reservationId: Long): AppResult<Unit> =
+            reservationSource.acceptReservation(reservationId)
+
+        override suspend fun rejectReservation(
+            reservationId: Long,
+            reasons: List<String>,
+            reasonDetail: String?,
+        ): AppResult<Unit> =
+            reservationSource.rejectReservation(
+                reservationId,
+                RejectReservationRequest(
+                    rejectReasons = reasons,
+                    rejectReasonDetail = reasonDetail?.takeIf { it.isNotBlank() },
+                ),
+            )
+
+        override suspend fun cancelReservation(
+            reservationId: Long,
+            reasons: List<String>,
+            reasonDetail: String?,
+        ): AppResult<Unit> =
+            reservationSource.cancelReservation(
+                reservationId,
+                CancelReservationRequest(
+                    cancelReasons = reasons,
+                    cancelReasonDetail = reasonDetail?.takeIf { it.isNotBlank() },
+                ),
+            )
+    }

--- a/core/data/src/main/kotlin/com/hm/picplz/data/source/ReservationSource.kt
+++ b/core/data/src/main/kotlin/com/hm/picplz/data/source/ReservationSource.kt
@@ -1,0 +1,53 @@
+package com.hm.picplz.data.source
+
+import com.hm.picplz.common.result.AppResult
+import com.hm.picplz.data.api.ReservationApi
+import com.hm.picplz.data.model.CancelReservationRequest
+import com.hm.picplz.data.model.RejectReservationRequest
+import com.hm.picplz.data.model.ReservationDetailDto
+import com.hm.picplz.data.util.safeApiCall
+import com.hm.picplz.data.util.safeApiCallUnit
+import javax.inject.Inject
+
+interface ReservationSource {
+    suspend fun getReservation(reservationId: Long): AppResult<ReservationDetailDto>
+
+    suspend fun getPhotographerReservations(): AppResult<List<ReservationDetailDto>>
+
+    suspend fun acceptReservation(reservationId: Long): AppResult<Unit>
+
+    suspend fun rejectReservation(
+        reservationId: Long,
+        request: RejectReservationRequest,
+    ): AppResult<Unit>
+
+    suspend fun cancelReservation(
+        reservationId: Long,
+        request: CancelReservationRequest,
+    ): AppResult<Unit>
+}
+
+class ReservationSourceImpl
+    @Inject
+    constructor(
+        private val reservationApi: ReservationApi,
+    ) : ReservationSource {
+        override suspend fun getReservation(reservationId: Long): AppResult<ReservationDetailDto> =
+            safeApiCall({ reservationApi.getReservation(reservationId) }) { it.data }
+
+        override suspend fun getPhotographerReservations(): AppResult<List<ReservationDetailDto>> =
+            safeApiCall({ reservationApi.getPhotographerReservations() }) { it.data }
+
+        override suspend fun acceptReservation(reservationId: Long): AppResult<Unit> =
+            safeApiCallUnit { reservationApi.acceptReservation(reservationId) }
+
+        override suspend fun rejectReservation(
+            reservationId: Long,
+            request: RejectReservationRequest,
+        ): AppResult<Unit> = safeApiCallUnit { reservationApi.rejectReservation(reservationId, request) }
+
+        override suspend fun cancelReservation(
+            reservationId: Long,
+            request: CancelReservationRequest,
+        ): AppResult<Unit> = safeApiCallUnit { reservationApi.cancelReservation(reservationId, request) }
+    }

--- a/core/data/src/test/kotlin/com/hm/picplz/data/mapper/ReservationMapperTest.kt
+++ b/core/data/src/test/kotlin/com/hm/picplz/data/mapper/ReservationMapperTest.kt
@@ -1,0 +1,114 @@
+package com.hm.picplz.data.mapper
+
+import com.hm.picplz.data.model.ReservationDetailDto
+import com.hm.picplz.domain.model.ReservationStatusCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * dev 서버가 실제로 내려준 예약 상세 응답을 기준으로 매핑을 고정합니다.
+ *
+ * ```
+ * {"reservationId":13,"packageName":"남친생기는 프사","productPrice":9900,"editPrice":0,
+ *  "reservationTime":"2026-09-01T14:00:00","place":"서울특별시 종로구 효자로 33...",
+ *  "photoAmount":5,"editedYn":"Y","reservationNumber":"N404e7a7c0964","status":"PENDING"}
+ * ```
+ */
+class ReservationMapperTest {
+    private fun dto(
+        reservationTime: String? = "2026-09-01T14:00:00",
+        editedYn: String? = "Y",
+        status: String? = "PENDING",
+    ) = ReservationDetailDto(
+        reservationId = 13L,
+        packageName = "남친생기는 프사",
+        productPrice = 9900,
+        editPrice = 0,
+        reservationTime = reservationTime,
+        place = "서울특별시 종로구 효자로 33",
+        photoAmount = 5,
+        editedYn = editedYn,
+        reservationNumber = "N404e7a7c0964",
+        status = status,
+    )
+
+    @Test
+    fun `서버 응답이 도메인 모델로 변환된다`() {
+        val detail = dto().toReservationDetail()
+
+        assertEquals(13L, detail.reservationId)
+        assertEquals("남친생기는 프사", detail.packageName)
+        assertEquals(9900, detail.productPrice)
+        assertEquals(5, detail.photoAmount)
+        assertEquals("N404e7a7c0964", detail.reservationNumber)
+        assertEquals(ReservationStatusCode.PENDING, detail.status)
+    }
+
+    @Test
+    fun `촬영 일시가 로컬 타임존 기준 millis 로 파싱된다`() {
+        val millis = requireNotNull(dto().toReservationDetail().shootingDateTimeMillis)
+
+        val calendar = Calendar.getInstance(TimeZone.getDefault()).apply { timeInMillis = millis }
+        assertEquals(2026, calendar.get(Calendar.YEAR))
+        assertEquals(Calendar.SEPTEMBER, calendar.get(Calendar.MONTH))
+        assertEquals(1, calendar.get(Calendar.DAY_OF_MONTH))
+        assertEquals(14, calendar.get(Calendar.HOUR_OF_DAY))
+        assertEquals(0, calendar.get(Calendar.MINUTE))
+    }
+
+    @Test
+    fun `초 단위 소수점이 붙어도 파싱된다`() {
+        val withFraction = dto(reservationTime = "2026-09-01T14:00:00.123456").toReservationDetail()
+        val plain = dto().toReservationDetail()
+
+        assertEquals(plain.shootingDateTimeMillis, withFraction.shootingDateTimeMillis)
+    }
+
+    @Test
+    fun `촬영 일시가 없거나 형식이 어긋나면 null 이다`() {
+        assertNull(dto(reservationTime = null).toReservationDetail().shootingDateTimeMillis)
+        assertNull(dto(reservationTime = "").toReservationDetail().shootingDateTimeMillis)
+        assertNull(dto(reservationTime = "2026-09-01").toReservationDetail().shootingDateTimeMillis)
+        assertNull(dto(reservationTime = "어제").toReservationDetail().shootingDateTimeMillis)
+    }
+
+    @Test
+    fun `editedYn 이 Y 일 때만 보정 포함이다`() {
+        assertEquals(true, dto(editedYn = "Y").toReservationDetail().isEdited)
+        assertEquals(false, dto(editedYn = "N").toReservationDetail().isEdited)
+        assertEquals(false, dto(editedYn = null).toReservationDetail().isEdited)
+    }
+
+    @Test
+    fun `서버가 모르는 상태 문자열은 null 로 남는다`() {
+        assertNull(dto(status = "COMPLETED").toReservationDetail().status)
+        assertNull(dto(status = null).toReservationDetail().status)
+    }
+
+    @Test
+    fun `누락된 숫자 필드는 0 으로 채운다`() {
+        val detail =
+            ReservationDetailDto(
+                reservationId = 1L,
+                packageName = null,
+                productPrice = null,
+                editPrice = null,
+                reservationTime = null,
+                place = null,
+                photoAmount = null,
+                editedYn = null,
+                reservationNumber = null,
+                status = null,
+            ).toReservationDetail()
+
+        assertEquals(0, detail.productPrice)
+        assertEquals(0, detail.editPrice)
+        assertEquals(0, detail.photoAmount)
+        assertEquals("", detail.packageName)
+        assertEquals("", detail.place)
+        assertEquals("", detail.reservationNumber)
+    }
+}

--- a/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Reservation.kt
+++ b/core/domain/src/main/kotlin/com/hm/picplz/domain/model/Reservation.kt
@@ -1,0 +1,53 @@
+package com.hm.picplz.domain.model
+
+/**
+ * 서버가 관리하는 예약 상태.
+ *
+ * UI의 `ReservationStatus`(예약 대기 / 일시 확정 대기 / 예약 확정 / 거래 완료)와는 별개입니다.
+ * 서버엔 "거래 완료"에 해당하는 값이 없고, 반대로 [REJECTED]·[CANCELED] 는 UI enum에 없습니다.
+ * 두 체계를 잇는 매핑은 `feature/reservation` 이 담당합니다.
+ */
+enum class ReservationStatusCode {
+    /** 작가 승인 대기 */
+    PENDING,
+
+    /** 작가가 승인함. 고객의 일자 확정 대기 */
+    ACCEPTED,
+
+    /** 고객이 일자를 확정함 */
+    CONFIRMED,
+
+    /** 작가가 거절함 */
+    REJECTED,
+
+    /** 고객 또는 작가가 취소함 */
+    CANCELED,
+
+    ;
+
+    companion object {
+        /** 서버 문자열 → enum. 모르는 값이면 null 을 반환합니다. */
+        fun from(raw: String?): ReservationStatusCode? = entries.firstOrNull { it.name == raw }
+    }
+}
+
+/**
+ * 예약 상세.
+ *
+ * 서버 응답에 고객 정보(닉네임/프로필)와 확정 시각이 없어 화면에서 필요한 일부 값은
+ * 아직 채울 수 없습니다.
+ */
+data class ReservationDetail(
+    val reservationId: Long,
+    val packageName: String,
+    val productPrice: Int,
+    val editPrice: Int,
+    /** 촬영 예정 일시(ms). 서버 값이 없거나 파싱에 실패하면 null */
+    val shootingDateTimeMillis: Long?,
+    val place: String,
+    val photoAmount: Int,
+    val isEdited: Boolean,
+    val reservationNumber: String,
+    /** 서버가 모르는 상태 문자열을 내려주면 null */
+    val status: ReservationStatusCode?,
+)

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -68,11 +68,14 @@ import com.hm.picplz.ui.theme.MainThemeColor
 /**
  * Dev 화면에서 예약 관련 화면으로 바로 진입할 때 쓰는 예약 id.
  *
- * dev 서버에 상태별 고정 예약을 만들어 뒀습니다 — **16=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
+ * dev 서버에 상태별 고정 예약을 만들어 뒀습니다 — **22=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
  * 기본값은 승인/거절 버튼을 확인할 수 있는 PENDING 이고, 다른 상태를 보려면 값만 바꾸면 됩니다.
- * (예약 상세 조회는 작가 전용 API라 작가 토큰으로 로그인해야 데이터가 뜹니다.)
+ * 승인·거절·취소는 상태를 실제로 바꾸므로, 다 쓴 예약은 새로 만들어 값을 갱신해야 합니다.
+ *
+ * 예약 상세 조회는 작가 전용 API라 `local.properties` 의 `dev_user_token` 을
+ * 작가 토큰(socialCode `test_social_001`)으로 두고 "개발 유저 로그인" 을 눌러야 데이터가 뜹니다.
  */
-private const val DEV_RESERVATION_ID = 16L
+private const val DEV_RESERVATION_ID = 22L
 
 @Composable
 fun DevScreen(

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -54,6 +54,7 @@ import com.hm.picplz.navigation.model.MyPagePhotographerModifyProfile
 import com.hm.picplz.navigation.model.MyPageShootingHistory
 import com.hm.picplz.navigation.model.OrderDetail
 import com.hm.picplz.navigation.model.PhotographerChatRoom
+import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.navigation.model.PhotographerEquipmentSetting
 import com.hm.picplz.navigation.model.PhotographerMain
 import com.hm.picplz.navigation.model.QuickShoot
@@ -63,6 +64,15 @@ import com.hm.picplz.navigation.model.SignUpCompletion
 import com.hm.picplz.navigation.model.SignUpIntro
 import com.hm.picplz.navigation.model.SignUpPhotographer
 import com.hm.picplz.ui.theme.MainThemeColor
+
+/**
+ * Dev 화면에서 예약 관련 화면으로 바로 진입할 때 쓰는 예약 id.
+ *
+ * dev 서버에 상태별 고정 예약을 만들어 뒀습니다 — **16=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
+ * 기본값은 승인/거절 버튼을 확인할 수 있는 PENDING 이고, 다른 상태를 보려면 값만 바꾸면 됩니다.
+ * (예약 상세 조회는 작가 전용 API라 작가 토큰으로 로그인해야 데이터가 뜹니다.)
+ */
+private const val DEV_RESERVATION_ID = 16L
 
 @Composable
 fun DevScreen(
@@ -300,8 +310,15 @@ fun DevScreen(
 
             // === Reservation ===
             SectionTitle("Reservation")
-            DevButton("DetailReservation(예약 상세)") { navController.navigate(DetailReservation) }
-            DevButton("OrderDetail(결제 후 취소 주문 상세)") { navController.navigate(OrderDetail("order123")) }
+            DevButton(
+                "DetailReservation(예약 상세)",
+            ) { navController.navigate(DetailReservation(reservationId = DEV_RESERVATION_ID)) }
+            DevButton(
+                "OrderDetail(결제 후 취소 주문 상세)",
+            ) { navController.navigate(OrderDetail(reservationId = DEV_RESERVATION_ID)) }
+            DevButton(
+                "PhotographerDetailReservation(작가 예약 상세)",
+            ) { navController.navigate(PhotographerDetailReservation(reservationId = DEV_RESERVATION_ID)) }
 
             Spacer(modifier = Modifier.height(32.dp))
         }

--- a/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
+++ b/feature/main/src/main/kotlin/com/hm/picplz/ui/screen/dev/DevScreen.kt
@@ -68,14 +68,14 @@ import com.hm.picplz.ui.theme.MainThemeColor
 /**
  * Dev 화면에서 예약 관련 화면으로 바로 진입할 때 쓰는 예약 id.
  *
- * dev 서버에 상태별 고정 예약을 만들어 뒀습니다 — **22=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
+ * dev 서버에 상태별 고정 예약을 만들어 뒀습니다 — **24=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
  * 기본값은 승인/거절 버튼을 확인할 수 있는 PENDING 이고, 다른 상태를 보려면 값만 바꾸면 됩니다.
  * 승인·거절·취소는 상태를 실제로 바꾸므로, 다 쓴 예약은 새로 만들어 값을 갱신해야 합니다.
  *
  * 예약 상세 조회는 작가 전용 API라 `local.properties` 의 `dev_user_token` 을
  * 작가 토큰(socialCode `test_social_001`)으로 두고 "개발 유저 로그인" 을 눌러야 데이터가 뜹니다.
  */
-private const val DEV_RESERVATION_ID = 22L
+private const val DEV_RESERVATION_ID = 24L
 
 @Composable
 fun DevScreen(

--- a/feature/reservation/build.gradle.kts
+++ b/feature/reservation/build.gradle.kts
@@ -61,4 +61,6 @@ dependencies {
     implementation(libs.kakao.maps)
 
     debugImplementation(libs.androidx.ui.tooling)
+
+    testImplementation(libs.junit)
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationIntent.kt
@@ -8,4 +8,6 @@ sealed interface CancelReservationIntent {
     data object OnBackClick : CancelReservationIntent
 
     data object OnSubmitClick : CancelReservationIntent
+
+    data object OnToastDismiss : CancelReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -18,6 +18,7 @@ import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReasonInputContent
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CancelReservationTopBar
 import com.hm.picplz.ui.screen.common.CommonBottomButton
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 
@@ -46,6 +47,7 @@ fun CancelReservationScreen(
         onReasonToggle = { reason -> viewModel.handleIntent(CancelReservationIntent.ToggleReason(reason)) },
         onDirectInputChange = { text -> viewModel.handleIntent(CancelReservationIntent.UpdateDirectInput(text)) },
         onSubmitClick = { viewModel.handleIntent(CancelReservationIntent.OnSubmitClick) },
+        onToastDismiss = { viewModel.handleIntent(CancelReservationIntent.OnToastDismiss) },
     )
 }
 
@@ -56,6 +58,7 @@ private fun CancelReservationScreenContent(
     onReasonToggle: (CancelReason) -> Unit,
     onDirectInputChange: (String) -> Unit,
     onSubmitClick: () -> Unit,
+    onToastDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -89,6 +92,15 @@ private fun CancelReservationScreenContent(
                 enabled = state.isSubmitButtonEnabled(),
             )
         }
+
+        // CommonToast는 항상 컴포즈해 두고 isVisible만 토글합니다(퇴장 애니메이션 유지).
+        // 내부에서 fillMaxSize + BottomCenter 정렬을 하므로 별도 Box 없이 형제로 둡니다.
+        CommonToast(
+            modifier = Modifier.padding(innerPadding),
+            message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
+            isVisible = state.showToast,
+            onDismiss = onToastDismiss,
+        )
     }
 }
 
@@ -98,11 +110,12 @@ private fun CancelReservationScreenContent(
 private fun CancelReservationScreenPreview() {
     PicplzTheme {
         CancelReservationScreenContent(
-            state = CancelReservationState(orderId = "order123"),
+            state = CancelReservationState(reservationId = 15L),
             onBackClick = {},
             onReasonToggle = {},
             onDirectInputChange = {},
             onSubmitClick = {},
+            onToastDismiss = {},
         )
     }
 }
@@ -115,7 +128,7 @@ private fun CancelReservationScreenDirectInputPreview() {
         CancelReservationScreenContent(
             state =
                 CancelReservationState(
-                    orderId = "order123",
+                    reservationId = 15L,
                     selectedReasons = setOf(CancelReason.SCHEDULE, CancelReason.DIRECT_INPUT),
                     directInputText = "개인적인 사유로 취소하게 되었습니다.",
                 ),
@@ -123,6 +136,7 @@ private fun CancelReservationScreenDirectInputPreview() {
             onReasonToggle = {},
             onDirectInputChange = {},
             onSubmitClick = {},
+            onToastDismiss = {},
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationScreen.kt
@@ -22,6 +22,9 @@ import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.PicplzTheme
 
+/** 하단 버튼(높이 + 바깥 여백)을 피해 토스트를 띄우기 위한 오프셋 */
+private val toastBottomOffset = 120.dp
+
 @Composable
 fun CancelReservationScreen(
     onNavigateBack: () -> Unit,
@@ -100,6 +103,8 @@ private fun CancelReservationScreenContent(
             message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
             isVisible = state.showToast,
             onDismiss = onToastDismiss,
+            // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+            bottomOffset = toastBottomOffset,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationState.kt
@@ -1,19 +1,25 @@
 package com.hm.picplz.ui.screen.cancel_reservation
 
 data class CancelReservationState(
-    val orderId: String = "",
+    val reservationId: Long = 0L,
     val selectedReasons: Set<CancelReason> = emptySet(),
     val directInputText: String = "",
     val isLoading: Boolean = false,
-    val errorMessage: String? = null,
+    /**
+     * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 남아 있어야 하므로
+     * [showToast]가 false가 되어도 지우지 않습니다.
+     */
+    val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
 ) {
     fun isSubmitButtonEnabled(): Boolean =
-        selectedReasons.isNotEmpty() && (
-            selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 사유가 있거나
-                directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
-        )
+        !isLoading &&
+            selectedReasons.isNotEmpty() && (
+                selectedReasons.any { it != CancelReason.DIRECT_INPUT } || // 직접 입력 이외의 사유가 있거나
+                    directInputText.isNotBlank() // 직접 입력 텍스트가 있으면 OK
+            )
 
     companion object {
-        fun idle(orderId: String): CancelReservationState = CancelReservationState(orderId = orderId)
+        fun idle(reservationId: Long): CancelReservationState = CancelReservationState(reservationId = reservationId)
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/cancel_reservation/CancelReservationViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hm.picplz.data.service.ReservationService
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.navigation.model.CancelReservation
+import com.hm.picplz.ui.screen.model.toServerReasons
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,10 +26,11 @@ class CancelReservationViewModel
     @Inject
     constructor(
         savedStateHandle: SavedStateHandle,
+        private val reservationService: ReservationService,
     ) : ViewModel() {
-        private val orderId: String = savedStateHandle.toRoute<CancelReservation>().orderId
+        private val reservationId: Long = savedStateHandle.toRoute<CancelReservation>().reservationId
 
-        private val _state = MutableStateFlow(CancelReservationState.idle(orderId))
+        private val _state = MutableStateFlow(CancelReservationState.idle(reservationId))
         val state: StateFlow<CancelReservationState> = _state.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<CancelReservationSideEffect>()
@@ -52,10 +56,37 @@ class CancelReservationViewModel
                     emitSideEffect(CancelReservationSideEffect.NavigateBack)
                 }
 
-                CancelReservationIntent.OnSubmitClick -> {
-                    // TODO: 취소 사유 전송 API 연동
-                    emitSideEffect(CancelReservationSideEffect.NavigateToCancelReservationConfirm)
+                CancelReservationIntent.OnSubmitClick -> submitCancel()
+
+                CancelReservationIntent.OnToastDismiss -> {
+                    _state.update { it.copy(showToast = false) }
                 }
+            }
+        }
+
+        private fun submitCancel() {
+            val current = _state.value
+            if (current.isLoading) return
+
+            viewModelScope.launch {
+                _state.update { it.copy(isLoading = true) }
+                reservationService
+                    .cancelReservation(
+                        reservationId = current.reservationId,
+                        reasons = current.selectedReasons.toServerReasons(),
+                        reasonDetail = current.directInputText,
+                    ).onSuccess {
+                        _state.update { it.copy(isLoading = false) }
+                        emitSideEffect(CancelReservationSideEffect.NavigateToCancelReservationConfirm)
+                    }.onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                toastMessageResId = R.string.reservation_error_cancel_failed,
+                                showToast = true,
+                            )
+                        }
+                    }
             }
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationScreen.kt
@@ -33,9 +33,9 @@ import com.hm.picplz.ui.theme.MainThemeColor
 @Composable
 fun DetailReservationScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToCancelReservation: (orderId: String) -> Unit,
-    onNavigateToOrderDetail: (orderId: String) -> Unit,
-    onNavigateToWriteReview: (orderId: String) -> Unit,
+    onNavigateToCancelReservation: (reservationId: Long) -> Unit,
+    onNavigateToOrderDetail: (reservationId: Long) -> Unit,
+    onNavigateToWriteReview: (reservationId: Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailReservationViewModel = hiltViewModel(),
 ) {
@@ -47,12 +47,12 @@ fun DetailReservationScreen(
                 is DetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
 
                 is DetailReservationSideEffect.NavigateToCancelReservation -> {
-                    onNavigateToCancelReservation(state.orderId)
+                    onNavigateToCancelReservation(state.reservationId)
                 }
 
-                is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail(state.orderId)
+                is DetailReservationSideEffect.NavigateToOrderDetail -> onNavigateToOrderDetail(state.reservationId)
 
-                is DetailReservationSideEffect.NavigateToWriteReview -> onNavigateToWriteReview(state.orderId)
+                is DetailReservationSideEffect.NavigateToWriteReview -> onNavigateToWriteReview(state.reservationId)
             }
         }
     }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationState.kt
@@ -4,7 +4,7 @@ import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 
 data class DetailReservationState(
-    val orderId: String = "",
+    val reservationId: Long = 0L,
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
     val hasWrittenReview: Boolean = false,
     val showCancelDialog: Boolean = false,

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/DetailReservationViewModel.kt
@@ -1,8 +1,11 @@
 package com.hm.picplz.ui.screen.detail_reservation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.hm.picplz.common.util.DateTimeUtil
+import com.hm.picplz.navigation.model.DetailReservation
 import com.hm.picplz.ui.screen.detail_reservation.model.RefundCondition
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,138 +22,145 @@ import javax.inject.Inject
 private const val DEAL_COMPLETE_MODAL_DURATION_MS = 1500L
 
 @HiltViewModel
-class DetailReservationViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow(DetailReservationState())
-    val state: StateFlow<DetailReservationState> get() = _state
+class DetailReservationViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+    ) : ViewModel() {
+        private val reservationId: Long = savedStateHandle.toRoute<DetailReservation>().reservationId
 
-    private val _sideEffect = MutableSharedFlow<DetailReservationSideEffect>()
-    val sideEffect: SharedFlow<DetailReservationSideEffect> get() = _sideEffect
+        private val _state = MutableStateFlow(DetailReservationState(reservationId = reservationId))
+        val state: StateFlow<DetailReservationState> get() = _state
 
-    init {
-        // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
-        // 임시로 더미 데이터 설정 (촬영일: 4일 후)
-        val currentTimeMillis = System.currentTimeMillis()
-        val dummyShootingDateTimeMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
-        val dummyConfirmedDateTimeMillis = currentTimeMillis - (12 * 60 * 60 * 1000) // 12시간 전
+        private val _sideEffect = MutableSharedFlow<DetailReservationSideEffect>()
+        val sideEffect: SharedFlow<DetailReservationSideEffect> get() = _sideEffect
 
-        _state.update {
-            it.copy(
-                shootingDateTimeMillis = dummyShootingDateTimeMillis,
-                confirmedDateTimeMillis = dummyConfirmedDateTimeMillis,
-            )
+        init {
+            // TODO: 고객용 예약 상세 조회 API가 없어 아직 더미입니다.
+            // `GET /reservations/{id}` 는 작가 전용이라 고객 토큰으로는 404가 떨어집니다.
+            // 임시로 더미 데이터 설정 (촬영일: 4일 후)
+            val currentTimeMillis = System.currentTimeMillis()
+            val dummyShootingDateTimeMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
+            val dummyConfirmedDateTimeMillis = currentTimeMillis - (12 * 60 * 60 * 1000) // 12시간 전
+
+            _state.update {
+                it.copy(
+                    shootingDateTimeMillis = dummyShootingDateTimeMillis,
+                    confirmedDateTimeMillis = dummyConfirmedDateTimeMillis,
+                )
+            }
         }
-    }
 
-    fun handelIntent(intent: DetailReservationIntent) {
-        when (intent) {
-            // 상태 변경 확인 테스트를 위한 코드입니다.
-            is DetailReservationIntent.NavigateToChat -> {
-                _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
-            }
-
-            is DetailReservationIntent.ConfirmReservation -> confirmReservation()
-
-            is DetailReservationIntent.NavigateToWriteReview -> {
-                viewModelScope.launch {
-                    _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
+        fun handelIntent(intent: DetailReservationIntent) {
+            when (intent) {
+                // 상태 변경 확인 테스트를 위한 코드입니다.
+                is DetailReservationIntent.NavigateToChat -> {
+                    _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
                 }
-            }
 
-            is DetailReservationIntent.ShowCancelDialog -> {
-                val currentState = _state.value
-                val refundCondition =
-                    RefundCondition.calculate(
-                        currentMillis = System.currentTimeMillis(),
-                        shootingMillis = currentState.shootingDateTimeMillis,
-                        confirmedMillis = currentState.confirmedDateTimeMillis,
-                    )
+                is DetailReservationIntent.ConfirmReservation -> confirmReservation()
 
-                _state.update {
-                    it.copy(
-                        showCancelDialog = true,
-                        refundCondition = refundCondition,
-                    )
+                is DetailReservationIntent.NavigateToWriteReview -> {
+                    viewModelScope.launch {
+                        _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
+                    }
                 }
-            }
 
-            is DetailReservationIntent.DismissCancelDialog -> {
-                _state.update { it.copy(showCancelDialog = false) }
-            }
+                is DetailReservationIntent.ShowCancelDialog -> {
+                    val currentState = _state.value
+                    val refundCondition =
+                        RefundCondition.calculate(
+                            currentMillis = System.currentTimeMillis(),
+                            shootingMillis = currentState.shootingDateTimeMillis,
+                            confirmedMillis = currentState.confirmedDateTimeMillis,
+                        )
 
-            is DetailReservationIntent.ConfirmCancel -> {
-                _state.update { it.copy(showCancelDialog = false) }
+                    _state.update {
+                        it.copy(
+                            showCancelDialog = true,
+                            refundCondition = refundCondition,
+                        )
+                    }
+                }
 
-                viewModelScope.launch {
-                    when (state.value.reservationStatus) {
-                        ReservationStatus.WAITING_APPROVAL,
-                        ReservationStatus.WAITING_SCHEDULE,
-                        -> {
-                            _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservation)
-                        }
+                is DetailReservationIntent.DismissCancelDialog -> {
+                    _state.update { it.copy(showCancelDialog = false) }
+                }
 
-                        ReservationStatus.RESERVED,
-                        ReservationStatus.COMPLETED,
-                        -> {
-                            _sideEffect.emit(DetailReservationSideEffect.NavigateToOrderDetail)
+                is DetailReservationIntent.ConfirmCancel -> {
+                    _state.update { it.copy(showCancelDialog = false) }
+
+                    viewModelScope.launch {
+                        when (state.value.reservationStatus) {
+                            ReservationStatus.WAITING_APPROVAL,
+                            ReservationStatus.WAITING_SCHEDULE,
+                            -> {
+                                _sideEffect.emit(DetailReservationSideEffect.NavigateToCancelReservation)
+                            }
+
+                            ReservationStatus.RESERVED,
+                            ReservationStatus.COMPLETED,
+                            -> {
+                                _sideEffect.emit(DetailReservationSideEffect.NavigateToOrderDetail)
+                            }
                         }
                     }
                 }
-            }
 
-            is DetailReservationIntent.ShowRefundPolicyDialog -> {
-                _state.update {
-                    it.copy(
-                        showRefundPolicyTooltip = true,
-                        showCancelDialog = false,
-                    )
+                is DetailReservationIntent.ShowRefundPolicyDialog -> {
+                    _state.update {
+                        it.copy(
+                            showRefundPolicyTooltip = true,
+                            showCancelDialog = false,
+                        )
+                    }
                 }
-            }
 
-            is DetailReservationIntent.DismissRefundPolicyTooltip -> {
-                _state.update {
-                    it.copy(
-                        showRefundPolicyTooltip = false,
-                        showCancelDialog = true,
-                    )
+                is DetailReservationIntent.DismissRefundPolicyTooltip -> {
+                    _state.update {
+                        it.copy(
+                            showRefundPolicyTooltip = false,
+                            showCancelDialog = true,
+                        )
+                    }
                 }
-            }
 
-            is DetailReservationIntent.NavigateBack -> {
-                viewModelScope.launch {
-                    _sideEffect.emit(DetailReservationSideEffect.NavigateToPrev)
+                is DetailReservationIntent.NavigateBack -> {
+                    viewModelScope.launch {
+                        _sideEffect.emit(DetailReservationSideEffect.NavigateToPrev)
+                    }
                 }
             }
         }
+
+        /**
+         * "거래 완료하기" → 거래 완료 처리 → 완료 모달 → 리뷰 작성 화면.
+         *
+         * 리뷰를 쓰지 않고 나와도 거래는 이미 완료된 상태이므로,
+         * 예약 상세에 다시 들어오면 "리뷰 쓰기" 버튼이 노출됩니다.
+         */
+        private fun confirmReservation() {
+            // TODO: 거래 완료 API 연동 (성공 응답을 받은 뒤 아래 처리를 수행해야 합니다)
+            _state.update {
+                it.copy(
+                    reservationStatus = ReservationStatus.COMPLETED,
+                    showDealCompleteModal = true,
+                )
+            }
+
+            viewModelScope.launch {
+                delay(DEAL_COMPLETE_MODAL_DURATION_MS)
+                _state.update { it.copy(showDealCompleteModal = false) }
+                _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
+            }
+        }
+
+        // 상태 변경 확인 테스트를 위한 코드입니다.
+        private fun ReservationStatus.next(): ReservationStatus =
+            when (this) {
+                ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_SCHEDULE
+                ReservationStatus.WAITING_SCHEDULE -> ReservationStatus.RESERVED
+                ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
+                ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
+            }
     }
-
-    /**
-     * "거래 완료하기" → 거래 완료 처리 → 완료 모달 → 리뷰 작성 화면.
-     *
-     * 리뷰를 쓰지 않고 나와도 거래는 이미 완료된 상태이므로,
-     * 예약 상세에 다시 들어오면 "리뷰 쓰기" 버튼이 노출됩니다.
-     */
-    private fun confirmReservation() {
-        // TODO: 거래 완료 API 연동 (성공 응답을 받은 뒤 아래 처리를 수행해야 합니다)
-        _state.update {
-            it.copy(
-                reservationStatus = ReservationStatus.COMPLETED,
-                showDealCompleteModal = true,
-            )
-        }
-
-        viewModelScope.launch {
-            delay(DEAL_COMPLETE_MODAL_DURATION_MS)
-            _state.update { it.copy(showDealCompleteModal = false) }
-            _sideEffect.emit(DetailReservationSideEffect.NavigateToWriteReview)
-        }
-    }
-
-    // 상태 변경 확인 테스트를 위한 코드입니다.
-    private fun ReservationStatus.next(): ReservationStatus =
-        when (this) {
-            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_SCHEDULE
-            ReservationStatus.WAITING_SCHEDULE -> ReservationStatus.RESERVED
-            ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
-            ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
-        }
-}

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/detail_reservation/composable/ReservationInfoSection.kt
@@ -15,10 +15,18 @@ import com.hm.picplz.ui.theme.MainFontFamily.bodyLarge
 import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont.Body
 
+/**
+ * 고객·작가 예약 상세가 공유하는 정보 섹션.
+ *
+ * [packageName]/[place] 는 작가 화면만 실데이터를 넘깁니다.
+ * 고객 화면은 예약 상세 조회 API가 작가 전용이라 아직 값을 구할 수 없어 기본값(더미)을 씁니다.
+ */
 @Composable
 fun ReservationInfoSection(
     modifier: Modifier = Modifier,
     customerName: String = "",
+    packageName: String = DUMMY_PACKAGE_NAME,
+    place: String = DUMMY_PLACE,
     shootingDateText: String = "작가와 협의",
 ) {
     Column(
@@ -33,11 +41,11 @@ fun ReservationInfoSection(
         }
         ReservationInfoItem(
             title = "촬영 상품명",
-            description = "프로필 패키지",
+            description = packageName.ifBlank { DUMMY_PACKAGE_NAME },
         )
         ReservationInfoItem(
             title = "촬영 장소",
-            description = "서울특별시 종로구 효자로 3, 네번째 테이블 창문 앞",
+            description = place.ifBlank { DUMMY_PLACE },
         )
         ReservationInfoItem(
             title = "촬영 일시",
@@ -45,6 +53,9 @@ fun ReservationInfoSection(
         )
     }
 }
+
+private const val DUMMY_PACKAGE_NAME = "프로필 패키지"
+private const val DUMMY_PLACE = "서울특별시 종로구 효자로 3, 네번째 테이블 창문 앞"
 
 @Composable
 private fun ReservationInfoItem(

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/model/ReservationReasonMapper.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/model/ReservationReasonMapper.kt
@@ -1,0 +1,57 @@
+package com.hm.picplz.ui.screen.model
+
+import com.hm.picplz.ui.screen.cancel_reservation.CancelReason
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReason
+import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejectReason
+
+/**
+ * 화면의 사유 선택지를 서버 enum 이름으로 변환합니다.
+ *
+ * 서버 사유 목록은 고객 취소 6종 + 작가 취소 6종(`SCHEDULE_CONFLICT` 공유)으로 총 11종이고,
+ * 앱 선택지와 1:1로 대응합니다. `DIRECT_INPUT` 만 대응하는 서버 enum 이 없어
+ * `*ReasonDetail` 문자열로만 전달되므로 null 을 반환합니다.
+ *
+ * 사유 enum 이 UI 계층에 있어 data 모듈에서 참조할 수 없기 때문에 매핑은 여기에 둡니다.
+ * 선택지를 추가하면 아래 `when` 이 exhaustive 하지 않아 컴파일 에러가 납니다.
+ */
+fun CancelReason.toServerReason(): String? =
+    when (this) {
+        CancelReason.SCHEDULE -> "SCHEDULE_CONFLICT"
+        CancelReason.PRODUCT -> "PRODUCT_CHANGE_REQUEST"
+        CancelReason.LOCATION -> "LOCATION_ISSUE"
+        CancelReason.MIND -> "CHANGE_OF_MIND"
+        CancelReason.PHOTOGRAPHER_RESPONSE -> "PHOTOGRAPHER_NO_RESPONSE"
+        CancelReason.PHOTOGRAPHER_EXTRA_PAYMENT -> "ADDITIONAL_PAYMENT_REQUEST"
+        CancelReason.DIRECT_INPUT -> null
+    }
+
+fun PhotographerCancelReason.toServerReason(): String? =
+    when (this) {
+        PhotographerCancelReason.SCHEDULE -> "SCHEDULE_CONFLICT"
+        PhotographerCancelReason.HEALTH -> "HEALTH_ISSUE"
+        PhotographerCancelReason.CUSTOMER_RESPONSE -> "CUSTOMER_NO_RESPONSE"
+        PhotographerCancelReason.MISTAKE -> "ACCIDENTAL_ACCEPTANCE"
+        PhotographerCancelReason.EQUIPMENT -> "EQUIPMENT_FAILURE"
+        PhotographerCancelReason.EXTERNAL -> "EXTERNAL_CIRCUMSTANCE"
+        PhotographerCancelReason.DIRECT_INPUT -> null
+    }
+
+fun PhotographerRejectReason.toServerReason(): String? =
+    when (this) {
+        PhotographerRejectReason.AREA -> "REGION_UNAVAILABLE"
+        PhotographerRejectReason.TIME -> "TIME_UNAVAILABLE"
+        PhotographerRejectReason.EQUIPMENT -> "EQUIPMENT_ISSUE"
+        PhotographerRejectReason.DIRECT_INPUT -> null
+    }
+
+/**
+ * 선택된 사유들을 서버 enum 이름 목록으로 변환합니다.
+ *
+ * 선언 순서(= 화면 노출 순서)를 유지하고 `DIRECT_INPUT` 은 제외합니다.
+ */
+fun Set<CancelReason>.toServerReasons(): List<String> =
+    CancelReason.entries.filter { it in this }.mapNotNull { it.toServerReason() }
+
+@JvmName("photographerCancelReasonsToServerReasons")
+fun Set<PhotographerCancelReason>.toServerReasons(): List<String> =
+    PhotographerCancelReason.entries.filter { it in this }.mapNotNull { it.toServerReason() }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/model/ReservationStatusMapper.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/model/ReservationStatusMapper.kt
@@ -1,0 +1,20 @@
+package com.hm.picplz.ui.screen.model
+
+import com.hm.picplz.domain.model.ReservationStatusCode
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+
+/**
+ * 서버 예약 상태를 화면 상태로 변환합니다.
+ *
+ * 두 체계가 완전히 대응하지 않습니다.
+ * - 서버 `REJECTED`/`CANCELED` 에 해당하는 화면 상태가 없습니다. 거절·취소 후에는 화면을 벗어나는
+ *   플로우라 지금은 null 을 반환하고, 호출부가 기존 상태를 유지합니다.
+ * - 화면의 `COMPLETED`(거래 완료)에 대응하는 서버 상태가 없어 역방향 매핑은 만들지 않습니다.
+ */
+fun ReservationStatusCode.toUiStatusOrNull(): ReservationStatus? =
+    when (this) {
+        ReservationStatusCode.PENDING -> ReservationStatus.WAITING_APPROVAL
+        ReservationStatusCode.ACCEPTED -> ReservationStatus.WAITING_SCHEDULE
+        ReservationStatusCode.CONFIRMED -> ReservationStatus.RESERVED
+        ReservationStatusCode.REJECTED, ReservationStatusCode.CANCELED -> null
+    }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/order_detail/OrderDetailViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 class OrderDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    private val orderId: String = savedStateHandle.toRoute<OrderDetail>().orderId
+    private val reservationId: Long = savedStateHandle.toRoute<OrderDetail>().reservationId
 
     private val _state = MutableStateFlow(OrderDetailState.idle())
     val state: StateFlow<OrderDetailState> = _state
@@ -26,7 +26,7 @@ class OrderDetailViewModel @Inject constructor(
     val sideEffect: SharedFlow<OrderDetailSideEffect> = _sideEffect
 
     init {
-        loadOrderDetail(orderId)
+        loadOrderDetail(reservationId)
     }
 
     fun handleIntent(intent: OrderDetailIntent) {
@@ -44,13 +44,13 @@ class OrderDetailViewModel @Inject constructor(
         }
     }
 
-    fun loadOrderDetail(bookingId: String) {
+    fun loadOrderDetail(bookingId: Long) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true)
             try {
                 _state.value =
                     OrderDetailState(
-                        orderNumber = bookingId,
+                        orderNumber = bookingId.toString(),
                         orderTime = "2025-03-09 19:09:14",
                         customerName = "가나다",
                         phoneNumber = "01023293185",

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationIntent.kt
@@ -23,4 +23,7 @@ sealed interface PhotographerCancelReservationIntent {
 
     /** 상단 뒤로가기 (2단계면 1단계로, 1단계면 화면 종료) */
     data object OnBackClick : PhotographerCancelReservationIntent
+
+    /** 실패 토스트 표시 시간이 끝남 */
+    data object OnToastDismiss : PhotographerCancelReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
@@ -22,6 +22,7 @@ import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.cancel_reservation.composable.CheckboxWithLabel
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReservationState.Step
 import com.hm.picplz.ui.screen.photographer_cancel_reservation.composable.PhotographerCancelPolicyContent
@@ -73,6 +74,7 @@ fun PhotographerCancelReservationScreen(
         onSubmitClick = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnSubmitClick) },
         onDialogConfirm = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnConfirmDialogConfirm) },
         onDialogDismiss = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnConfirmDialogDismiss) },
+        onToastDismiss = { viewModel.handleIntent(PhotographerCancelReservationIntent.OnToastDismiss) },
     )
 }
 
@@ -89,6 +91,7 @@ private fun PhotographerCancelReservationScreenContent(
     onSubmitClick: () -> Unit,
     onDialogConfirm: () -> Unit,
     onDialogDismiss: () -> Unit,
+    onToastDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -171,6 +174,14 @@ private fun PhotographerCancelReservationScreenContent(
                 onDismiss = onDialogDismiss,
             )
         }
+
+        // CommonToast는 항상 컴포즈해 두고 isVisible만 토글합니다(퇴장 애니메이션 유지).
+        CommonToast(
+            modifier = Modifier.padding(innerPadding),
+            message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
+            isVisible = state.showToast,
+            onDismiss = onToastDismiss,
+        )
     }
 }
 
@@ -218,7 +229,7 @@ private fun PhotographerCancelReservationReasonPreview() {
         PhotographerCancelReservationScreenContent(
             state =
                 PhotographerCancelReservationState(
-                    orderId = "order123",
+                    reservationId = 15L,
                     currentStep = Step.REASON,
                     selectedReasons = setOf(PhotographerCancelReason.SCHEDULE),
                 ),
@@ -231,6 +242,7 @@ private fun PhotographerCancelReservationReasonPreview() {
             onSubmitClick = {},
             onDialogConfirm = {},
             onDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }
@@ -243,7 +255,7 @@ private fun PhotographerCancelReservationPolicyPreview() {
         PhotographerCancelReservationScreenContent(
             state =
                 PhotographerCancelReservationState(
-                    orderId = "order123",
+                    reservationId = 15L,
                     currentStep = Step.POLICY,
                     agreedToPolicy = true,
                 ),
@@ -256,6 +268,7 @@ private fun PhotographerCancelReservationPolicyPreview() {
             onSubmitClick = {},
             onDialogConfirm = {},
             onDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationScreen.kt
@@ -32,6 +32,9 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
 
+/** 하단 버튼(높이 + 바깥 여백)을 피해 토스트를 띄우기 위한 오프셋 */
+private val toastBottomOffset = 120.dp
+
 @Composable
 fun PhotographerCancelReservationScreen(
     onNavigateBack: () -> Unit,
@@ -181,6 +184,8 @@ private fun PhotographerCancelReservationScreenContent(
             message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
             isVisible = state.showToast,
             onDismiss = onToastDismiss,
+            // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+            bottomOffset = toastBottomOffset,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationState.kt
@@ -1,7 +1,7 @@
 package com.hm.picplz.ui.screen.photographer_cancel_reservation
 
 data class PhotographerCancelReservationState(
-    val orderId: String = "",
+    val reservationId: Long = 0L,
     val currentStep: Step = Step.REASON,
     val selectedReasons: Set<PhotographerCancelReason> = emptySet(),
     val directInputText: String = "",
@@ -11,6 +11,12 @@ data class PhotographerCancelReservationState(
     val agreedToPolicy: Boolean = false,
     val showConfirmDialog: Boolean = false,
     val isLoading: Boolean = false,
+    /**
+     * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 남아 있어야 하므로
+     * [showToast]가 false가 되어도 지우지 않습니다.
+     */
+    val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
 ) {
     /** 사유 입력(1/2) 단계의 "다음" 활성화 조건 */
     fun isReasonStepValid(): Boolean =
@@ -25,7 +31,7 @@ data class PhotographerCancelReservationState(
     enum class Step { REASON, POLICY }
 
     companion object {
-        fun idle(orderId: String): PhotographerCancelReservationState =
-            PhotographerCancelReservationState(orderId = orderId)
+        fun idle(reservationId: Long): PhotographerCancelReservationState =
+            PhotographerCancelReservationState(reservationId = reservationId)
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_cancel_reservation/PhotographerCancelReservationViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hm.picplz.data.service.ReservationService
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.navigation.model.PhotographerCancelReservation
+import com.hm.picplz.ui.screen.model.toServerReasons
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,10 +26,12 @@ class PhotographerCancelReservationViewModel
     @Inject
     constructor(
         savedStateHandle: SavedStateHandle,
+        private val reservationService: ReservationService,
     ) : ViewModel() {
-        private val orderId: String = savedStateHandle.toRoute<PhotographerCancelReservation>().orderId
+        private val reservationId: Long =
+            savedStateHandle.toRoute<PhotographerCancelReservation>().reservationId
 
-        private val _state = MutableStateFlow(PhotographerCancelReservationState.idle(orderId))
+        private val _state = MutableStateFlow(PhotographerCancelReservationState.idle(reservationId))
         val state: StateFlow<PhotographerCancelReservationState> = _state.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<PhotographerCancelReservationSideEffect>()
@@ -70,8 +75,11 @@ class PhotographerCancelReservationViewModel
 
                 PhotographerCancelReservationIntent.OnConfirmDialogConfirm -> {
                     _state.update { it.copy(showConfirmDialog = false) }
-                    // TODO: 취소 사유·사전 합의 여부 전송 API 연동
-                    emitSideEffect(PhotographerCancelReservationSideEffect.NavigateToCancelConfirm)
+                    submitCancel()
+                }
+
+                PhotographerCancelReservationIntent.OnToastDismiss -> {
+                    _state.update { it.copy(showToast = false) }
                 }
 
                 PhotographerCancelReservationIntent.OnBackClick -> {
@@ -82,6 +90,36 @@ class PhotographerCancelReservationViewModel
                         emitSideEffect(PhotographerCancelReservationSideEffect.NavigateBack)
                     }
                 }
+            }
+        }
+
+        /**
+         * 화면의 "고객과 사전 합의" 체크(`agreedWithCustomer`)는 서버 요청에 담을 필드가 없어
+         * 아직 전송하지 못합니다. 백엔드에 필드 추가를 요청해 둔 상태입니다.
+         */
+        private fun submitCancel() {
+            val current = _state.value
+            if (current.isLoading) return
+
+            viewModelScope.launch {
+                _state.update { it.copy(isLoading = true) }
+                reservationService
+                    .cancelReservation(
+                        reservationId = current.reservationId,
+                        reasons = current.selectedReasons.toServerReasons(),
+                        reasonDetail = current.directInputText,
+                    ).onSuccess {
+                        _state.update { it.copy(isLoading = false) }
+                        emitSideEffect(PhotographerCancelReservationSideEffect.NavigateToCancelConfirm)
+                    }.onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                toastMessageResId = R.string.reservation_error_cancel_failed,
+                                showToast = true,
+                            )
+                        }
+                    }
             }
         }
 

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationIntent.kt
@@ -14,4 +14,7 @@ sealed interface PhotographerDetailReservationIntent {
     data object NavigateToCancelReservation : PhotographerDetailReservationIntent
 
     data object NavigateBack : PhotographerDetailReservationIntent
+
+    /** 실패 토스트 표시 시간이 끝남 */
+    data object OnToastDismiss : PhotographerDetailReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -18,6 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.common.util.DateTimeUtil
 import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.detail_reservation.composable.DetailReservationMap
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerDetailReservationBottomButtons
 import com.hm.picplz.ui.screen.detail_reservation.composable.PhotographerReservationStatusHeader
@@ -30,8 +31,8 @@ import com.hm.picplz.ui.theme.MainThemeColor
 @Composable
 fun PhotographerDetailReservationScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToRejectReason: (orderId: String) -> Unit,
-    onNavigateToCancelReservation: (orderId: String) -> Unit,
+    onNavigateToRejectReason: (reservationId: Long) -> Unit,
+    onNavigateToCancelReservation: (reservationId: Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PhotographerDetailReservationViewModel = hiltViewModel(),
 ) {
@@ -43,10 +44,10 @@ fun PhotographerDetailReservationScreen(
                 is PhotographerDetailReservationSideEffect.NavigateToPrev -> onNavigateBack()
 
                 is PhotographerDetailReservationSideEffect.NavigateToRejectReason ->
-                    onNavigateToRejectReason(sideEffect.orderId)
+                    onNavigateToRejectReason(sideEffect.reservationId)
 
                 is PhotographerDetailReservationSideEffect.NavigateToCancelReservation ->
-                    onNavigateToCancelReservation(sideEffect.orderId)
+                    onNavigateToCancelReservation(sideEffect.reservationId)
             }
         }
     }
@@ -72,6 +73,9 @@ fun PhotographerDetailReservationScreen(
         onCloseClick = {
             viewModel.handelIntent(PhotographerDetailReservationIntent.NavigateBack)
         },
+        onToastDismiss = {
+            viewModel.handelIntent(PhotographerDetailReservationIntent.OnToastDismiss)
+        },
     )
 }
 
@@ -85,6 +89,7 @@ private fun PhotographerDetailReservationScreen(
     onCancelReject: () -> Unit,
     onReservationApproveClick: () -> Unit,
     onCloseClick: () -> Unit,
+    onToastDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -125,9 +130,11 @@ private fun PhotographerDetailReservationScreen(
 
                 item {
                     ReservationInfoSection(
+                        packageName = state.packageName,
+                        place = state.place,
                         modifier = Modifier.padding(top = 28.dp, bottom = 24.dp),
                         customerName = state.customerName,
-                        shootingDateText = state.reservationStatus.shootingDateText(state.confirmedDateTimeMillis),
+                        shootingDateText = state.reservationStatus.shootingDateText(state.shootingDateTimeMillis),
                     )
                 }
             }
@@ -146,6 +153,14 @@ private fun PhotographerDetailReservationScreen(
                 )
             }
         }
+
+        // CommonToast는 항상 컴포즈해 두고 isVisible만 토글합니다(퇴장 애니메이션 유지).
+        CommonToast(
+            modifier = Modifier.padding(innerPadding),
+            message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
+            isVisible = state.showToast,
+            onDismiss = onToastDismiss,
+        )
     }
 }
 
@@ -154,11 +169,11 @@ private fun PhotographerDetailReservationScreen(
  * 일시 미확정(예약 대기) 단계는 "작가와 협의", 확정 이후(촬영 진행/거래 완료)는 확정된 일시를 표시합니다.
  */
 @Composable
-private fun ReservationStatus.shootingDateText(confirmedDateTimeMillis: Long): String =
+private fun ReservationStatus.shootingDateText(shootingDateTimeMillis: Long): String =
     when (this) {
         ReservationStatus.RESERVED,
         ReservationStatus.COMPLETED,
-        -> DateTimeUtil.getFormattedReservationDateTime(confirmedDateTimeMillis)
+        -> DateTimeUtil.getFormattedReservationDateTime(shootingDateTimeMillis)
 
         ReservationStatus.WAITING_APPROVAL,
         ReservationStatus.WAITING_SCHEDULE,
@@ -177,5 +192,6 @@ private fun PhotographerDetailReservationScreenPreview() {
         onCancelReject = {},
         onReservationApproveClick = {},
         onCloseClick = {},
+        onToastDismiss = {},
     )
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationScreen.kt
@@ -28,6 +28,9 @@ import com.hm.picplz.ui.screen.detail_reservation.composable.ReservationProgress
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 import com.hm.picplz.ui.theme.MainThemeColor
 
+/** 하단 버튼(높이 + 바깥 여백)을 피해 토스트를 띄우기 위한 오프셋 */
+private val toastBottomOffset = 120.dp
+
 @Composable
 fun PhotographerDetailReservationScreen(
     onNavigateBack: () -> Unit,
@@ -160,6 +163,8 @@ private fun PhotographerDetailReservationScreen(
             message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
             isVisible = state.showToast,
             onDismiss = onToastDismiss,
+            // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+            bottomOffset = toastBottomOffset,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationSideEffect.kt
@@ -4,7 +4,7 @@ sealed interface PhotographerDetailReservationSideEffect {
     data object NavigateToPrev : PhotographerDetailReservationSideEffect
 
     /** "예약 거절" → 거절 사유 입력 화면으로 이동 */
-    data class NavigateToRejectReason(val orderId: String) : PhotographerDetailReservationSideEffect
+    data class NavigateToRejectReason(val reservationId: Long) : PhotographerDetailReservationSideEffect
 
-    data class NavigateToCancelReservation(val orderId: String) : PhotographerDetailReservationSideEffect
+    data class NavigateToCancelReservation(val reservationId: Long) : PhotographerDetailReservationSideEffect
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationState.kt
@@ -3,11 +3,23 @@ package com.hm.picplz.ui.screen.photographer_detail_reservation
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
 
 data class PhotographerDetailReservationState(
-    val orderId: String = "",
+    val reservationId: Long = 0L,
     val reservationStatus: ReservationStatus = ReservationStatus.WAITING_APPROVAL,
+    /** 서버 `reservationTime` 을 매핑한 촬영 예정 일시 */
     val shootingDateTimeMillis: Long = System.currentTimeMillis(),
-    val confirmedDateTimeMillis: Long = System.currentTimeMillis(),
+    /** 서버 `packageName`. 비어 있으면 정보 섹션이 기본값을 씁니다. */
+    val packageName: String = "",
+    /** 서버 `place`. 비어 있으면 정보 섹션이 기본값을 씁니다. */
+    val place: String = "",
+    /** 서버 예약 상세 응답에 고객 정보가 없어 더미를 유지합니다. */
     val customerName: String = DUMMY_CUSTOMER_NAME,
+    val isLoading: Boolean = false,
+    /**
+     * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 남아 있어야 하므로
+     * [showToast]가 false가 되어도 지우지 않습니다.
+     */
+    val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
 )
 
 const val DUMMY_CUSTOMER_NAME = "애니프사"

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -1,9 +1,15 @@
 package com.hm.picplz.ui.screen.photographer_detail_reservation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hm.picplz.common.util.DateTimeUtil
+import androidx.navigation.toRoute
+import com.hm.picplz.data.service.ReservationService
+import com.hm.picplz.domain.model.ReservationDetail
+import com.hm.picplz.feature.reservation.R
+import com.hm.picplz.navigation.model.PhotographerDetailReservation
 import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import com.hm.picplz.ui.screen.model.toUiStatusOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,72 +20,122 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class PhotographerDetailReservationViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow(PhotographerDetailReservationState())
-    val state: StateFlow<PhotographerDetailReservationState> get() = _state
+class PhotographerDetailReservationViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        private val reservationService: ReservationService,
+    ) : ViewModel() {
+        private val reservationId: Long =
+            savedStateHandle.toRoute<PhotographerDetailReservation>().reservationId
 
-    private val _sideEffect = MutableSharedFlow<PhotographerDetailReservationSideEffect>()
-    val sideEffect: SharedFlow<PhotographerDetailReservationSideEffect> get() = _sideEffect
+        private val _state = MutableStateFlow(PhotographerDetailReservationState(reservationId = reservationId))
+        val state: StateFlow<PhotographerDetailReservationState> get() = _state
 
-    init {
-        // TODO: API에서 촬영 일시 데이터를 받아와야 합니다.
-        // 임시로 더미 데이터 설정 (촬영일: 4일 후)
-        val currentTimeMillis = System.currentTimeMillis()
-        val dummyShootingDateTimeMillis = DateTimeUtil.plusDays(currentTimeMillis, 4)
-        val dummyConfirmedDateTimeMillis = currentTimeMillis - (12 * 60 * 60 * 1000) // 12시간 전
+        private val _sideEffect = MutableSharedFlow<PhotographerDetailReservationSideEffect>()
+        val sideEffect: SharedFlow<PhotographerDetailReservationSideEffect> get() = _sideEffect
 
-        _state.update {
-            it.copy(
-                shootingDateTimeMillis = dummyShootingDateTimeMillis,
-                confirmedDateTimeMillis = dummyConfirmedDateTimeMillis,
-            )
+        init {
+            loadReservation()
         }
-    }
 
-    fun handelIntent(intent: PhotographerDetailReservationIntent) {
-        when (intent) {
-            // 상태 변경 확인 테스트를 위한 코드입니다.
-            is PhotographerDetailReservationIntent.NavigateToChat,
-            is PhotographerDetailReservationIntent.ApproveReservation,
-            is PhotographerDetailReservationIntent.ConfirmReservation,
-            -> {
-                _state.update { it.copy(reservationStatus = it.reservationStatus.next()) }
-            }
+        fun handelIntent(intent: PhotographerDetailReservationIntent) {
+            when (intent) {
+                is PhotographerDetailReservationIntent.ApproveReservation -> approveReservation()
 
-            is PhotographerDetailReservationIntent.RejectReservation -> {
-                viewModelScope.launch {
-                    _sideEffect.emit(
+                // 거래 완료로 전환하는 서버 API가 없어(상태 enum에도 없음) 화면에서만 진행시킵니다.
+                // 백엔드에 전환 API 추가를 요청해 둔 상태입니다.
+                is PhotographerDetailReservationIntent.ConfirmReservation -> {
+                    _state.update { it.copy(reservationStatus = ReservationStatus.COMPLETED) }
+                }
+
+                // TODO: 채팅방 이동 연결 (현재 대응하는 SideEffect가 없습니다)
+                is PhotographerDetailReservationIntent.NavigateToChat -> Unit
+
+                is PhotographerDetailReservationIntent.RejectReservation -> {
+                    emitSideEffect(
                         PhotographerDetailReservationSideEffect.NavigateToRejectReason(
-                            orderId = _state.value.orderId,
+                            reservationId = _state.value.reservationId,
                         ),
                     )
                 }
-            }
 
-            is PhotographerDetailReservationIntent.NavigateToCancelReservation -> {
-                viewModelScope.launch {
-                    _sideEffect.emit(
+                is PhotographerDetailReservationIntent.NavigateToCancelReservation -> {
+                    emitSideEffect(
                         PhotographerDetailReservationSideEffect.NavigateToCancelReservation(
-                            orderId = _state.value.orderId,
+                            reservationId = _state.value.reservationId,
                         ),
                     )
                 }
-            }
 
-            is PhotographerDetailReservationIntent.NavigateBack -> {
-                viewModelScope.launch {
-                    _sideEffect.emit(PhotographerDetailReservationSideEffect.NavigateToPrev)
+                is PhotographerDetailReservationIntent.NavigateBack -> {
+                    emitSideEffect(PhotographerDetailReservationSideEffect.NavigateToPrev)
                 }
+
+                is PhotographerDetailReservationIntent.OnToastDismiss -> {
+                    _state.update { it.copy(showToast = false) }
+                }
+            }
+        }
+
+        private fun loadReservation() {
+            viewModelScope.launch {
+                _state.update { it.copy(isLoading = true) }
+                reservationService
+                    .getReservation(reservationId)
+                    .onSuccess { detail -> _state.update { it.applyDetail(detail) } }
+                    .onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                toastMessageResId = R.string.reservation_error_load_failed,
+                                showToast = true,
+                            )
+                        }
+                    }
+            }
+        }
+
+        private fun approveReservation() {
+            if (_state.value.isLoading) return
+
+            viewModelScope.launch {
+                _state.update { it.copy(isLoading = true) }
+                reservationService
+                    .acceptReservation(reservationId)
+                    .onSuccess { loadReservation() }
+                    .onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                toastMessageResId = R.string.reservation_error_accept_failed,
+                                showToast = true,
+                            )
+                        }
+                    }
+            }
+        }
+
+        private fun emitSideEffect(sideEffect: PhotographerDetailReservationSideEffect) {
+            viewModelScope.launch {
+                _sideEffect.emit(sideEffect)
             }
         }
     }
 
-    // 상태 변경 확인 테스트를 위한 코드입니다.
-    private fun ReservationStatus.next(): ReservationStatus =
-        when (this) {
-            ReservationStatus.WAITING_APPROVAL -> ReservationStatus.WAITING_SCHEDULE
-            ReservationStatus.WAITING_SCHEDULE -> ReservationStatus.RESERVED
-            ReservationStatus.RESERVED -> ReservationStatus.COMPLETED
-            ReservationStatus.COMPLETED -> ReservationStatus.COMPLETED
-        }
-}
+/**
+ * 서버에서 받은 값만 덮어씁니다.
+ *
+ * 응답에 없는 확정 시각·고객 이름은 기존 값을 유지하고, `REJECTED`/`CANCELED` 처럼
+ * 대응하는 화면 상태가 없는 경우에도 직전 상태를 그대로 둡니다.
+ */
+private fun PhotographerDetailReservationState.applyDetail(
+    detail: ReservationDetail,
+): PhotographerDetailReservationState =
+    copy(
+        isLoading = false,
+        reservationStatus = detail.status?.toUiStatusOrNull() ?: reservationStatus,
+        shootingDateTimeMillis = detail.shootingDateTimeMillis ?: shootingDateTimeMillis,
+        packageName = detail.packageName,
+        place = detail.place,
+    )

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_detail_reservation/PhotographerDetailReservationViewModel.kt
@@ -49,8 +49,11 @@ class PhotographerDetailReservationViewModel
                     _state.update { it.copy(reservationStatus = ReservationStatus.COMPLETED) }
                 }
 
-                // TODO: 채팅방 이동 연결 (현재 대응하는 SideEffect가 없습니다)
-                is PhotographerDetailReservationIntent.NavigateToChat -> Unit
+                // 이 화면은 채팅방에서 진입하므로 뒤로 가면 채팅방으로 돌아간다.
+                // 채팅방을 거치지 않은 경로(Dev 메뉴 등)에서는 그냥 이전 화면으로 간다.
+                is PhotographerDetailReservationIntent.NavigateToChat -> {
+                    emitSideEffect(PhotographerDetailReservationSideEffect.NavigateToPrev)
+                }
 
                 is PhotographerDetailReservationIntent.RejectReservation -> {
                     emitSideEffect(
@@ -78,7 +81,16 @@ class PhotographerDetailReservationViewModel
             }
         }
 
+        /**
+         * 유효한 id 가 없으면 조회하지 않습니다.
+         *
+         * 채팅방의 예약 카드가 아직 더미라 id 0 으로 진입하는 경로가 있는데,
+         * 그대로 호출하면 404 를 받아 "불러오지 못했어요" 토스트만 뜹니다.
+         * 서버에 물어볼 게 없는 상황이므로 기존처럼 기본값 화면을 보여줍니다.
+         */
         private fun loadReservation() {
+            if (reservationId <= 0L) return
+
             viewModelScope.launch {
                 _state.update { it.copy(isLoading = true) }
                 reservationService

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationIntent.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationIntent.kt
@@ -18,4 +18,7 @@ sealed interface PhotographerRejectReservationIntent {
 
     /** 상단 뒤로가기 */
     data object OnBackClick : PhotographerRejectReservationIntent
+
+    /** 실패 토스트 표시 시간이 끝남 */
+    data object OnToastDismiss : PhotographerRejectReservationIntent
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.ui.screen.common.CommonBottomButton
 import com.hm.picplz.ui.screen.common.CommonButtonModal
+import com.hm.picplz.ui.screen.common.CommonToast
 import com.hm.picplz.ui.screen.common.CommonTopBar
 import com.hm.picplz.ui.screen.photographer_reject_reservation.composable.PhotographerRejectReasonContent
 import com.hm.picplz.ui.theme.MainThemeColor
@@ -62,6 +63,7 @@ fun PhotographerRejectReservationScreen(
         onNextClick = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnNextClick) },
         onDialogConfirm = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnConfirmDialogConfirm) },
         onDialogDismiss = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnConfirmDialogDismiss) },
+        onToastDismiss = { viewModel.handleIntent(PhotographerRejectReservationIntent.OnToastDismiss) },
     )
 }
 
@@ -75,6 +77,7 @@ private fun PhotographerRejectReservationScreenContent(
     onNextClick: () -> Unit,
     onDialogConfirm: () -> Unit,
     onDialogDismiss: () -> Unit,
+    onToastDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -118,6 +121,14 @@ private fun PhotographerRejectReservationScreenContent(
                 onDismiss = onDialogDismiss,
             )
         }
+
+        // CommonToast는 항상 컴포즈해 두고 isVisible만 토글합니다(퇴장 애니메이션 유지).
+        CommonToast(
+            modifier = Modifier.padding(innerPadding),
+            message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
+            isVisible = state.showToast,
+            onDismiss = onToastDismiss,
+        )
     }
 }
 
@@ -158,7 +169,7 @@ private fun PhotographerRejectReservationReasonPreview() {
         PhotographerRejectReservationScreenContent(
             state =
                 PhotographerRejectReservationState(
-                    orderId = "order123",
+                    reservationId = 15L,
                     selectedReason = PhotographerRejectReason.AREA,
                 ),
             onBackClick = {},
@@ -167,6 +178,7 @@ private fun PhotographerRejectReservationReasonPreview() {
             onNextClick = {},
             onDialogConfirm = {},
             onDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }
@@ -179,7 +191,7 @@ private fun PhotographerRejectReservationDialogPreview() {
         PhotographerRejectReservationScreenContent(
             state =
                 PhotographerRejectReservationState(
-                    orderId = "order123",
+                    reservationId = 15L,
                     selectedReason = PhotographerRejectReason.DIRECT_INPUT,
                     directInputText = "다른 지역 일정과 겹쳤어요",
                     showConfirmDialog = true,
@@ -190,6 +202,7 @@ private fun PhotographerRejectReservationDialogPreview() {
             onNextClick = {},
             onDialogConfirm = {},
             onDialogDismiss = {},
+            onToastDismiss = {},
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationScreen.kt
@@ -28,6 +28,9 @@ import com.hm.picplz.ui.theme.MainThemeColor
 import com.hm.picplz.ui.theme.MainThemeFont
 import com.hm.picplz.ui.theme.PicplzTheme
 
+/** 하단 버튼(높이 + 바깥 여백)을 피해 토스트를 띄우기 위한 오프셋 */
+private val toastBottomOffset = 120.dp
+
 @Composable
 fun PhotographerRejectReservationScreen(
     onNavigateBack: () -> Unit,
@@ -128,6 +131,8 @@ private fun PhotographerRejectReservationScreenContent(
             message = state.toastMessageResId?.let { stringResource(it) }.orEmpty(),
             isVisible = state.showToast,
             onDismiss = onToastDismiss,
+            // 기본 오프셋(50dp)은 하단 버튼과 겹치므로 버튼 위로 띄웁니다.
+            bottomOffset = toastBottomOffset,
         )
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationState.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationState.kt
@@ -1,21 +1,29 @@
 package com.hm.picplz.ui.screen.photographer_reject_reservation
 
 data class PhotographerRejectReservationState(
-    val orderId: String = "",
+    val reservationId: Long = 0L,
     val selectedReason: PhotographerRejectReason? = null,
     val directInputText: String = "",
     val showConfirmDialog: Boolean = false,
+    val isLoading: Boolean = false,
+    /**
+     * 마지막으로 띄운 토스트 문구. 퇴장 애니메이션이 끝날 때까지 남아 있어야 하므로
+     * [showToast]가 false가 되어도 지우지 않습니다.
+     */
+    val toastMessageResId: Int? = null,
+    val showToast: Boolean = false,
 ) {
     /** 하단 "다음" 버튼 활성화 조건 */
     fun isNextEnabled(): Boolean =
-        when (selectedReason) {
-            null -> false
-            PhotographerRejectReason.DIRECT_INPUT -> directInputText.isNotBlank()
-            else -> true
-        }
+        !isLoading &&
+            when (selectedReason) {
+                null -> false
+                PhotographerRejectReason.DIRECT_INPUT -> directInputText.isNotBlank()
+                else -> true
+            }
 
     companion object {
-        fun idle(orderId: String): PhotographerRejectReservationState =
-            PhotographerRejectReservationState(orderId = orderId)
+        fun idle(reservationId: Long): PhotographerRejectReservationState =
+            PhotographerRejectReservationState(reservationId = reservationId)
     }
 }

--- a/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationViewModel.kt
+++ b/feature/reservation/src/main/kotlin/com/hm/picplz/ui/screen/photographer_reject_reservation/PhotographerRejectReservationViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hm.picplz.data.service.ReservationService
+import com.hm.picplz.feature.reservation.R
 import com.hm.picplz.navigation.model.PhotographerRejectReservation
+import com.hm.picplz.ui.screen.model.toServerReason
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,10 +24,12 @@ class PhotographerRejectReservationViewModel
     @Inject
     constructor(
         savedStateHandle: SavedStateHandle,
+        private val reservationService: ReservationService,
     ) : ViewModel() {
-        private val orderId: String = savedStateHandle.toRoute<PhotographerRejectReservation>().orderId
+        private val reservationId: Long =
+            savedStateHandle.toRoute<PhotographerRejectReservation>().reservationId
 
-        private val _state = MutableStateFlow(PhotographerRejectReservationState.idle(orderId))
+        private val _state = MutableStateFlow(PhotographerRejectReservationState.idle(reservationId))
         val state: StateFlow<PhotographerRejectReservationState> = _state.asStateFlow()
 
         private val _sideEffect = MutableSharedFlow<PhotographerRejectReservationSideEffect>()
@@ -50,13 +55,42 @@ class PhotographerRejectReservationViewModel
 
                 PhotographerRejectReservationIntent.OnConfirmDialogConfirm -> {
                     _state.update { it.copy(showConfirmDialog = false) }
-                    // TODO: 거절 사유 전송 API 연동
-                    emitSideEffect(PhotographerRejectReservationSideEffect.NavigateToChat)
+                    submitReject()
                 }
 
                 PhotographerRejectReservationIntent.OnBackClick -> {
                     emitSideEffect(PhotographerRejectReservationSideEffect.NavigateBack)
                 }
+
+                PhotographerRejectReservationIntent.OnToastDismiss -> {
+                    _state.update { it.copy(showToast = false) }
+                }
+            }
+        }
+
+        private fun submitReject() {
+            val current = _state.value
+            if (current.isLoading) return
+
+            viewModelScope.launch {
+                _state.update { it.copy(isLoading = true) }
+                reservationService
+                    .rejectReservation(
+                        reservationId = current.reservationId,
+                        reasons = listOfNotNull(current.selectedReason?.toServerReason()),
+                        reasonDetail = current.directInputText,
+                    ).onSuccess {
+                        _state.update { it.copy(isLoading = false) }
+                        emitSideEffect(PhotographerRejectReservationSideEffect.NavigateToChat)
+                    }.onFailure {
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                toastMessageResId = R.string.reservation_error_reject_failed,
+                                showToast = true,
+                            )
+                        }
+                    }
             }
         }
 

--- a/feature/reservation/src/main/res/values/strings.xml
+++ b/feature/reservation/src/main/res/values/strings.xml
@@ -202,4 +202,10 @@
 
     <!-- 포맷 문자열 -->
     <string name="amount_format">%,d원</string>
+
+    <!-- 예약 API 실패 안내 -->
+    <string name="reservation_error_cancel_failed">예약 취소에 실패했어요. 잠시 후 다시 시도해주세요.</string>
+    <string name="reservation_error_reject_failed">예약 거절에 실패했어요. 잠시 후 다시 시도해주세요.</string>
+    <string name="reservation_error_accept_failed">예약 승인에 실패했어요. 잠시 후 다시 시도해주세요.</string>
+    <string name="reservation_error_load_failed">예약 정보를 불러오지 못했어요.</string>
 </resources>

--- a/feature/reservation/src/test/kotlin/com/hm/picplz/ui/screen/model/ReservationReasonMapperTest.kt
+++ b/feature/reservation/src/test/kotlin/com/hm/picplz/ui/screen/model/ReservationReasonMapperTest.kt
@@ -1,0 +1,110 @@
+package com.hm.picplz.ui.screen.model
+
+import com.hm.picplz.ui.screen.cancel_reservation.CancelReason
+import com.hm.picplz.ui.screen.photographer_cancel_reservation.PhotographerCancelReason
+import com.hm.picplz.ui.screen.photographer_reject_reservation.PhotographerRejectReason
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 서버가 받는 사유 enum 이름을 고정합니다.
+ *
+ * 문자열이 하나라도 틀리면 서버가 400을 돌려주는데 화면상으로는 "취소 실패"로만 보여서
+ * 원인을 찾기 어렵습니다. 그래서 매핑을 값 그대로 검증합니다.
+ */
+class ReservationReasonMapperTest {
+    /** dev 서버 `CancelReservationRequest.cancelReasons` 가 허용하는 11개 값 */
+    private val serverCancelReasons =
+        setOf(
+            "SCHEDULE_CONFLICT",
+            "PRODUCT_CHANGE_REQUEST",
+            "LOCATION_ISSUE",
+            "CHANGE_OF_MIND",
+            "PHOTOGRAPHER_NO_RESPONSE",
+            "ADDITIONAL_PAYMENT_REQUEST",
+            "HEALTH_ISSUE",
+            "CUSTOMER_NO_RESPONSE",
+            "ACCIDENTAL_ACCEPTANCE",
+            "EQUIPMENT_FAILURE",
+            "EXTERNAL_CIRCUMSTANCE",
+        )
+
+    /** dev 서버 `RejectReservationRequest.rejectReasons` 가 허용하는 3개 값 */
+    private val serverRejectReasons =
+        setOf("REGION_UNAVAILABLE", "TIME_UNAVAILABLE", "EQUIPMENT_ISSUE")
+
+    @Test
+    fun `고객 취소 사유가 서버 enum 이름으로 변환된다`() {
+        assertEquals("SCHEDULE_CONFLICT", CancelReason.SCHEDULE.toServerReason())
+        assertEquals("PRODUCT_CHANGE_REQUEST", CancelReason.PRODUCT.toServerReason())
+        assertEquals("LOCATION_ISSUE", CancelReason.LOCATION.toServerReason())
+        assertEquals("CHANGE_OF_MIND", CancelReason.MIND.toServerReason())
+        assertEquals("PHOTOGRAPHER_NO_RESPONSE", CancelReason.PHOTOGRAPHER_RESPONSE.toServerReason())
+        assertEquals("ADDITIONAL_PAYMENT_REQUEST", CancelReason.PHOTOGRAPHER_EXTRA_PAYMENT.toServerReason())
+    }
+
+    @Test
+    fun `작가 취소 사유가 서버 enum 이름으로 변환된다`() {
+        assertEquals("SCHEDULE_CONFLICT", PhotographerCancelReason.SCHEDULE.toServerReason())
+        assertEquals("HEALTH_ISSUE", PhotographerCancelReason.HEALTH.toServerReason())
+        assertEquals("CUSTOMER_NO_RESPONSE", PhotographerCancelReason.CUSTOMER_RESPONSE.toServerReason())
+        assertEquals("ACCIDENTAL_ACCEPTANCE", PhotographerCancelReason.MISTAKE.toServerReason())
+        assertEquals("EQUIPMENT_FAILURE", PhotographerCancelReason.EQUIPMENT.toServerReason())
+        assertEquals("EXTERNAL_CIRCUMSTANCE", PhotographerCancelReason.EXTERNAL.toServerReason())
+    }
+
+    @Test
+    fun `거절 사유가 서버 enum 이름으로 변환된다`() {
+        assertEquals("REGION_UNAVAILABLE", PhotographerRejectReason.AREA.toServerReason())
+        assertEquals("TIME_UNAVAILABLE", PhotographerRejectReason.TIME.toServerReason())
+        assertEquals("EQUIPMENT_ISSUE", PhotographerRejectReason.EQUIPMENT.toServerReason())
+    }
+
+    @Test
+    fun `직접 입력은 서버 enum 이 없어 null 이다`() {
+        assertNull(CancelReason.DIRECT_INPUT.toServerReason())
+        assertNull(PhotographerCancelReason.DIRECT_INPUT.toServerReason())
+        assertNull(PhotographerRejectReason.DIRECT_INPUT.toServerReason())
+    }
+
+    @Test
+    fun `변환 결과가 모두 서버가 아는 값이다`() {
+        CancelReason.entries.mapNotNull { it.toServerReason() }.forEach {
+            assertTrue("서버가 모르는 취소 사유: $it", it in serverCancelReasons)
+        }
+        PhotographerCancelReason.entries.mapNotNull { it.toServerReason() }.forEach {
+            assertTrue("서버가 모르는 취소 사유: $it", it in serverCancelReasons)
+        }
+        PhotographerRejectReason.entries.mapNotNull { it.toServerReason() }.forEach {
+            assertTrue("서버가 모르는 거절 사유: $it", it in serverRejectReasons)
+        }
+    }
+
+    @Test
+    fun `서로 다른 선택지가 같은 서버 값으로 겹치지 않는다`() {
+        val customer = CancelReason.entries.mapNotNull { it.toServerReason() }
+        val photographer = PhotographerCancelReason.entries.mapNotNull { it.toServerReason() }
+        assertEquals(customer.size, customer.toSet().size)
+        assertEquals(photographer.size, photographer.toSet().size)
+        // 고객 6종 + 작가 6종에서 SCHEDULE_CONFLICT 만 공유하므로 합집합은 11종이 된다.
+        assertEquals(serverCancelReasons, (customer + photographer).toSet())
+    }
+
+    @Test
+    fun `선택 집합은 화면 노출 순서를 유지하고 직접 입력은 제외한다`() {
+        val selected = setOf(CancelReason.DIRECT_INPUT, CancelReason.MIND, CancelReason.SCHEDULE)
+
+        assertEquals(listOf("SCHEDULE_CONFLICT", "CHANGE_OF_MIND"), selected.toServerReasons())
+    }
+
+    @Test
+    fun `직접 입력만 고른 경우 서버 사유 목록은 비어 있다`() {
+        assertEquals(emptyList<String>(), setOf(CancelReason.DIRECT_INPUT).toServerReasons())
+        assertEquals(
+            emptyList<String>(),
+            setOf(PhotographerCancelReason.DIRECT_INPUT).toServerReasons(),
+        )
+    }
+}

--- a/feature/reservation/src/test/kotlin/com/hm/picplz/ui/screen/model/ReservationStatusMapperTest.kt
+++ b/feature/reservation/src/test/kotlin/com/hm/picplz/ui/screen/model/ReservationStatusMapperTest.kt
@@ -1,0 +1,36 @@
+package com.hm.picplz.ui.screen.model
+
+import com.hm.picplz.domain.model.ReservationStatusCode
+import com.hm.picplz.ui.screen.detail_reservation.model.ReservationStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReservationStatusMapperTest {
+    @Test
+    fun `서버 상태가 화면 상태로 변환된다`() {
+        assertEquals(ReservationStatus.WAITING_APPROVAL, ReservationStatusCode.PENDING.toUiStatusOrNull())
+        assertEquals(ReservationStatus.WAITING_SCHEDULE, ReservationStatusCode.ACCEPTED.toUiStatusOrNull())
+        assertEquals(ReservationStatus.RESERVED, ReservationStatusCode.CONFIRMED.toUiStatusOrNull())
+    }
+
+    @Test
+    fun `거절 취소 상태는 대응하는 화면 상태가 없다`() {
+        assertNull(ReservationStatusCode.REJECTED.toUiStatusOrNull())
+        assertNull(ReservationStatusCode.CANCELED.toUiStatusOrNull())
+    }
+
+    @Test
+    fun `서버가 모르는 문자열은 null 로 파싱된다`() {
+        assertNull(ReservationStatusCode.from("COMPLETED"))
+        assertNull(ReservationStatusCode.from(null))
+        assertNull(ReservationStatusCode.from(""))
+    }
+
+    @Test
+    fun `서버 상태 문자열이 그대로 파싱된다`() {
+        ReservationStatusCode.entries.forEach { code ->
+            assertEquals(code, ReservationStatusCode.from(code.name))
+        }
+    }
+}


### PR DESCRIPTION
## 개요

예약 도메인의 클라이언트 데이터 계층을 신설하고, 상태 전이 API(승인·거절·취소)를 연동합니다.

클라이언트에 예약 API가 **한 줄도 없어서** 예약 화면 6개가 전부 더미로 동작하고 있었습니다. 화면과 다이얼로그는 이미 구현돼 있었지만 제출해도 아무 요청을 보내지 않고 다음 화면으로 넘어가기만 했습니다.

## 변경 사항

### 1. 데이터 계층 신설
- `ReservationApi` / `ReservationSource` / `ReservationService` / `ReservationModule`
- 도메인 모델 `ReservationDetail`, `ReservationStatusCode`
- `DateTimeUtil.parseServerDateTime` — minSdk 24 + desugaring 미사용이라 `java.time` 대신 `SimpleDateFormat`, 형식이 어긋나면 null

> `ReservationApi` provider는 `NetworkModule`이 아니라 `ReservationModule`에 뒀습니다.
> `NetworkModule`은 `@Provides`가 14개라 하나만 더 넣으면 detekt `TooManyFunctions`(thresholdInObjects = 15) 한계에 정확히 걸려 **다음 API 추가가 막힙니다.**

### 2. 라우트 id를 서버 계약에 맞춤
예약 상세 두 화면이 파라미터 없는 `data object`라 어떤 예약을 보여줄지 알 수 없었습니다. 서버 예약 id가 integer이므로 `reservationId: Long`으로 통일했습니다.

`DetailReservation` · `PhotographerDetailReservation`(신규 파라미터) · `CancelReservation` · `PhotographerCancelReservation` · `PhotographerRejectReservation` · `OrderDetail`

`WriteReview`는 #217 범위라 `String`을 유지하고 경계에서만 변환합니다.

### 3. 사유 매퍼
앱 선택지와 서버 enum이 **1:1로 정확히 대응**합니다. exhaustive `when`이라 선택지를 추가하면 컴파일 에러가 납니다.

| 앱 | 서버 |
|---|---|
| 고객 취소 `SCHEDULE`/`PRODUCT`/`LOCATION`/`MIND`/`PHOTOGRAPHER_RESPONSE`/`PHOTOGRAPHER_EXTRA_PAYMENT` | `SCHEDULE_CONFLICT`/`PRODUCT_CHANGE_REQUEST`/`LOCATION_ISSUE`/`CHANGE_OF_MIND`/`PHOTOGRAPHER_NO_RESPONSE`/`ADDITIONAL_PAYMENT_REQUEST` |
| 작가 취소 `SCHEDULE`/`HEALTH`/`CUSTOMER_RESPONSE`/`MISTAKE`/`EQUIPMENT`/`EXTERNAL` | `SCHEDULE_CONFLICT`/`HEALTH_ISSUE`/`CUSTOMER_NO_RESPONSE`/`ACCIDENTAL_ACCEPTANCE`/`EQUIPMENT_FAILURE`/`EXTERNAL_CIRCUMSTANCE` |
| 거절 `AREA`/`TIME`/`EQUIPMENT` | `REGION_UNAVAILABLE`/`TIME_UNAVAILABLE`/`EQUIPMENT_ISSUE` |

`DIRECT_INPUT`은 대응 서버 enum이 없어 `*ReasonDetail` 문자열로만 보냅니다. 빈 사유 배열도 서버가 200으로 받는 것을 확인했습니다.

### 4. ViewModel 배선
고객 취소 / 작가 취소 / 작가 거절 / 작가 예약 상세(조회 + 승인). 실패 시 토스트로 안내하고 중복 제출을 막습니다.

### 5. 곁다리로 고친 것
- **작가 예약 상세가 촬영 일시로 확정 시각(더미)을 쓰고 `shootingDateTimeMillis`는 안 쓰고 있었습니다.** 서버 `reservationTime`으로 바로잡았습니다.
- 실패 토스트가 하단 버튼을 완전히 가리던 문제 (리뷰 작성 화면과 같은 120dp 오프셋 적용)
- 채팅방에서 진입하면 예약 id가 없어 `GET /reservations/0` → 404 → 오류 토스트가 뜨던 문제 (id가 유효하지 않으면 조회를 건너뜀)
- "채팅 바로가기"가 아무 동작도 하지 않던 문제 (뒤로가기로 연결)

## 검증

에뮬레이터에서 dev 서버를 상대로 실제로 돌렸고, **서버 상태가 바뀌는 것까지 재조회로 확인**했습니다.

| 동작 | 결과 |
|---|---|
| 조회 | `GET /reservations/{id}` 200 — PENDING / ACCEPTED / CONFIRMED 3상태 렌더 |
| 작가 승인 | `PATCH /accept` 200 → 자동 재조회 → 화면 갱신 |
| 작가 거절 | `PATCH /reject` 200 → 서버 `REJECTED` |
| 작가 취소 | `PATCH /cancel` 200 → 서버 `CANCELED` |
| 고객 취소 | `PATCH /cancel` 200 → 서버 `CANCELED` → 고객용 완료 화면 |
| 실패 처리 | 400 → 화면 유지 + 실패 토스트 |
| 채팅 진입 | 네트워크 호출 없이 기본값 화면 |
| 리뷰 화면 진입 | 라우트 `Long`→`String` 변환 크래시 없음 |

단위 테스트 19개 추가 (사유 매퍼 8 / 상태 매퍼 4 / DTO 매퍼 7). ktlint · detekt · `:app:compileDevDebugKotlin` 통과.

### 스크린샷

| 조회 (PENDING) | 승인 후 (ACCEPTED) | 조회 (CONFIRMED) |
|---|---|---|
| <!-- 01 --> | <!-- 02 --> | <!-- 03 --> |

| 취소 성공 | 취소 실패 |
|---|---|
| <!-- 04 --> | <!-- 05 --> |

> 상태 · 상품명 · 장소 · 촬영일시는 서버 값입니다.
> **고객명과 상단 지도는 아직 더미**입니다 — 예약 상세 응답에 고객 정보가 없고, `DetailReservationMap`은 고정 좌표를 씁니다.
> 거절은 화면상 결과가 채팅방 복귀뿐이라 스크린샷 대신 서버 상태(`REJECTED`)로 확인했습니다.

## 아직 안 본 것

- **에뮬레이터만** 확인했습니다. 실기기 미검증
- **dev 플레이버만** 빌드했습니다. staging / prod 미확인
- **토큰 만료(401) 처리가 없습니다.** 15분 뒤엔 "예약 정보를 불러오지 못했어요"만 뜹니다 (기존 이슈지만 화면이 실데이터를 쓰기 시작해 더 드러남)
- 라우트 시그니처를 6개 바꿨는데 예약 외 화면 전수 회귀는 하지 않았습니다 (컴파일 통과 + 리뷰·주문상세 경계만 실제 확인)

## 백엔드가 없어 못 한 것

- 작가 취소 화면의 **"고객과 사전 합의" 체크**를 보낼 필드가 서버에 없습니다 (페널티 규정 분기에 쓰이는 값)
- **거래 완료 전환 API와 `COMPLETED` 상태가 없어** 해당 CTA는 그대로입니다 (#170 참고)
- 예약 상세 응답에 고객 정보가 없어 고객명은 더미 유지
- **고객용 예약 상세 조회 API가 없습니다** (`GET /reservations/{id}`는 작가 전용 — 설계상 그러함). 고객 `DetailReservationViewModel`은 이번 범위에서 제외

## 검증용 dev 데이터

dev 서버에 상태별 고정 예약을 남겨뒀습니다 — **24=PENDING**, 17=ACCEPTED, 18=CONFIRMED.
Dev 메뉴 → Reservation → `PhotographerDetailReservation(작가 예약 상세)`로 진입하며, `DEV_RESERVATION_ID` 값만 바꾸면 다른 상태를 볼 수 있습니다.
예약 상세는 작가 전용 API라 `local.properties`의 `dev_user_token`을 작가 토큰(socialCode `test_social_001`)으로 두고 "개발 유저 로그인"을 눌러야 데이터가 뜹니다.

## 체크리스트
- [x] 코드가 작동하는지 확인했습니다.
- [x] 테스트를 작성했습니다.
- [ ] 문서를 업데이트했습니다.

## 이슈 번호
- Resolves #229
